### PR TITLE
calculate_mags_to_downsample: raise on infinite loop

### DIFF
--- a/webknossos/webknossos/dataset/downsampling_utils.py
+++ b/webknossos/webknossos/dataset/downsampling_utils.py
@@ -65,12 +65,17 @@ def calculate_mags_to_downsample(
             # The smaller the ratio between the smallest dimension and the largest dimension, the better.
             if all_scaled_ratio < min_scaled_ratio:
                 # Multiply all dimensions with "2"
-                current_mag = Mag(np.minimum(current_mag.to_np() * 2, max_mag.to_np()))
+                new_mag = Mag(np.minimum(current_mag.to_np() * 2, max_mag.to_np()))
             else:
                 # Multiply only the minimal dimension by "2".
-                current_mag = Mag(
+                new_mag = Mag(
                     np.minimum(current_mag.to_np() * factor, max_mag.to_np())
                 )
+            if new_mag == current_mag:
+                raise RuntimeError(
+                    f"The maximum mag {max_mag} can not be reached from {current_mag} with scale {scale}!"
+                )
+            current_mag = new_mag
 
         mags += [current_mag]
 

--- a/webknossos/webknossos/dataset/downsampling_utils.py
+++ b/webknossos/webknossos/dataset/downsampling_utils.py
@@ -68,9 +68,7 @@ def calculate_mags_to_downsample(
                 new_mag = Mag(np.minimum(current_mag.to_np() * 2, max_mag.to_np()))
             else:
                 # Multiply only the minimal dimension by "2".
-                new_mag = Mag(
-                    np.minimum(current_mag.to_np() * factor, max_mag.to_np())
-                )
+                new_mag = Mag(np.minimum(current_mag.to_np() * factor, max_mag.to_np()))
             if new_mag == current_mag:
                 raise RuntimeError(
                     f"The maximum mag {max_mag} can not be reached from {current_mag} with scale {scale}!"


### PR DESCRIPTION
### Description:
`calculate_mags_to_downsample` can run into an infinite loop when having a scale and max-mag which don't result in a roughly isotropic resolution. This case is detected now and an `RuntimeError` is raised.
