### PR TITLE
Move Changelog portions to respective releases

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -7,7 +7,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.13...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.16...HEAD)
+
+### Breaking Changes
+### Added
+### Changed
+### Fixed
+
+## [0.8.16](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.16) - 2021-09-22
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.15...v0.8.16)
+
+### Breaking Changes
+- Refactored the BufferedSliceWriter and added a BufferedSliceReader. [#425](https://github.com/scalableminds/webknossos-libs/pull/425)
+  - BufferedSliceWriter
+    - The data no longer gets transposed: previously the format of the slices was [y,x]; now it is [x,y]
+    - The interface of the constructor was changed:
+      - A `View` (or `MagView`) is now required as datasource
+      - The parameter `dimension` can be used to specify the axis along the data is sliced
+      - The offset is expected to be in the magnification of the view
+    - This class is now supposed to be used within a context manager and the slices are written by sending them to the generator (see documentation of the class).
+  - BufferedSliceReader
+    - This class was added complementary to the BufferedSliceWriter
+  - Added methods to get a BufferedSliceReader/BufferedSliceWriter from a View directly
+
+### Added
+### Changed
+### Fixed
+
+## [0.8.15](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.13) - 2021-09-22
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.13...v0.8.15)
 
 ### Breaking Changes
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -34,7 +34,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 ### Fixed
 
-## [0.8.15](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.13) - 2021-09-22
+## [0.8.15](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.15) - 2021-09-22
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.13...v0.8.15)
 
 ### Breaking Changes

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -10,17 +10,15 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.13...HEAD)
 
 ### Breaking Changes in Config & CLI
-- Refactored the BufferedSliceWriter and added a BufferedSliceReader. [#425](https://github.com/scalableminds/webknossos-libs/pull/425)
-  - BufferedSliceWriter
-    - The data no longer gets transposed: previously the format of the slices was [y,x]; now it is [x,y]
-    - The interface of the constructor was changed: 
-      - A `View` (or `MagView`) is now required as datasource
-      - The parameter `dimension` can be used to specify the axis along the data is sliced
-      - The offset is expected to be in the magnification of the view
-    - This class is now supposed to be used within a context manager and the slices are written by sending them to the generator (see documentation of the class).
-  - BufferedSliceReader
-    - This class was added complementary to the BufferedSliceWriter
-  - Added methods to get a BufferedSliceReader/BufferedSliceWriter from a View directly
+### Added
+### Changed
+### Fixed
+
+
+## [0.8.16](https://github.com/scalableminds/webknossos-cuber/releases/tag/v0.8.16) - 2021-09-01
+[Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.13...v0.8.16)
+
+### Breaking Changes in Config & CLI
 
 ### Added
 - Add `jp2` support. [#428](https://github.com/scalableminds/webknossos-libs/pull/428)

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.13...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.16...HEAD)
 
 ### Breaking Changes in Config & CLI
 ### Added


### PR DESCRIPTION
@rschwanhold @youri-k Could you both please have a look if the mapping from changes to releases is correct now (and fix it here if you notice an error)?