### PR TITLE
wkcuber: use venv by default (except for Dockerfile & win build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
     - name: Install dependencies
       shell: bash
       run: |
+        pip install -U pip
         pip install poetry
         poetry config virtualenvs.create false --local
         poetry install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,6 @@ jobs:
     - name: Install dependencies
       shell: bash
       run: |
-        pip install -U pip
         pip install poetry
         poetry config virtualenvs.create false --local
         poetry install
@@ -146,7 +145,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run tests/scripts/all_tests.sh
+      run: tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,13 @@ jobs:
       if: ${{ needs.changes.outputs.wkcuber == 'true' }}
 
     - name: Check typing
-      run: |
-        ./typecheck.sh
+      run: poetry run ./typecheck.sh
 
     - name: Python tests
       run: poetry run pytest tests
 
     - name: CLI tests
-      run: tests/scripts/all_tests.sh
+      run: poetry run tests/scripts/all_tests.sh
 
     - name: Check if git is dirty
       run: |
@@ -145,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: tests/scripts/all_tests.sh
+      run: poetry run tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest
@@ -176,7 +175,7 @@ jobs:
       run: poetry run pytest tests
 
     - name: CLI tests
-      run: tests/scripts/all_tests.sh
+      run: poetry run tests/scripts/all_tests.sh
 
   wkcuber_docker:
     needs: [webknossos_linux, wkcuber_linux, wkcuber_win, wkcuber_mac]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
       shell: bash
       run: |
         pip install poetry
+        poetry config virtualenvs.create false --local
         poetry install
 
     - name: Decompress test data

--- a/wkcuber/.gitignore
+++ b/wkcuber/.gitignore
@@ -106,3 +106,5 @@ testdata/tiff_mag_2_reference
 
 # MyPy
 .mypy_cache/
+
+/poetry.toml

--- a/wkcuber/Dockerfile
+++ b/wkcuber/Dockerfile
@@ -19,8 +19,7 @@ COPY webknossos/poetry.lock /webknossos/
 COPY webknossos/pyproject.toml /webknossos/
 COPY webknossos/README.md /webknossos/
 
-RUN echo '[virtualenvs]' > poetry.toml && \
-    echo 'create = false' >> poetry.toml
+RUN poetry config virtualenvs.create false --local
 RUN poetry install --no-dev
 
 ENTRYPOINT [ "python", "-m" ]

--- a/wkcuber/Dockerfile
+++ b/wkcuber/Dockerfile
@@ -4,7 +4,6 @@ RUN mkdir /app
 WORKDIR /app
 
 COPY wkcuber/README.md /app
-COPY wkcuber/poetry.toml /app
 COPY wkcuber/poetry.lock /app
 COPY wkcuber/pyproject.toml /app
 

--- a/wkcuber/Dockerfile
+++ b/wkcuber/Dockerfile
@@ -19,6 +19,8 @@ COPY webknossos/poetry.lock /webknossos/
 COPY webknossos/pyproject.toml /webknossos/
 COPY webknossos/README.md /webknossos/
 
+RUN echo '[virtualenvs]' > poetry.toml && \
+    echo 'create = false' >> poetry.toml
 RUN poetry install --no-dev
 
 ENTRYPOINT [ "python", "-m" ]

--- a/wkcuber/poetry.toml
+++ b/wkcuber/poetry.toml
@@ -1,2 +1,0 @@
-[virtualenvs]
-create = false


### PR DESCRIPTION
### Description:
wkcuber CI was failing with errors such as `FileNotFoundError: [Errno 2] No such file or directory: '…/python3.8/site-packages/packaging-20.9.dist-info/METADATA`. This PR changes the poetry configuration to use a venv by default (except for docker), which worked fine on mac & linux. Only the windows build fails when using a venv with weird errors, so not using it there.

If you want to use your default Python env or another managed conda/venv/… env, simply run to configure the local repo `poetry config virtualenvs.create false --local` or without `--local` to have it in your user-wide settings.