### PR TITLE
CI: run dependent jobs after skipped ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,3 +290,11 @@ jobs:
         PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
         PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
       run: ./publish.sh
+
+  success:
+    needs: [webknossos_linux, wkcuber_linux, wkcuber_win, wkcuber_mac, wkcuber_docker]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
+    runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,4 +298,6 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
-    steps: []
+    steps:
+    - name: Success
+      run: echo Success!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,3 +298,4 @@ jobs:
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
+    steps: []

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,10 @@ jobs:
 
   wkcuber_docker:
     needs: [webknossos_linux, wkcuber_linux, wkcuber_win, wkcuber_mac]
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled')
     runs-on: ubuntu-latest
 
     steps:
@@ -263,7 +267,11 @@ jobs:
 
   pypi:
     needs: [webknossos_linux, wkcuber_linux, wkcuber_win, wkcuber_mac]
-    if: startsWith(github.event.ref, 'refs/tags')
+    if: |
+      always() &&
+      !contains(needs.*.result, 'failure') &&
+      !contains(needs.*.result, 'cancelled') &&
+      startsWith(github.event.ref, 'refs/tags')
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4


### PR DESCRIPTION
### Description:
Jobs which depend on skipped jobs, are also skipped normally. We want to run them in this case, except any of the previous jobs failed. I used the solution from here for this
https://github.com/actions/runner/issues/491#issuecomment-907216595

An alternative would be to place the original job conditional on all the single steps, which should result in the same behavior (only steps are skipped, the whole job would be successful). A step / action for a successful early exit would also help, but this does not seem to exist.

