### PR TITLE
CI: fix conditions on complete step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,11 +318,13 @@ jobs:
 
   complete:
     needs: [webknossos_linux, wkcuber_linux, wkcuber_win, wkcuber_mac, wkcuber_docker, docs]
-    if: |
-      always() &&
-      !contains(needs.*.result, 'failure') &&
-      !contains(needs.*.result, 'cancelled')
+    if: always()
     runs-on: ubuntu-latest
     steps:
+    - name: Check failure
+      if: |
+        contains(needs.*.result, 'failure') ||
+        contains(needs.*.result, 'cancelled')
+      run: exit 1
     - name: Success
       run: echo Success!


### PR DESCRIPTION
### Description:
The `complete` step was skipped previously if other earlier skips failed. Skipped is taken as `succeeded` for mergeability checks. This is changed now, by failing the step if any earlier steps failed or were cancelled.

`complete` should fail with the current master, and succeed when the CI is fixed on master again.

