### PR TITLE
Make parameter `executor` optional for `View.for_each_chunk`

### DIFF
--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -584,13 +584,23 @@ def test_chunking_wk(tmp_path: Path) -> None:
     original_data = (np.random.rand(50, 100, 150) * 205).astype(np.uint8)
     mag.write(offset=(70, 80, 90), data=original_data)
 
+    # Test with executor
     with get_executor_for_args(None) as executor:
         mag.for_each_chunk(
             chunk_job,
             chunk_size=(64, 64, 64),
             executor=executor,
         )
+    assert np.array_equal(original_data + 50, mag.get_view().read()[0])
 
+    # Reset the data
+    mag.write(offset=(70, 80, 90), data=original_data)
+
+    # Test without executor
+    mag.for_each_chunk(
+        chunk_job,
+        chunk_size=(64, 64, 64),
+    )
     assert np.array_equal(original_data + 50, mag.get_view().read()[0])
 
 

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -296,7 +296,9 @@ class View:
         self,
         work_on_chunk: Callable[[Tuple["View", int]], None],
         chunk_size: Tuple[int, int, int],
-        executor: Optional[Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]] = None,
+        executor: Optional[
+            Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]
+        ] = None,
     ) -> None:
         """
         The view is chunked into multiple sub-views of size `chunk_size`.
@@ -364,7 +366,9 @@ class View:
         target_view: "View",
         source_chunk_size: Vec3,
         target_chunk_size: Vec3,
-        executor: Optional[Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]] = None,
+        executor: Optional[
+            Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]
+        ] = None,
     ) -> None:
         """
         This method is similar to 'for_each_chunk' in the sense, that it delegates work to smaller chunks.

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -296,7 +296,7 @@ class View:
         self,
         work_on_chunk: Callable[[Tuple["View", int]], None],
         chunk_size: Tuple[int, int, int],
-        executor: Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor],
+        executor: Optional[Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]] = None,
     ) -> None:
         """
         The view is chunked into multiple sub-views of size `chunk_size`.
@@ -320,13 +320,11 @@ class View:
         # ...
         # let 'mag1' be a `MagView`
         view = mag1.get_view()
-        with get_executor_for_args(None) as executor:
-            func = named_partial(advanced_chunk_job, some_parameter=42)
-            view.for_each_chunk(
-                func,
-                chunk_size=(100, 100, 100),  # Use mag1._get_file_dimensions() if the size of the chunks should match the size of the files on disk
-                executor=executor,
-            )
+        func = named_partial(some_work, some_parameter=42)
+        view.for_each_chunk(
+            func,
+            chunk_size=(100, 100, 100),  # Use mag1._get_file_dimensions() if the size of the chunks should match the size of the files on disk
+        )
         ```
         """
 
@@ -354,7 +352,11 @@ class View:
             job_args.append((chunk_view, i))
 
         # execute the work for each chunk
-        wait_and_ensure_success(executor.map_to_futures(work_on_chunk, job_args))
+        if executor is None:
+            for args in job_args:
+                work_on_chunk(args)
+        else:
+            wait_and_ensure_success(executor.map_to_futures(work_on_chunk, job_args))
 
     def for_zipped_chunks(
         self,
@@ -362,7 +364,7 @@ class View:
         target_view: "View",
         source_chunk_size: Vec3,
         target_chunk_size: Vec3,
-        executor: Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor],
+        executor: Optional[Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]] = None,
     ) -> None:
         """
         This method is similar to 'for_each_chunk' in the sense, that it delegates work to smaller chunks.
@@ -439,7 +441,11 @@ class View:
             job_args.append((source_chunk_view, target_chunk_view, i))
 
         # execute the work for each pair of chunks
-        wait_and_ensure_success(executor.map_to_futures(work_on_chunk, job_args))
+        if executor is None:
+            for args in job_args:
+                work_on_chunk(args)
+        else:
+            wait_and_ensure_success(executor.map_to_futures(work_on_chunk, job_args))
 
     def _is_compressed(self) -> bool:
         return (

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Make parameter `executor` optional for `View.for_each_chunk` and `View.for_zipped_chunks`. [#404](https://github.com/scalableminds/webknossos-libs/pull/404)
 
 ### Fixed
 


### PR DESCRIPTION
### Description:
- If the parameter `executor` is not specified for `View.for_each_chunk` or `View.for_zipped_chunks`, the chunks are executed sequentially. 

### Issues:
- fixes #400

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
