### PR TITLE
Add option to not resolve symlink when adding a foreign layer

### DIFF
--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -385,7 +385,10 @@ class Dataset:
         self._export_as_json()
 
     def add_symlink_layer(
-        self, foreign_layer: Union[str, Path, Layer], make_relative: bool = False, resolve_symlinks: bool = True
+        self,
+        foreign_layer: Union[str, Path, Layer],
+        make_relative: bool = False,
+        resolve_symlinks: bool = True,
     ) -> Layer:
         """
         Creates a symlink to the data at `foreign_layer` which belongs to another dataset.
@@ -424,7 +427,9 @@ class Dataset:
         self._export_as_json()
         return self.layers[layer_name]
 
-    def add_copy_layer(self, foreign_layer: Union[str, Path, Layer], resolve_symlinks: bool = True) -> Layer:
+    def add_copy_layer(
+        self, foreign_layer: Union[str, Path, Layer], resolve_symlinks: bool = True
+    ) -> Layer:
         """
         Copies the data at `foreign_layer` which belongs to another dataset to the current dataset.
         Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied too.

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -385,7 +385,7 @@ class Dataset:
         self._export_as_json()
 
     def add_symlink_layer(
-        self, foreign_layer: Union[str, Path, Layer], make_relative: bool = False
+        self, foreign_layer: Union[str, Path, Layer], make_relative: bool = False, resolve_symlinks: bool = True
     ) -> Layer:
         """
         Creates a symlink to the data at `foreign_layer` which belongs to another dataset.
@@ -400,7 +400,8 @@ class Dataset:
         else:
             foreign_layer_path = Path(foreign_layer).absolute()
 
-        foreign_layer_path = foreign_layer_path.resolve()
+        if resolve_symlinks:
+            foreign_layer_path = foreign_layer_path.resolve()
         layer_name = foreign_layer_path.name
         if layer_name in self.layers.keys():
             raise IndexError(
@@ -423,7 +424,7 @@ class Dataset:
         self._export_as_json()
         return self.layers[layer_name]
 
-    def add_copy_layer(self, foreign_layer: Union[str, Path, Layer]) -> Layer:
+    def add_copy_layer(self, foreign_layer: Union[str, Path, Layer], resolve_symlinks: bool = True) -> Layer:
         """
         Copies the data at `foreign_layer` which belongs to another dataset to the current dataset.
         Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied too.
@@ -434,7 +435,8 @@ class Dataset:
         else:
             foreign_layer_path = Path(foreign_layer)
 
-        foreign_layer_path = foreign_layer_path.resolve()
+        if resolve_symlinks:
+            foreign_layer_path = foreign_layer_path.resolve()
         layer_name = foreign_layer_path.name
         if layer_name in self.layers.keys():
             raise IndexError(

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Added
 - The API documentation is now hosted on a publicwebpage. [#392](https://github.com/scalableminds/webknossos-cuber/pull/392)
+- Added optional parameter `resolve_symlinks` to `Dataset.add_symlink_layer` and `Dataset.add_copy_layer` to prevent that symlinks are resolved. [#406](https://github.com/scalableminds/webknossos-libs/pull/406)
 
 ### Changed
 - Uses the new `webknossos` package. All classes and functions are re-exported under the same names. [#398](https://github.com/scalableminds/webknossos-cuber/pull/398)


### PR DESCRIPTION
### Description:
- When adding a foreign layer, the path to the layer was previously resolved. This caused problems if the foreign layer was only a symlink and the original dataset did not contain a datasource-properties.json
- The parameter `resolve_symlinks` defaults to `True`, which is the previous behavior

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
