### PR TITLE
Windows CI: don't use venv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc -e -o pipefail tests/scripts/all_tests.sh
+      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
       shell: bash
       run: |
         pip install poetry
-        poetry config virtualenvs.create false --local
         poetry install
 
     - name: Decompress test data
@@ -145,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: tests/scripts/all_tests.sh
+      run: poetry run tests\scripts\all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail tests/scripts/all_tests.sh
+      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc -e -o pipefail tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run bash tests/scripts/all_tests.sh
+      run: poetry run C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
       shell: bash
       run: |
         pip install poetry
+        pip install virtualenv==20.0.33
         poetry install
 
     - name: Decompress test data

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,6 @@ jobs:
       shell: bash
       run: |
         pip install poetry
-        pip install virtualenv==20.0.33
         poetry install
 
     - name: Decompress test data
@@ -144,7 +143,6 @@ jobs:
       run: poetry run pytest tests
 
     - name: CLI tests
-      shell: bash
       run: poetry run tests\scripts\all_tests.sh
 
   wkcuber_mac:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,7 +144,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run tests\\scripts\\all_tests.sh
+      run: poetry run bash tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,8 @@ jobs:
       run: poetry run pytest tests
 
     - name: CLI tests
-      run: poetry run tests\scripts\all_tests.sh
+      shell: bash
+      run: poetry run tests\\scripts\\all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/wkcuber/tests/scripts/all_tests.sh
+++ b/wkcuber/tests/scripts/all_tests.sh
@@ -5,6 +5,8 @@ if [ -d "./testoutput" ]; then rm -Rf ./testoutput; fi
 
 BASEDIR=./tests/scripts
 
+false
+
 mkdir -p testdata/tiff_mag_2_reference
 tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
 

--- a/wkcuber/tests/scripts/all_tests.sh
+++ b/wkcuber/tests/scripts/all_tests.sh
@@ -5,8 +5,6 @@ if [ -d "./testoutput" ]; then rm -Rf ./testoutput; fi
 
 BASEDIR=./tests/scripts
 
-false
-
 mkdir -p testdata/tiff_mag_2_reference
 tar -xzvf testdata/tiff_mag_2_reference.tar.gz -C testdata/tiff_mag_2_reference
 


### PR DESCRIPTION
### Description:
The Windows CI run was unreliable with similar errors as the linux and mac runs before, so we're also using the default poetry venv here now.

