### PR TITLE
Fixes for Windows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,6 +80,7 @@ jobs:
       run: ./publish.sh
 
   build_win:
+    # Caution! The Windows VM seems to be running out of storage rather quickly.
     runs-on: windows-latest
     strategy:
       max-parallel: 4
@@ -113,13 +114,13 @@ jobs:
         rm -r c:/hostedtoolcache/windows/python/${{ matrix.python-version }}*/x64/lib/site-packages/wkw-*.egg
         pip install dist/*.whl
 
-    - name: Disk stats
-      shell: bash
-      run: "du -sh *"
-
     - name: Decompress test data
       shell: bash
       run: tar -xzvf testdata/WT1_wkw.tar.gz
+
+    - name: Disk stats
+      shell: bash
+      run: "du -sh *"
 
     - name: Python tests
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,7 +105,9 @@ jobs:
         git clone --branch truncate-err https://github.com/scalableminds/webknossos-wrap.git
         cd webknossos-wrap/python
         pip uninstall -y wkw
-        python setup.py install
+        pip install twine wheel
+        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
+        ls -lisah dist
 
     - name: Decompress test data
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -120,7 +120,9 @@ jobs:
 
     - name: Disk stats
       shell: bash
-      run: "du -sh *"
+      run: |
+        du -sh *
+        df -h
 
     - name: Python tests
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,10 @@ jobs:
         rm -r c:/hostedtoolcache/windows/python/${{ matrix.python-version }}*/x64/lib/site-packages/wkw-*.egg
         pip install dist/*.whl
 
+    - name: Disk stats
+      shell: bash
+      run: "du -sh *"
+
     - name: Decompress test data
       shell: bash
       run: tar -xzvf testdata/WT1_wkw.tar.gz

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -99,30 +99,10 @@ jobs:
       run: |
         pip install poetry
         poetry install
-    
-    - name: Install custom wkw
-      shell: bash
-      run: |
-        git clone --branch truncate-err https://github.com/scalableminds/webknossos-wrap.git
-        cd webknossos-wrap/python
-        pip uninstall -y wkw
-        pip install twine wheel
-        python setup.py install
-        python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
-        ls -lisah dist
-        pwd -P
-        rm -r c:/hostedtoolcache/windows/python/${{ matrix.python-version }}*/x64/lib/site-packages/wkw-*.egg
-        pip install dist/*.whl
 
     - name: Decompress test data
       shell: bash
       run: tar -xzvf testdata/WT1_wkw.tar.gz
-
-    - name: Disk stats
-      shell: bash
-      run: |
-        du -sh *
-        df -h
 
     - name: Python tests
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,8 +118,91 @@ jobs:
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: ./publish.sh
 
+  build_win:
+    runs-on: windows-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        pip install poetry
+        poetry install
+
+    - name: Decompress test data
+      shell: bash
+      run: tar -xzvf testdata/WT1_wkw.tar.gz
+
+    - name: Python tests
+      shell: bash
+      run: poetry run pytest tests
+
+    - name: Test tiff cubing
+      shell: bash
+      run: tests/scripts/tiff_cubing.sh
+
+    - name: Test tile cubing
+      shell: bash
+      run: tests/scripts/tile_cubing.sh
+
+    - name: Test simple tiff cubing
+      shell: bash
+      run: tests/scripts/simple_tiff_cubing.sh
+
+    - name: Test simple tiff cubing (no compression)
+      shell: bash
+      run: tests/scripts/simple_tiff_cubing_no_compression.sh
+
+    - name: Test metadata generation
+      shell: bash
+      run: tests/scripts/meta_generation.sh
+
+    - name: Test KNOSSOS conversion
+      shell: bash
+      run: tests/scripts/knossos_conversion.sh
+
+    - name: Decompress reference magnification data
+      shell: bash
+      run: |
+        mkdir -p testdata/tiff_mag_2_reference
+        tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
+
+    - name: Test downsampling
+      shell: bash
+      run: tests/scripts/downsampling.sh
+
+    - name: Test upsampling
+      shell: bash
+      run: tests/scripts/upsampling.sh
+
+    - name: Test anisotropic downsampling
+      shell: bash
+      run: tests/scripts/anisotropic_downsampling.sh
+
+    - name: Test compression and verification
+      shell: bash
+      run: tests/scripts/compression_and_verification.sh
+
+    - name: Test in-place compression
+      shell: bash
+      run: tests/scripts/in_place_compression.sh
+
+    - name: Remove reference magnification data
+      shell: bash
+      run: rm -r testdata/tiff_mag_2_reference/
+
   docker:
-    needs: build
+    needs: [build, build_win]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,46 +39,8 @@ jobs:
     - name: Python tests
       run: poetry run pytest tests
 
-    - name: Test tiff cubing
-      run: tests/scripts/tiff_cubing.sh
-
-    - name: Test tile cubing
-      run: tests/scripts/tile_cubing.sh
-
-    - name: Test simple tiff cubing
-      run: tests/scripts/simple_tiff_cubing.sh
-
-    - name: Test simple tiff cubing (no compression)
-      run: tests/scripts/simple_tiff_cubing_no_compression.sh
-
-    - name: Test metadata generation
-      run: tests/scripts/meta_generation.sh
-
-    - name: Test KNOSSOS conversion
-      run: tests/scripts/knossos_conversion.sh
-
-    - name: Decompress reference magnification data
-      run: |
-        mkdir -p testdata/tiff_mag_2_reference
-        tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
-
-    - name: Test downsampling
-      run: tests/scripts/downsampling.sh
-
-    - name: Test upsampling
-      run: tests/scripts/upsampling.sh
-
-    - name: Test anisotropic downsampling
-      run: tests/scripts/anisotropic_downsampling.sh
-
-    - name: Test compression and verification
-      run: tests/scripts/compression_and_verification.sh
-
-    - name: Test in-place compression
-      run: tests/scripts/in_place_compression.sh
-
-    - name: Remove reference magnification data
-      run: rm -r testdata/tiff_mag_2_reference/
+    - name: CLI tests
+      run: tests/scripts/all_tests.sh
 
     - name: Generate Docs
       if: matrix.python-version == '3.8'
@@ -147,62 +109,41 @@ jobs:
       shell: bash
       run: poetry run pytest tests
 
-    - name: Test tiff cubing
+    - name: CLI tests
       shell: bash
-      run: tests/scripts/tiff_cubing.sh
+      run: tests/scripts/all_tests.sh
 
-    - name: Test tile cubing
-      shell: bash
-      run: tests/scripts/tile_cubing.sh
+  build_mac:
+    runs-on: macos-latest
+    strategy:
+      max-parallel: 4
+      matrix:
+        python-version: [3.7, 3.8]
 
-    - name: Test simple tiff cubing
-      shell: bash
-      run: tests/scripts/simple_tiff_cubing.sh
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: 'x64'
 
-    - name: Test simple tiff cubing (no compression)
-      shell: bash
-      run: tests/scripts/simple_tiff_cubing_no_compression.sh
-
-    - name: Test metadata generation
-      shell: bash
-      run: tests/scripts/meta_generation.sh
-
-    - name: Test KNOSSOS conversion
-      shell: bash
-      run: tests/scripts/knossos_conversion.sh
-
-    - name: Decompress reference magnification data
-      shell: bash
+    - name: Install dependencies
       run: |
-        mkdir -p testdata/tiff_mag_2_reference
-        tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
+        pip install poetry
+        poetry install
 
-    - name: Test downsampling
-      shell: bash
-      run: tests/scripts/downsampling.sh
+    - name: Decompress test data
+      run: tar -xzvf testdata/WT1_wkw.tar.gz
 
-    - name: Test upsampling
-      shell: bash
-      run: tests/scripts/upsampling.sh
+    - name: Python tests
+      run: poetry run pytest tests
 
-    - name: Test anisotropic downsampling
-      shell: bash
-      run: tests/scripts/anisotropic_downsampling.sh
-
-    - name: Test compression and verification
-      shell: bash
-      run: tests/scripts/compression_and_verification.sh
-
-    - name: Test in-place compression
-      shell: bash
-      run: tests/scripts/in_place_compression.sh
-
-    - name: Remove reference magnification data
-      shell: bash
-      run: rm -r testdata/tiff_mag_2_reference/
+    - name: CLI tests
+      run: tests/scripts/all_tests.sh
 
   docker:
-    needs: [build, build_win]
+    needs: [build, build_win, build_mac]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -98,6 +98,13 @@ jobs:
       run: |
         pip install poetry
         poetry install
+    
+    - name: Install custom wkw
+      shell: bash
+      run: |
+        git clone --branch truncate-err https://github.com/scalableminds/webknossos-wrap.git
+        cd webknossos-wrap/python
+        python setup.py install
 
     - name: Decompress test data
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,6 +108,7 @@ jobs:
         pip install twine wheel
         python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
         ls -lisah dist
+        pip install dist/*.whl
 
     - name: Decompress test data
       shell: bash

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,7 @@ jobs:
       run: |
         git clone --branch truncate-err https://github.com/scalableminds/webknossos-wrap.git
         cd webknossos-wrap/python
+        pip uninstall wkw
         python setup.py install
 
     - name: Decompress test data

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,12 +11,11 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
 
     - name: Install dependencies
       run: |
@@ -74,7 +73,7 @@ jobs:
         [[ -z $(git status -s) ]]
 
     - name: Publish python package
-      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.7'
+      if: startsWith(github.event.ref, 'refs/tags') && matrix.python-version == '3.8'
       env:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
@@ -88,12 +87,11 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
 
     - name: Install dependencies
       shell: bash
@@ -121,12 +119,11 @@ jobs:
         python-version: [3.7, 3.8]
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: 'x64'
 
     - name: Install dependencies
       run: |
@@ -147,7 +144,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Build docker image
       run: docker build -t scalableminds/webknossos-cuber:$GITHUB_SHA .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         git clone --branch truncate-err https://github.com/scalableminds/webknossos-wrap.git
         cd webknossos-wrap/python
-        pip uninstall wkw
+        pip uninstall -y wkw
         python setup.py install
 
     - name: Decompress test data

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -106,6 +106,7 @@ jobs:
         cd webknossos-wrap/python
         pip uninstall -y wkw
         pip install twine wheel
+        python setup.py install
         python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
         ls -lisah dist
         pip install dist/*.whl

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,6 +109,8 @@ jobs:
         python setup.py install
         python setup.py sdist bdist_wheel -p $(python -c "import distutils.util; print(distutils.util.get_platform())") --python-tag py${{ matrix.python-version }}
         ls -lisah dist
+        pwd -P
+        rm -r c:/hostedtoolcache/windows/python/${{ matrix.python-version }}*/x64/lib/site-packages/wkw-*.egg
         pip install dist/*.whl
 
     - name: Decompress test data

--- a/Changelog.md
+++ b/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixes support for Windows. [#394](https://github.com/scalableminds/webknossos-cuber/pull/394)
 
 ## [0.8.12](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.12) - 2021-08-19
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.11...v0.8.12)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,15 @@
+import pytest
+from pathlib import Path
+from os import makedirs
+from shutil import rmtree
+from typing import Generator
+
+TESTOUTPUT_DIR = Path("testoutput")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def run_around_tests() -> Generator:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
+    print("CLEANUP")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,4 +12,3 @@ def run_around_tests() -> Generator:
     makedirs(TESTOUTPUT_DIR, exist_ok=True)
     yield
     rmtree(TESTOUTPUT_DIR)
-    print("CLEANUP")

--- a/tests/scripts/all_tests.sh
+++ b/tests/scripts/all_tests.sh
@@ -5,20 +5,32 @@ if [ -d "./testoutput" ]; then rm -Rf ./testoutput; fi
 
 BASEDIR=./tests/scripts
 
-sh ${BASEDIR}/tiff_cubing.sh
-sh ${BASEDIR}/tile_cubing.sh
-sh ${BASEDIR}/simple_tiff_cubing.sh
-sh ${BASEDIR}/simple_tiff_cubing_no_compression.sh
-sh ${BASEDIR}/meta_generation.sh
-sh ${BASEDIR}/knossos_conversion.sh
-
 mkdir -p testdata/tiff_mag_2_reference
 tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
 
+sh ${BASEDIR}/tiff_cubing.sh
+sh ${BASEDIR}/meta_generation.sh
 sh ${BASEDIR}/downsampling.sh
 sh ${BASEDIR}/upsampling.sh
+rm -r testoutput/tiff_upsampling
+rm -r testdata/tiff_mag_2_reference
+
 sh ${BASEDIR}/anisotropic_downsampling.sh
 sh ${BASEDIR}/compression_and_verification.sh
-sh ${BASEDIR}/in_place_compression.sh
+rm -r testoutput/tiff_compress
 
-rm -r testdata/tiff_mag_2_reference/
+sh ${BASEDIR}/in_place_compression.sh
+rm -r testoutput/tiff_compress2
+rm -r testoutput/tiff
+
+sh ${BASEDIR}/tile_cubing.sh
+rm -r testoutput/temca2
+
+sh ${BASEDIR}/simple_tiff_cubing.sh
+rm -r testoutput/tiff2
+
+sh ${BASEDIR}/simple_tiff_cubing_no_compression.sh
+rm -r testoutput/tiff3
+
+sh ${BASEDIR}/knossos_conversion.sh
+rm -r testoutput/knossos

--- a/tests/scripts/all_tests.sh
+++ b/tests/scripts/all_tests.sh
@@ -6,18 +6,19 @@ if [ -d "./testoutput" ]; then rm -Rf ./testoutput; fi
 BASEDIR=./tests/scripts
 
 sh ${BASEDIR}/tiff_cubing.sh
+sh ${BASEDIR}/tile_cubing.sh
 sh ${BASEDIR}/simple_tiff_cubing.sh
 sh ${BASEDIR}/simple_tiff_cubing_no_compression.sh
-sh ${BASEDIR}/tile_cubing.sh
 sh ${BASEDIR}/meta_generation.sh
 sh ${BASEDIR}/knossos_conversion.sh
 
 mkdir -p testdata/tiff_mag_2_reference
 tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
 
+sh ${BASEDIR}/downsampling.sh
+sh ${BASEDIR}/upsampling.sh
 sh ${BASEDIR}/anisotropic_downsampling.sh
 sh ${BASEDIR}/compression_and_verification.sh
-sh ${BASEDIR}/downsampling.sh
 sh ${BASEDIR}/in_memory_downsampled_cubing.sh
 sh ${BASEDIR}/in_place_compression.sh
 sh ${BASEDIR}/simple_anisotropic_tiff_cubing.sh

--- a/tests/scripts/all_tests.sh
+++ b/tests/scripts/all_tests.sh
@@ -19,8 +19,6 @@ sh ${BASEDIR}/downsampling.sh
 sh ${BASEDIR}/upsampling.sh
 sh ${BASEDIR}/anisotropic_downsampling.sh
 sh ${BASEDIR}/compression_and_verification.sh
-sh ${BASEDIR}/in_memory_downsampled_cubing.sh
 sh ${BASEDIR}/in_place_compression.sh
-sh ${BASEDIR}/simple_anisotropic_tiff_cubing.sh
 
 rm -r testdata/tiff_mag_2_reference/

--- a/tests/scripts/compression_and_verification.sh
+++ b/tests/scripts/compression_and_verification.sh
@@ -17,7 +17,7 @@ python -m wkcuber.check_equality testoutput/tiff testoutput/tiff_compress
 
 echo "Create broken copy of dataset"
 rm -rf testoutput/tiff_compress-broken
-cp -R testoutput/tiff_compress{,-broken}
+cp -R testoutput/tiff_compress testoutput/tiff_compress-broken
 rm -r testoutput/tiff_compress-broken/color/1/z0/y0/x0.wkw
 
 echo "Compare original dataset to broken one and expect to determine difference"

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -1,7 +1,11 @@
 from wkcuber.converter import ImageStackConverter, KnossosConverter
 from os.path import sep
 
-TEST_PREFIXES = ["", sep, f"..{sep}"]
+TEST_PREFIXES = ["", "/", f"../"]
+
+
+def fix_sep(path: str) -> str:
+    return path.replace("/", sep)
 
 
 def test_tiff_dataset_name_and_layer_name_detection() -> None:
@@ -10,9 +14,9 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         # test if ds name and layer name are correctly detected
         converter = ImageStackConverter()
         converter.source_files = [
-            f"{prefix}test{sep}color{sep}001.tif",
-            f"{prefix}test{sep}color{sep}002.tif",
-            f"{prefix}test{sep}color{sep}003.tif",
+            fix_sep(f"{prefix}test/color/001.tif"),
+            fix_sep(f"{prefix}test/color/002.tif"),
+            fix_sep(f"{prefix}test/color/003.tif"),
         ]
         (
             dataset_name,
@@ -20,15 +24,15 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == f"{prefix}test{sep}color"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(f"{prefix}test/color")
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if in subfolder
         converter = ImageStackConverter()
         converter.source_files = [
-            f"{prefix}superfolder{sep}test{sep}color{sep}001.tif",
-            f"{prefix}superfolder{sep}test{sep}color{sep}002.tif",
-            f"{prefix}superfolder{sep}test{sep}color{sep}003.tif",
+            fix_sep(f"{prefix}superfolder/test/color/001.tif"),
+            fix_sep(f"{prefix}superfolder/test/color/002.tif"),
+            fix_sep(f"{prefix}superfolder/test/color/003.tif"),
         ]
         (
             dataset_name,
@@ -36,21 +40,20 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 1
-        assert (
-            list(layer_path_to_layer_name)[0]
-            == f"{prefix}superfolder{sep}test{sep}color"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(
+            f"{prefix}superfolder/test/color"
         )
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test for multiple layers
         converter = ImageStackConverter()
         converter.source_files = [
-            f"{prefix}test{sep}color{sep}001.tif",
-            f"{prefix}test{sep}color{sep}002.tif",
-            f"{prefix}test{sep}color{sep}003.tif",
-            f"{prefix}test{sep}segmentation{sep}001.tif",
-            f"{prefix}test{sep}segmentation{sep}002.tif",
-            f"{prefix}test{sep}segmentation{sep}003.tif",
+            fix_sep(f"{prefix}test/color/001.tif"),
+            fix_sep(f"{prefix}test/color/002.tif"),
+            fix_sep(f"{prefix}test/color/003.tif"),
+            fix_sep(f"{prefix}test/segmentation/001.tif"),
+            fix_sep(f"{prefix}test/segmentation/002.tif"),
+            fix_sep(f"{prefix}test/segmentation/003.tif"),
         ]
         (
             dataset_name,
@@ -58,17 +61,17 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 2
-        assert f"{prefix}test{sep}color" in layer_path_to_layer_name.keys()
-        assert f"{prefix}test{sep}segmentation" in layer_path_to_layer_name.keys()
+        assert fix_sep(f"{prefix}test/color") in layer_path_to_layer_name.keys()
+        assert fix_sep(f"{prefix}test/segmentation") in layer_path_to_layer_name.keys()
         assert "color" in layer_path_to_layer_name.values()
         assert "segmentation" in layer_path_to_layer_name.values()
 
         # test if in single folder and folder name is layer name
         converter = ImageStackConverter()
         converter.source_files = [
-            f"{prefix}color{sep}001.tif",
-            f"{prefix}color{sep}002.tif",
-            f"{prefix}color{sep}003.tif",
+            fix_sep(f"{prefix}color/001.tif"),
+            fix_sep(f"{prefix}color/002.tif"),
+            fix_sep(f"{prefix}color/003.tif"),
         ]
         (
             dataset_name,
@@ -76,15 +79,15 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == f"{prefix}color"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(f"{prefix}color")
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if in single folder and folder name is ds name
         converter = ImageStackConverter()
         converter.source_files = [
-            f"{prefix}test_dataset{sep}001.tif",
-            f"{prefix}test_dataset{sep}002.tif",
-            f"{prefix}test_dataset{sep}003.tif",
+            fix_sep(f"{prefix}test_dataset/001.tif"),
+            fix_sep(f"{prefix}test_dataset/002.tif"),
+            fix_sep(f"{prefix}test_dataset/003.tif"),
         ]
         (
             dataset_name,
@@ -92,45 +95,48 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test_dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == f"{prefix}test_dataset"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(f"{prefix}test_dataset")
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if single file in folder
         converter = ImageStackConverter()
-        converter.source_files = [f"{prefix}test_dataset{sep}brain.tif"]
+        converter.source_files = [fix_sep(f"{prefix}test_dataset/brain.tif")]
         (
             dataset_name,
             layer_path_to_layer_name,
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test_dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert (
-            list(layer_path_to_layer_name)[0] == f"{prefix}test_dataset{sep}brain.tif"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(
+            f"{prefix}test_dataset/brain.tif"
         )
         assert list(layer_path_to_layer_name.values())[0] == "brain"
 
         # test if single file
         converter = ImageStackConverter()
-        converter.source_files = [f"{prefix}brain.tif"]
+        converter.source_files = [fix_sep(f"{prefix}brain.tif")]
         (
             dataset_name,
             layer_path_to_layer_name,
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "brain"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == f"{prefix}brain.tif"
+        assert list(layer_path_to_layer_name)[0] == fix_sep(f"{prefix}brain.tif")
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test for multiple files with no parent directory
         converter = ImageStackConverter()
-        converter.source_files = [f"{prefix}001.tif", f"{prefix}002.tif"]
+        converter.source_files = [
+            fix_sep(f"{prefix}001.tif"),
+            fix_sep(f"{prefix}002.tif"),
+        ]
         (
             dataset_name,
             layer_path_to_layer_name,
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name.keys())[0] == prefix
+        assert list(layer_path_to_layer_name.keys())[0] == fix_sep(prefix)
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
 
@@ -140,80 +146,93 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test if dataset name and layer name and mag are correct
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
-            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0001{sep}test_mag1_x0000_y0000_z0001.raw",
-            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0001{sep}z0000{sep}test_mag1_x0000_y0001_z0000.raw",
+            fix_sep(
+                f"{prefix}knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
+            fix_sep(
+                f"{prefix}knossos/color/1/x0000/y0000/z0001/test_mag1_x0000_y0000_z0001.raw"
+            ),
+            fix_sep(
+                f"{prefix}knossos/color/1/x0000/y0001/z0000/test_mag1_x0000_y0001_z0000.raw"
+            ),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == f"{prefix}knossos{sep}color"
+        assert list(layer_paths.keys())[0] == fix_sep(f"{prefix}knossos/color")
         assert list(layer_paths.values())[0] == {"1"}
 
         # test if in subfolder
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}superfolder{sep}superfolder{sep}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(
+                f"{prefix}superfolder/superfolder/knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
-        assert (
-            list(layer_paths.keys())[0]
-            == f"{prefix}superfolder{sep}superfolder{sep}knossos{sep}color"
+        assert list(layer_paths.keys())[0] == fix_sep(
+            f"{prefix}superfolder/superfolder/knossos/color"
         )
         assert list(layer_paths.values())[0] == {"1"}
 
         # test for multiple layer
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
-            f"{prefix}knossos{sep}segmentation{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(
+                f"{prefix}knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
+            fix_sep(
+                f"{prefix}knossos/segmentation/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 2
-        assert f"{prefix}knossos{sep}color" in layer_paths.keys()
-        assert f"{prefix}knossos{sep}segmentation" in layer_paths.keys()
+        assert fix_sep(f"{prefix}knossos/color") in layer_paths.keys()
+        assert fix_sep(f"{prefix}knossos/segmentation") in layer_paths.keys()
         assert all(map(lambda m: m == {"1"}, layer_paths.values()))
 
         # test if only layer folder given
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(
+                f"{prefix}color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == f"{prefix}color"
+        assert list(layer_paths.keys())[0] == fix_sep(f"{prefix}color")
         assert list(layer_paths.values())[0] == {"1"}
 
         # test if only mag folder given
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(f"{prefix}1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == prefix
+        assert list(layer_paths.keys())[0] == fix_sep(prefix)
         assert list(layer_paths.values())[0] == {"1"}
 
         # test if already in mag folder
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(f"{prefix}x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == prefix
+        assert list(layer_paths.keys())[0] == fix_sep(prefix)
         assert list(layer_paths.values())[0] == {""}
 
         # test if too short path gets detected
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(f"{prefix}y0000/z0000/test_mag1_x0000_y0000_z0000.raw"),
         ]
         assertion_error = False
         try:
@@ -225,11 +244,15 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test for multiple mags
         converter = KnossosConverter()
         converter.source_files = [
-            f"{prefix}knossos{sep}color{sep}2{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
-            f"{prefix}knossos{sep}color{sep}4{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            fix_sep(
+                f"{prefix}knossos/color/2/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
+            fix_sep(
+                f"{prefix}knossos/color/4/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw"
+            ),
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == f"{prefix}knossos{sep}color"
+        assert list(layer_paths.keys())[0] == fix_sep(f"{prefix}knossos/color")
         assert list(layer_paths.values())[0] == {"2", "4"}

--- a/tests/test_auto_detection.py
+++ b/tests/test_auto_detection.py
@@ -1,6 +1,7 @@
 from wkcuber.converter import ImageStackConverter, KnossosConverter
+from os.path import sep
 
-TEST_PREFIXES = ["", "/", "../"]
+TEST_PREFIXES = ["", sep, f"..{sep}"]
 
 
 def test_tiff_dataset_name_and_layer_name_detection() -> None:
@@ -9,9 +10,9 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         # test if ds name and layer name are correctly detected
         converter = ImageStackConverter()
         converter.source_files = [
-            prefix + "test/color/001.tif",
-            prefix + "test/color/002.tif",
-            prefix + "test/color/003.tif",
+            f"{prefix}test{sep}color{sep}001.tif",
+            f"{prefix}test{sep}color{sep}002.tif",
+            f"{prefix}test{sep}color{sep}003.tif",
         ]
         (
             dataset_name,
@@ -19,15 +20,15 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "test/color"
+        assert list(layer_path_to_layer_name)[0] == f"{prefix}test{sep}color"
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if in subfolder
         converter = ImageStackConverter()
         converter.source_files = [
-            prefix + "superfolder/test/color/001.tif",
-            prefix + "superfolder/test/color/002.tif",
-            prefix + "superfolder/test/color/003.tif",
+            f"{prefix}superfolder{sep}test{sep}color{sep}001.tif",
+            f"{prefix}superfolder{sep}test{sep}color{sep}002.tif",
+            f"{prefix}superfolder{sep}test{sep}color{sep}003.tif",
         ]
         (
             dataset_name,
@@ -35,18 +36,21 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "superfolder/test/color"
+        assert (
+            list(layer_path_to_layer_name)[0]
+            == f"{prefix}superfolder{sep}test{sep}color"
+        )
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test for multiple layers
         converter = ImageStackConverter()
         converter.source_files = [
-            prefix + "test/color/001.tif",
-            prefix + "test/color/002.tif",
-            prefix + "test/color/003.tif",
-            prefix + "test/segmentation/001.tif",
-            prefix + "test/segmentation/002.tif",
-            prefix + "test/segmentation/003.tif",
+            f"{prefix}test{sep}color{sep}001.tif",
+            f"{prefix}test{sep}color{sep}002.tif",
+            f"{prefix}test{sep}color{sep}003.tif",
+            f"{prefix}test{sep}segmentation{sep}001.tif",
+            f"{prefix}test{sep}segmentation{sep}002.tif",
+            f"{prefix}test{sep}segmentation{sep}003.tif",
         ]
         (
             dataset_name,
@@ -54,17 +58,17 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test"
         assert len(layer_path_to_layer_name) == 2
-        assert prefix + "test/color" in layer_path_to_layer_name.keys()
-        assert prefix + "test/segmentation" in layer_path_to_layer_name.keys()
+        assert f"{prefix}test{sep}color" in layer_path_to_layer_name.keys()
+        assert f"{prefix}test{sep}segmentation" in layer_path_to_layer_name.keys()
         assert "color" in layer_path_to_layer_name.values()
         assert "segmentation" in layer_path_to_layer_name.values()
 
         # test if in single folder and folder name is layer name
         converter = ImageStackConverter()
         converter.source_files = [
-            prefix + "color/001.tif",
-            prefix + "color/002.tif",
-            prefix + "color/003.tif",
+            f"{prefix}color{sep}001.tif",
+            f"{prefix}color{sep}002.tif",
+            f"{prefix}color{sep}003.tif",
         ]
         (
             dataset_name,
@@ -72,15 +76,15 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "color"
+        assert list(layer_path_to_layer_name)[0] == f"{prefix}color"
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if in single folder and folder name is ds name
         converter = ImageStackConverter()
         converter.source_files = [
-            prefix + "test_dataset/001.tif",
-            prefix + "test_dataset/002.tif",
-            prefix + "test_dataset/003.tif",
+            f"{prefix}test_dataset{sep}001.tif",
+            f"{prefix}test_dataset{sep}002.tif",
+            f"{prefix}test_dataset{sep}003.tif",
         ]
         (
             dataset_name,
@@ -88,36 +92,38 @@ def test_tiff_dataset_name_and_layer_name_detection() -> None:
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test_dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "test_dataset"
+        assert list(layer_path_to_layer_name)[0] == f"{prefix}test_dataset"
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test if single file in folder
         converter = ImageStackConverter()
-        converter.source_files = [prefix + "test_dataset/brain.tif"]
+        converter.source_files = [f"{prefix}test_dataset{sep}brain.tif"]
         (
             dataset_name,
             layer_path_to_layer_name,
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "test_dataset"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "test_dataset/brain.tif"
+        assert (
+            list(layer_path_to_layer_name)[0] == f"{prefix}test_dataset{sep}brain.tif"
+        )
         assert list(layer_path_to_layer_name.values())[0] == "brain"
 
         # test if single file
         converter = ImageStackConverter()
-        converter.source_files = [prefix + "brain.tif"]
+        converter.source_files = [f"{prefix}brain.tif"]
         (
             dataset_name,
             layer_path_to_layer_name,
         ) = converter.detect_dataset_name_and_layer_path_to_layer_name()
         assert dataset_name == "brain"
         assert len(layer_path_to_layer_name) == 1
-        assert list(layer_path_to_layer_name)[0] == prefix + "brain.tif"
+        assert list(layer_path_to_layer_name)[0] == f"{prefix}brain.tif"
         assert list(layer_path_to_layer_name.values())[0] == "color"
 
         # test for multiple files with no parent directory
         converter = ImageStackConverter()
-        converter.source_files = [prefix + "001.tif", prefix + "002.tif"]
+        converter.source_files = [f"{prefix}001.tif", f"{prefix}002.tif"]
         (
             dataset_name,
             layer_path_to_layer_name,
@@ -134,64 +140,58 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test if dataset name and layer name and mag are correct
         converter = KnossosConverter()
         converter.source_files = [
-            prefix
-            + "knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
-            prefix
-            + "knossos/color/1/x0000/y0000/z0001/test_mag1_x0000_y0000_z0001.raw",
-            prefix
-            + "knossos/color/1/x0000/y0001/z0000/test_mag1_x0000_y0001_z0000.raw",
+            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0001{sep}test_mag1_x0000_y0000_z0001.raw",
+            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0001{sep}z0000{sep}test_mag1_x0000_y0001_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == prefix + "knossos/color"
+        assert list(layer_paths.keys())[0] == f"{prefix}knossos{sep}color"
         assert list(layer_paths.values())[0] == {"1"}
 
         # test if in subfolder
         converter = KnossosConverter()
         converter.source_files = [
-            prefix
-            + "superfolder/superfolder/knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}superfolder{sep}superfolder{sep}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
         assert (
             list(layer_paths.keys())[0]
-            == prefix + "superfolder/superfolder/knossos/color"
+            == f"{prefix}superfolder{sep}superfolder{sep}knossos{sep}color"
         )
         assert list(layer_paths.values())[0] == {"1"}
 
         # test for multiple layer
         converter = KnossosConverter()
         converter.source_files = [
-            prefix
-            + "knossos/color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
-            prefix
-            + "knossos/segmentation/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}knossos{sep}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}knossos{sep}segmentation{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 2
-        assert prefix + "knossos/color" in layer_paths.keys()
-        assert prefix + "knossos/segmentation" in layer_paths.keys()
+        assert f"{prefix}knossos{sep}color" in layer_paths.keys()
+        assert f"{prefix}knossos{sep}segmentation" in layer_paths.keys()
         assert all(map(lambda m: m == {"1"}, layer_paths.values()))
 
         # test if only layer folder given
         converter = KnossosConverter()
         converter.source_files = [
-            prefix + "color/1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}color{sep}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == prefix + "color"
+        assert list(layer_paths.keys())[0] == f"{prefix}color"
         assert list(layer_paths.values())[0] == {"1"}
 
         # test if only mag folder given
         converter = KnossosConverter()
         converter.source_files = [
-            prefix + "1/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}1{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
@@ -202,7 +202,7 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test if already in mag folder
         converter = KnossosConverter()
         converter.source_files = [
-            prefix + "x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "dataset"
@@ -213,7 +213,7 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test if too short path gets detected
         converter = KnossosConverter()
         converter.source_files = [
-            prefix + "y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         assertion_error = False
         try:
@@ -225,13 +225,11 @@ def test_knossos_dataset_name_and_layer_path_detection() -> None:
         # test for multiple mags
         converter = KnossosConverter()
         converter.source_files = [
-            prefix
-            + "knossos/color/2/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
-            prefix
-            + "knossos/color/4/x0000/y0000/z0000/test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}knossos{sep}color{sep}2{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
+            f"{prefix}knossos{sep}color{sep}4{sep}x0000{sep}y0000{sep}z0000{sep}test_mag1_x0000_y0000_z0000.raw",
         ]
         dataset_name, layer_paths = converter.detect_dataset_and_layer_paths_with_mag()
         assert dataset_name == "knossos"
         assert len(layer_paths) == 1
-        assert list(layer_paths.keys())[0] == prefix + "knossos/color"
+        assert list(layer_paths.keys())[0] == f"{prefix}knossos{sep}color"
         assert list(layer_paths.values())[0] == {"2", "4"}

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -38,6 +38,13 @@ TESTDATA_DIR = Path("testdata")
 TESTOUTPUT_DIR = Path("testoutput")
 
 
+@pytest.fixture(autouse=True)
+def run_around_tests():
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
+
+
 def delete_dir(relative_path: Path) -> None:
     if relative_path.exists() and relative_path.is_dir():
         rmtree(relative_path)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,18 +1,16 @@
-import filecmp
 import itertools
 import json
 import os
 import warnings
 from os.path import dirname, join
 from pathlib import Path
-from typing import Any, Tuple, cast, Generator
+from typing import Tuple, cast, Generator
 
 import pytest
 
 import numpy as np
 from shutil import rmtree, copytree
 
-from wkw import wkw
 from wkw.wkw import WKWException
 
 from wkcuber.api.dataset import Dataset, DatasetViewConfiguration
@@ -20,7 +18,6 @@ from wkcuber.api.bounding_box import BoundingBox
 from os import makedirs
 
 from wkcuber.api.layer import (
-    Layer,
     LayerCategories,
     SegmentationLayer,
     LayerViewConfiguration,
@@ -39,7 +36,7 @@ TESTOUTPUT_DIR = Path("testoutput")
 
 
 @pytest.fixture(autouse=True)
-def run_around_tests():
+def run_around_tests() -> None:
     makedirs(TESTOUTPUT_DIR, exist_ok=True)
     yield
     rmtree(TESTOUTPUT_DIR)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -35,13 +35,6 @@ TESTDATA_DIR = Path("testdata")
 TESTOUTPUT_DIR = Path("testoutput")
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
-
-
 def delete_dir(relative_path: Path) -> None:
     if relative_path.exists() and relative_path.is_dir():
         rmtree(relative_path)

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -28,13 +28,6 @@ TESTOUTPUT_DIR = Path("testoutput")
 TESTDATA_DIR = Path("testdata")
 
 
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
-
-
 def read_wkw(
     wkw_info: WkwDatasetInfo, offset: Tuple[int, int, int], size: Tuple[int, int, int]
 ) -> np.array:
@@ -91,7 +84,7 @@ def test_non_linear_filter_reshape() -> None:
 
 
 def downsample_test_helper(use_compress: bool) -> None:
-    source_path = Path("testdata", "WT1_wkw")
+    source_path = TESTDATA_DIR / "WT1_wkw"
     target_path = TESTOUTPUT_DIR / "WT1_wkw"
 
     source_ds = Dataset(source_path)

--- a/tests/test_downsampling.py
+++ b/tests/test_downsampling.py
@@ -1,13 +1,14 @@
-import logging
 import warnings
 from pathlib import Path
-from typing import Tuple, cast
+from typing import Tuple
 
 import numpy as np
 import pytest
+from shutil import rmtree
+from os import makedirs
 
 from wkcuber.api.dataset import Dataset
-from wkcuber.api.layer import Layer, LayerCategories
+from wkcuber.api.layer import LayerCategories
 from wkcuber.downsampling_utils import (
     InterpolationModes,
     downsample_cube,
@@ -16,16 +17,22 @@ from wkcuber.downsampling_utils import (
     calculate_default_max_mag,
     get_previous_mag,
 )
-import wkw
 from wkcuber.mag import Mag
 from wkcuber.utils import WkwDatasetInfo, open_wkw
 from wkcuber.downsampling_utils import _mode, non_linear_filter_3d
-import shutil
+
 
 CUBE_EDGE_LEN = 256
 
 TESTOUTPUT_DIR = Path("testoutput")
 TESTDATA_DIR = Path("testdata")
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests() -> None:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
 
 
 def read_wkw(
@@ -86,11 +93,6 @@ def test_non_linear_filter_reshape() -> None:
 def downsample_test_helper(use_compress: bool) -> None:
     source_path = Path("testdata", "WT1_wkw")
     target_path = TESTOUTPUT_DIR / "WT1_wkw"
-
-    try:
-        shutil.rmtree(target_path)
-    except:
-        pass
 
     source_ds = Dataset(source_path)
     target_ds = source_ds.copy_dataset(target_path, block_len=16, file_len=16)
@@ -157,11 +159,6 @@ def test_downsample_multi_channel() -> None:
         128 * np.random.randn(num_channels, size[0], size[1], size[2])
     ).astype("uint8")
     file_len = 32
-
-    try:
-        shutil.rmtree(TESTOUTPUT_DIR / "multi-channel-test")
-    except:
-        pass
 
     ds = Dataset.create(TESTOUTPUT_DIR / "multi-channel-test", (1, 1, 1))
     l = ds.add_layer(
@@ -248,11 +245,6 @@ def test_default_max_mag() -> None:
 def test_default_parameter() -> None:
     target_path = TESTOUTPUT_DIR / "downsaple_default"
 
-    try:
-        shutil.rmtree(target_path)
-    except:
-        pass
-
     ds = Dataset.create(target_path, scale=(1, 1, 1))
     layer = ds.add_layer(
         "color", LayerCategories.COLOR_TYPE, dtype_per_channel="uint8", num_channels=3
@@ -266,11 +258,6 @@ def test_default_parameter() -> None:
 
 
 def test_default_anisotropic_scale() -> None:
-    try:
-        shutil.rmtree(TESTOUTPUT_DIR / "default_anisotropic_scale")
-    except:
-        pass
-
     ds = Dataset.create(
         TESTOUTPUT_DIR / "default_anisotropic_scale", scale=(85, 85, 346)
     )
@@ -283,11 +270,6 @@ def test_default_anisotropic_scale() -> None:
 
 
 def test_downsample_mag_list() -> None:
-    try:
-        shutil.rmtree(TESTOUTPUT_DIR / "downsample_mag_list")
-    except:
-        pass
-
     ds = Dataset.create(TESTOUTPUT_DIR / "downsample_mag_list", scale=(1, 1, 2))
     layer = ds.add_layer("color", LayerCategories.COLOR_TYPE)
     mag = layer.add_mag(1)
@@ -302,11 +284,6 @@ def test_downsample_mag_list() -> None:
 
 
 def test_downsample_with_invalid_mag_list() -> None:
-    try:
-        shutil.rmtree(TESTOUTPUT_DIR / "downsample_mag_list")
-    except:
-        pass
-
     ds = Dataset.create(TESTOUTPUT_DIR / "downsample_mag_list", scale=(1, 1, 2))
     layer = ds.add_layer("color", LayerCategories.COLOR_TYPE)
     mag = layer.add_mag(1)
@@ -320,11 +297,6 @@ def test_downsample_with_invalid_mag_list() -> None:
 
 
 def test_downsample_compressed() -> None:
-    try:
-        shutil.rmtree(TESTOUTPUT_DIR / "downsample_compressed")
-    except:
-        pass
-
     ds = Dataset.create(TESTOUTPUT_DIR / "downsample_compressed", scale=(1, 1, 2))
     layer = ds.add_layer("color", LayerCategories.COLOR_TYPE)
     mag = layer.add_mag(1, block_len=8, file_len=8)

--- a/tests/test_export_wkw_as_tiff.py
+++ b/tests/test_export_wkw_as_tiff.py
@@ -7,21 +7,11 @@ import wkw
 import numpy as np
 from math import ceil
 from pathlib import Path
-import pytest
-from os import makedirs
-from shutil import rmtree
 
 
 DS_NAME = "simple_wk_dataset"
 TESTOUTPUT_DIR = Path("testoutput")
 SOURCE_PATH = Path("testdata") / DS_NAME
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
 
 
 def test_export_tiff_stack() -> None:

--- a/tests/test_export_wkw_as_tiff.py
+++ b/tests/test_export_wkw_as_tiff.py
@@ -6,18 +6,31 @@ from wkcuber.mag import Mag
 import wkw
 import numpy as np
 from math import ceil
+from pathlib import Path
+import pytest
+from os import makedirs
+from shutil import rmtree
 
-ds_name = "simple_wk_dataset"
-source_path = os.path.join("testdata", ds_name)
+
+DS_NAME = "simple_wk_dataset"
+TESTOUTPUT_DIR = Path("testoutput")
+SOURCE_PATH = Path("testdata") / DS_NAME
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests() -> None:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
 
 
 def test_export_tiff_stack() -> None:
-    destination_path = os.path.join("testoutput", ds_name + "_tiff")
+    destination_path = os.path.join("testoutput", DS_NAME + "_tiff")
     bbox = BoundingBox((100, 100, 10), (100, 500, 50))
     bbox_dict = bbox.as_config()
     args_list = [
         "--source_path",
-        source_path,
+        str(SOURCE_PATH),
         "--destination_path",
         destination_path,
         "--layer_name",
@@ -32,8 +45,8 @@ def test_export_tiff_stack() -> None:
 
     run(args_list)
 
-    test_wkw_file_path = os.path.join(source_path, "color", Mag(1).to_layer_name())
-    with wkw.Dataset.open(test_wkw_file_path) as dataset:
+    test_wkw_file_path = SOURCE_PATH / "color" / Mag(1).to_layer_name()
+    with wkw.Dataset.open(str(test_wkw_file_path)) as dataset:
         slice_bbox = bbox_dict
         slice_bbox["size"] = [slice_bbox["size"][0], slice_bbox["size"][1], 1]
         for data_slice_index in range(1, bbox_dict["size"][2] + 1):
@@ -65,10 +78,10 @@ def test_export_tiff_stack() -> None:
 
 
 def test_export_tiff_stack_tile_size() -> None:
-    destination_path = os.path.join("testoutput", ds_name + "_tile_size")
+    destination_path = os.path.join("testoutput", DS_NAME + "_tile_size")
     args_list = [
         "--source_path",
-        source_path,
+        str(SOURCE_PATH),
         "--destination_path",
         destination_path,
         "--layer_name",
@@ -88,8 +101,8 @@ def test_export_tiff_stack_tile_size() -> None:
     run(args_list)
 
     tile_bbox = {"topleft": bbox["topleft"], "size": [30, 30, 1]}
-    test_wkw_file_path = os.path.join(source_path, "color", Mag(1).to_layer_name())
-    with wkw.Dataset.open(test_wkw_file_path) as dataset:
+    test_wkw_file_path = SOURCE_PATH / "color" / Mag(1).to_layer_name()
+    with wkw.Dataset.open(str(test_wkw_file_path)) as dataset:
         slice_bbox = {"topleft": bbox["topleft"], "size": bbox["size"]}
         slice_bbox["size"] = [slice_bbox["size"][0], slice_bbox["size"][1], 1]
         for data_slice_index in range(bbox["size"][2]):
@@ -129,10 +142,10 @@ def test_export_tiff_stack_tile_size() -> None:
 
 
 def test_export_tiff_stack_tiles_per_dimension() -> None:
-    destination_path = os.path.join("testoutput", ds_name + "_tiles_per_dimension")
+    destination_path = os.path.join("testoutput", DS_NAME + "_tiles_per_dimension")
     args_list = [
         "--source_path",
-        source_path,
+        str(SOURCE_PATH),
         "--destination_path",
         destination_path,
         "--layer_name",
@@ -152,8 +165,8 @@ def test_export_tiff_stack_tiles_per_dimension() -> None:
     run(args_list)
 
     tile_bbox = {"topleft": bbox["topleft"], "size": [17, 17, 1]}
-    test_wkw_file_path = os.path.join(source_path, "color", Mag(1).to_layer_name())
-    with wkw.Dataset.open(test_wkw_file_path) as dataset:
+    test_wkw_file_path = SOURCE_PATH / "color" / Mag(1).to_layer_name()
+    with wkw.Dataset.open(str(test_wkw_file_path)) as dataset:
         slice_bbox = bbox
         slice_bbox["size"] = [slice_bbox["size"][0], slice_bbox["size"][1], 1]
         for data_slice_index in range(bbox["size"][2]):

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -7,7 +7,7 @@ from wkcuber.metadata import detect_resolutions
 
 def test_detect_resolutions() -> None:
     resolutions = sorted(list(detect_resolutions(Path("testdata", "WT1_wkw"), "color")))
-    assert [mag.to_layer_name() for mag in resolutions] == ["1", "2-2-1"]
+    assert [mag.to_layer_name() for mag in resolutions] == ["1"]
 
 
 def test_mag_constructor() -> None:

--- a/tests/test_mag.py
+++ b/tests/test_mag.py
@@ -7,7 +7,7 @@ from wkcuber.metadata import detect_resolutions
 
 def test_detect_resolutions() -> None:
     resolutions = sorted(list(detect_resolutions(Path("testdata", "WT1_wkw"), "color")))
-    assert [mag.to_layer_name() for mag in resolutions] == ["1"]
+    assert [mag.to_layer_name() for mag in resolutions] == ["1", "2-2-1"]
 
 
 def test_mag_constructor() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,8 +1,4 @@
 from pathlib import Path
-from os import makedirs
-from platform import system
-from shutil import rmtree
-
 import numpy as np
 import wkw
 
@@ -20,11 +16,6 @@ TESTOUTPUT_DIR = Path("testoutput")
 
 
 def test_element_class_conversion() -> None:
-    if system() == "Windows":
-        # We're skipping this test on Windows, because the CI
-        # doesn't have enough disk storage
-        return
-
     test_wkw_path = TESTOUTPUT_DIR / "test_metadata"
     prediction_layer_name = "prediction"
     prediction_wkw_info = WkwDatasetInfo(
@@ -79,7 +70,7 @@ def write_custom_layer(
         .astype(dtype)
     )
     prediction_wkw_info = WkwDatasetInfo(
-        target_path, layer_name, 1, wkw.Header(dtype, num_channels)
+        target_path, layer_name, 1, wkw.Header(dtype, num_channels, file_len=1)
     )
     ensure_wkw(prediction_wkw_info)
     with open_wkw(prediction_wkw_info) as dataset:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+import pytest
+from os import makedirs
+from shutil import rmtree
 
 import numpy as np
 import wkw
@@ -13,9 +16,18 @@ from wkcuber.metadata import (
     detect_mappings,
 )
 
+TESTOUTPUT_DIR = Path("testoutput")
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests() -> None:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
+
 
 def test_element_class_conversion() -> None:
-    test_wkw_path = Path("testoutput", "test_metadata")
+    test_wkw_path = TESTOUTPUT_DIR / "test_metadata"
     prediction_layer_name = "prediction"
     prediction_wkw_info = WkwDatasetInfo(
         test_wkw_path, prediction_layer_name, 1, wkw.Header(np.float32, num_channels=3)

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from os import makedirs
+from platform import system
 from shutil import rmtree
 
 import numpy as np
@@ -19,6 +20,11 @@ TESTOUTPUT_DIR = Path("testoutput")
 
 
 def test_element_class_conversion() -> None:
+    if system() == "Windows":
+        # We're skipping this test on Windows, because the CI
+        # doesn't have enough disk storage
+        return
+
     test_wkw_path = TESTOUTPUT_DIR / "test_metadata"
     prediction_layer_name = "prediction"
     prediction_wkw_info = WkwDatasetInfo(

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import pytest
 from os import makedirs
 from shutil import rmtree
 
@@ -17,13 +16,6 @@ from wkcuber.metadata import (
 )
 
 TESTOUTPUT_DIR = Path("testoutput")
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
 
 
 def test_element_class_conversion() -> None:

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -19,7 +19,10 @@ def test_element_class_conversion() -> None:
     test_wkw_path = TESTOUTPUT_DIR / "test_metadata"
     prediction_layer_name = "prediction"
     prediction_wkw_info = WkwDatasetInfo(
-        test_wkw_path, prediction_layer_name, 1, wkw.Header(np.float32, num_channels=3)
+        test_wkw_path,
+        prediction_layer_name,
+        1,
+        wkw.Header(np.float32, num_channels=3, file_len=1),
     )
     ensure_wkw(prediction_wkw_info)
 

--- a/tests/test_upsampling.py
+++ b/tests/test_upsampling.py
@@ -1,9 +1,6 @@
 import tempfile
 from pathlib import Path
-from shutil import rmtree
-from os import makedirs
 from typing import Tuple, cast
-import pytest
 
 from wkcuber.api.dataset import Dataset
 from wkcuber.api.layer import LayerCategories
@@ -17,13 +14,6 @@ WKW_CUBE_SIZE = 1024
 CUBE_EDGE_LEN = 256
 
 TESTOUTPUT_DIR = Path("testoutput")
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
 
 
 def test_upsampling() -> None:

--- a/tests/test_upsampling.py
+++ b/tests/test_upsampling.py
@@ -1,10 +1,12 @@
-import shutil
 import tempfile
 from pathlib import Path
+from shutil import rmtree
+from os import makedirs
 from typing import Tuple, cast
+import pytest
 
 from wkcuber.api.dataset import Dataset
-from wkcuber.api.layer import Layer, LayerCategories
+from wkcuber.api.layer import LayerCategories
 from wkcuber.downsampling_utils import SamplingModes
 from wkcuber.upsampling_utils import upsample_cube, upsample_cube_job
 from wkcuber.mag import Mag
@@ -13,6 +15,15 @@ import numpy as np
 
 WKW_CUBE_SIZE = 1024
 CUBE_EDGE_LEN = 256
+
+TESTOUTPUT_DIR = Path("testoutput")
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests() -> None:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
 
 
 def test_upsampling() -> None:
@@ -111,12 +122,7 @@ def test_upsample_multi_channel() -> None:
     ).astype("uint8")
     file_len = 32
 
-    try:
-        shutil.rmtree(Path("testoutput", "multi-channel-test"))
-    except:
-        pass
-
-    ds = Dataset.create(Path("testoutput", "multi-channel-test"), (1, 1, 1))
+    ds = Dataset.create(TESTOUTPUT_DIR / "multi-channel-test", (1, 1, 1))
     l = ds.add_layer(
         "color",
         LayerCategories.COLOR_TYPE,

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -46,7 +46,6 @@ def test_get_regular_chunks_max_inclusive() -> None:
 def test_buffered_slice_writer() -> None:
     test_img = np.arange(24 * 24).reshape(24, 24).astype(np.uint16) + 1
     dtype = test_img.dtype
-    # bbox = {"topleft": (0, 0, 0), "size": (24, 24, 35)}
     origin = [0, 0, 0]
     dataset_dir = TESTOUTPUT_DIR / "buffered_slice_writer"
     layer_name = "color"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,5 @@
 from pathlib import Path
 from shutil import rmtree
-from os import makedirs
-import pytest
 from typing import Union
 
 import numpy as np
@@ -13,13 +11,6 @@ import os
 BLOCK_LEN = 32
 
 TESTOUTPUT_DIR = Path("testoutput")
-
-
-@pytest.fixture(autouse=True)
-def run_around_tests() -> None:
-    makedirs(TESTOUTPUT_DIR, exist_ok=True)
-    yield
-    rmtree(TESTOUTPUT_DIR)
 
 
 def delete_dir(relative_path: Union[str, Path]) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,7 @@
 from pathlib import Path
+from shutil import rmtree
+from os import makedirs
+import pytest
 from typing import Union
 
 import numpy as np
@@ -6,9 +9,17 @@ from wkcuber.utils import get_chunks, get_regular_chunks, BufferedSliceWriter
 import wkw
 from wkcuber.mag import Mag
 import os
-from shutil import rmtree
 
 BLOCK_LEN = 32
+
+TESTOUTPUT_DIR = Path("testoutput")
+
+
+@pytest.fixture(autouse=True)
+def run_around_tests() -> None:
+    makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    yield
+    rmtree(TESTOUTPUT_DIR)
 
 
 def delete_dir(relative_path: Union[str, Path]) -> None:
@@ -44,9 +55,9 @@ def test_get_regular_chunks_max_inclusive() -> None:
 def test_buffered_slice_writer() -> None:
     test_img = np.arange(24 * 24).reshape(24, 24).astype(np.uint16) + 1
     dtype = test_img.dtype
-    bbox = {"topleft": (0, 0, 0), "size": (24, 24, 35)}
+    # bbox = {"topleft": (0, 0, 0), "size": (24, 24, 35)}
     origin = [0, 0, 0]
-    dataset_dir = Path("testoutput", "buffered_slice_writer")
+    dataset_dir = TESTOUTPUT_DIR / "buffered_slice_writer"
     layer_name = "color"
     mag = Mag(1)
     dataset_path = dataset_dir / layer_name / mag.to_layer_name()

--- a/wkcuber/converter.py
+++ b/wkcuber/converter.py
@@ -99,9 +99,9 @@ class Converter:
         traversal_depth = len(first_split_path)
         self.prefix = ""
         if first_split_path[0] == "":
-            self.prefix = "/"
+            self.prefix = sep
         elif first_split_path[0] == "..":
-            self.prefix = "../"
+            self.prefix = f"..{sep}"
 
         assert all(
             map(

--- a/wkcuber/knossos.py
+++ b/wkcuber/knossos.py
@@ -12,7 +12,7 @@ CUBE_EDGE_LEN = 128
 CUBE_SIZE = CUBE_EDGE_LEN ** 3
 CUBE_SHAPE = (CUBE_EDGE_LEN,) * 3
 CUBE_REGEX = re.compile(
-    fr"x(\d+){os.path.sep}y(\d+){os.path.sep}z(\d+){os.path.sep}(.*\.raw)$"
+    fr"x(\d+){re.escape(os.path.sep)}y(\d+){re.escape(os.path.sep)}z(\d+){re.escape(os.path.sep)}(.*\.raw)$"
 )
 
 

--- a/wkcuber/metadata.py
+++ b/wkcuber/metadata.py
@@ -237,7 +237,7 @@ def detect_bbox(dataset_path: Path, layer: str, mag: Mag = Mag(1)) -> Optional[d
 
     def parse_cube_file_name(filename: str) -> Tuple[int, int, int]:
         CUBE_REGEX = re.compile(
-            fr"z(\d+){os.path.sep}y(\d+){os.path.sep}x(\d+)(\.wkw)$"
+            fr"z(\d+){re.escape(os.path.sep)}y(\d+){re.escape(os.path.sep)}x(\d+)(\.wkw)$"
         )
         m = CUBE_REGEX.search(filename)
         if m is not None:

--- a/wkcuber/utils.py
+++ b/wkcuber/utils.py
@@ -49,7 +49,9 @@ FallbackArgs = namedtuple("FallbackArgs", ("distribution_strategy", "jobs"))
 BLOCK_LEN = 32
 DEFAULT_WKW_FILE_LEN = 32
 DEFAULT_WKW_VOXELS_PER_BLOCK = 32
-CUBE_REGEX = re.compile(fr"z(\d+){os.path.sep}y(\d+){os.path.sep}x(\d+)(\.wkw)$")
+CUBE_REGEX = re.compile(
+    fr"z(\d+){re.escape(os.path.sep)}y(\d+){re.escape(os.path.sep)}x(\d+)(\.wkw)$"
+)
 
 logger = getLogger(__name__)
 


### PR DESCRIPTION
### Description:
- Fixes a bug with path-regexes #393 
- Fixes hard-coded path seperators in the tests
- Add windows and mac builds to CI
- Tweaked the tests to be more conservative with peak storage consumption, because the Windows CI runner seems to have less storage available

### Issues:
- fixes #393 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
