### PR TITLE
Publish wkcuber docs to S3

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -119,6 +119,7 @@ jobs:
       run: ./publish.sh
 
   docker:
+    needs: build
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         CI_BRANCH=${GITHUB_REF##*/}
         NORMALIZED_CI_BRANCH=${CI_BRANCH//[\/-]/_}
         docker tag \
-          scalableminds/webknossos-cuber:$GITHUB_SHA \s
+          scalableminds/webknossos-cuber:$GITHUB_SHA \
           scalableminds/webknossos-cuber:$NORMALIZED_CI_BRANCH
         docker push scalableminds/webknossos-cuber:$NORMALIZED_CI_BRANCH
         if [ "${CI_BRANCH}" == "master" ]; then

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,12 +81,12 @@ jobs:
       run: rm -r testdata/tiff_mag_2_reference/
 
     - name: Generate Docs
-      if: matrix.python-version == '3.7'
+      if: matrix.python-version == '3.8'
       run: |
         docs/api.sh --persist
     
     - name: Push docs (for branch)
-      if: matrix.python-version == '3.7'
+      if: startsWith(github.event.ref, 'refs/heads') && matrix.python-version == '3.8'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -97,7 +97,7 @@ jobs:
         aws s3 sync --acl public-read docs/api s3://static.webknossos.org/lib-docs/${NORMALIZED_CI_BRANCH}
 
     - name: Push docs (for tag)
-      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.7'
+      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.8'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,9 +18,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: 'x64'
 
-    - name: Build docker image
-      run: docker build -t scalableminds/webknossos-cuber:$GITHUB_SHA .
-
     - name: Install dependencies
       run: |
         pip install poetry
@@ -41,18 +38,6 @@ jobs:
 
     - name: Python tests
       run: poetry run pytest tests
-
-    - name: Smoke test docker
-      run: |
-        docker run --rm \
-          -v$(pwd)/testdata:/app/testdata \
-          scalableminds/webknossos-cuber:$GITHUB_SHA \
-          wkcuber.cubing \
-            --jobs 2 \
-            --batch_size 8 \
-            --layer_name color \
-            --wkw_file_len 32 \
-            testdata/tiff testoutput/tiff
 
     - name: Test tiff cubing
       run: tests/scripts/tiff_cubing.sh
@@ -96,10 +81,12 @@ jobs:
       run: rm -r testdata/tiff_mag_2_reference/
 
     - name: Generate Docs
+      if: matrix.python-version == '3.7'
       run: |
         docs/api.sh --persist
     
     - name: Push docs (for branch)
+      if: matrix.python-version == '3.7'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -107,17 +94,49 @@ jobs:
       run: |
         CI_BRANCH=${GITHUB_REF##*/}
         NORMALIZED_CI_BRANCH=${CI_BRANCH//[\/-]/_}
-        aws s3 sync docs/api s3://static.webknossos.org/lib-docs/${NORMALIZED_CI_BRANCH}
+        aws s3 sync --acl public-read docs/api s3://static.webknossos.org/lib-docs/${NORMALIZED_CI_BRANCH}
 
     - name: Push docs (for tag)
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.7'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         AWS_DEFAULT_REGION: "eu-west-1"
       run: |
         CI_TAG=$(git describe --tags)
-        aws s3 sync docs/api s3://static.webknossos.org/lib-docs/${CI_TAG}
+        aws s3 sync --acl public-read docs/api s3://static.webknossos.org/lib-docs/${CI_TAG}
+
+    - name: Check if git is dirty
+      run: |
+        git diff --no-ext-diff --quiet --exit-code
+        [[ -z $(git status -s) ]]
+
+    - name: Publish python package
+      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.7'
+      env:
+        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: ./publish.sh
+
+  docker:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build docker image
+      run: docker build -t scalableminds/webknossos-cuber:$GITHUB_SHA .
+
+    - name: Smoke test docker
+      run: |
+        docker run --rm \
+          -v$(pwd)/testdata:/app/testdata \
+          scalableminds/webknossos-cuber:$GITHUB_SHA \
+          wkcuber.cubing \
+            --jobs 2 \
+            --batch_size 8 \
+            --layer_name color \
+            --wkw_file_len 32 \
+            testdata/tiff testoutput/tiff
 
     - name: Login to docker
       env:
@@ -145,7 +164,7 @@ jobs:
         CI_BRANCH=${GITHUB_REF##*/}
         NORMALIZED_CI_BRANCH=${CI_BRANCH//[\/-]/_}
         docker tag \
-          scalableminds/webknossos-cuber:$GITHUB_SHA \
+          scalableminds/webknossos-cuber:$GITHUB_SHA \s
           scalableminds/webknossos-cuber:$NORMALIZED_CI_BRANCH
         docker push scalableminds/webknossos-cuber:$NORMALIZED_CI_BRANCH
         if [ "${CI_BRANCH}" == "master" ]; then
@@ -154,15 +173,3 @@ jobs:
             scalableminds/webknossos-cuber:latest
           docker push scalableminds/webknossos-cuber:latest
         fi
-
-    - name: Check if git is dirty
-      run: |
-        git diff --no-ext-diff --quiet --exit-code
-        [[ -z $(git status -s) ]]
-
-    - name: Publish python package
-      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.7'
-      env:
-        PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
-        PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-      run: ./publish.sh

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,6 +95,30 @@ jobs:
     - name: Remove reference magnification data
       run: rm -r testdata/tiff_mag_2_reference/
 
+    - name: Generate Docs
+      run: |
+        docs/api.sh --persist
+    
+    - name: Push docs (for branch)
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "eu-west-1"
+      run: |
+        CI_BRANCH=${GITHUB_REF##*/}
+        NORMALIZED_CI_BRANCH=${CI_BRANCH//[\/-]/_}
+        aws s3 sync docs/api s3://static.webknossos.org/lib-docs/${NORMALIZED_CI_BRANCH}
+
+    - name: Push docs (for tag)
+      if: startsWith(github.event.ref, 'refs/tags')
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: "eu-west-1"
+      run: |
+        CI_TAG=$(git describe --tags)
+        aws s3 sync docs/api s3://static.webknossos.org/lib-docs/${CI_TAG}
+
     - name: Login to docker
       env:
         DOCKER_USER: ${{ secrets.DOCKER_USER }}

--- a/Changelog.md
+++ b/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
+- The API documentation is now hosted on a publicwebpage. [#392](https://github.com/scalableminds/webknossos-cuber/pull/392)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ PyPi releases are automatically pushed when creating a new Git tag/Github releas
 ## API documentation
 Check out the [latest version of the API documentation](https://static.webknossos.org/lib-docs/master/wkcuber/api.html).
 
-## Generate the API documentation
+### Generate the API documentation
 Run `docs/api.sh` to open a server displaying the API docs. `docs/api.sh --persist` persists the html to `docs/api`.
 
 ## Test Data Credits

--- a/README.md
+++ b/README.md
@@ -128,6 +128,9 @@ tests/scripts/all_tests.sh
 
 PyPi releases are automatically pushed when creating a new Git tag/Github release. 
 
+## API documentation
+Check out the [latest version of the API documentation](https://static.webknossos.org/lib-docs/master/wkcuber/api.html).
+
 ## Generate the API documentation
 Run `docs/api.sh` to open a server displaying the API docs. `docs/api.sh --persist` persists the html to `docs/api`.
 


### PR DESCRIPTION
### Description:
- Publishes the wkcuber docs to a bucket in S3. Example: https://static.webknossos.org/lib-docs/docs_s3/wkcuber/api.html
- Refactors CI to just run the docker builds once

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
