### PR TITLE
Add shallow_copy_dataset method

### DIFF
--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -1360,7 +1360,7 @@ def test_outdated_dtype_parameter() -> None:
 
 
 @pytest.mark.parametrize("make_relative", [True, False])
-def test_dataset_shallow_copy(make_relative) -> None:
+def test_dataset_shallow_copy(make_relative: bool) -> None:
     delete_dir(TESTOUTPUT_DIR / "original_dataset")
     delete_dir(TESTOUTPUT_DIR / "copy_dataset")
     ds = Dataset.create(TESTOUTPUT_DIR / "original_dataset", (1, 1, 1))

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -545,8 +545,7 @@ class Dataset:
         Create a new dataset at the given path. Link all mags of all existing layers.
         In addition, link all other directories in all layer directories
         to make this method robust against additional files e.g. layer/mappings/agglomerate_view.hdf5.
-        This method becomes useful when exposing a dataset to webknossos
-        by e.g. linking several layers together or adding downsampled mags
+        This method becomes useful when exposing a dataset to webknossos.
         """
         new_dataset = Dataset.create(
             new_dataset_path, scale=self.scale, name=name or self.name

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -14,7 +14,7 @@ import numpy as np
 import wkw
 
 from webknossos.geometry import BoundingBox, Vec3Int
-from webknossos.utils import get_executor_for_args, copy_directory_with_symlinks
+from webknossos.utils import copy_directory_with_symlinks, get_executor_for_args
 
 from .layer import (
     Layer,
@@ -535,20 +535,33 @@ class Dataset:
         new_ds._export_as_json()
         return new_ds
 
-    def shallow_copy_dataset(self, new_dataset_path: Path, name: Optional[str] = None, make_relative: bool = False) -> "Dataset":
+    def shallow_copy_dataset(
+        self,
+        new_dataset_path: Path,
+        name: Optional[str] = None,
+        make_relative: bool = False,
+    ) -> "Dataset":
         """
         Create a new dataset at the given path. Link all mags of all existing layers.
-        In addition, link all files in all layer directories
-        to make this method robust against additional files e.g. layer/mappings/agglomerate_view.hdf5
+        In addition, link all other directories in all layer directories
+        to make this method robust against additional files e.g. layer/mappings/agglomerate_view.hdf5.
+        This method becomes useful when exposing a dataset to webknossos by e.g. linking several layers together or adding downsampled mags
         """
-        new_dataset = Dataset.create(new_dataset_path, scale=self.scale, name=name or self.name)
+        new_dataset = Dataset.create(
+            new_dataset_path, scale=self.scale, name=name or self.name
+        )
         for layer_name, layer in self.layers.items():
             new_layer = new_dataset.add_layer_like(layer, layer_name)
             for mag_view in layer.mags.values():
                 new_layer.add_symlink_mag(mag_view, make_relative)
 
-            # copy all other files with a dir scan
-            copy_directory_with_symlinks(layer.path, new_layer.path, ignore=[str(mag) for mag in layer.mags] + [PROPERTIES_FILE_NAME])
+            # copy all other directories with a dir scan
+            copy_directory_with_symlinks(
+                layer.path,
+                new_layer.path,
+                ignore=[str(mag) for mag in layer.mags] + [PROPERTIES_FILE_NAME],
+                make_relative=make_relative,
+            )
 
         return new_dataset
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -545,7 +545,8 @@ class Dataset:
         Create a new dataset at the given path. Link all mags of all existing layers.
         In addition, link all other directories in all layer directories
         to make this method robust against additional files e.g. layer/mappings/agglomerate_view.hdf5.
-        This method becomes useful when exposing a dataset to webknossos by e.g. linking several layers together or adding downsampled mags
+        This method becomes useful when exposing a dataset to webknossos
+        by e.g. linking several layers together or adding downsampled mags
         """
         new_dataset = Dataset.create(
             new_dataset_path, scale=self.scale, name=name or self.name

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import math
 import operator
@@ -390,7 +389,7 @@ class Layer:
         foreign_normalized_mag_path = (
             Path(os.path.relpath(foreign_mag_view.path, self.path))
             if make_relative
-            else os.path.abspath(foreign_mag_view.path)
+            else Path(os.path.abspath(foreign_mag_view.path))
         )
 
         if symlink:

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -372,50 +372,35 @@ class Layer:
         rmtree(full_path)
 
     def _add_foreign_mag(
-        self, foreign_mag_path: Path, symlink: bool, make_relative: bool
+        self, foreign_mag_view: MagView, symlink: bool, make_relative: bool
     ) -> MagView:
-        mag_name = foreign_mag_path.name
-        mag = Mag(mag_name)
-        operation = "symlink" if symlink else "copy"
-        if mag in self.mags.keys():
-            raise IndexError(
-                f"Cannot {operation} {foreign_mag_path}. This dataset already has a mag called {mag_name}."
-            )
+        is_foreign_mag_compressed = foreign_mag_view.header.block_type != wkw.Header.BLOCK_TYPE_RAW
+        added_mag_view = self.add_mag(foreign_mag_view.mag, foreign_mag_view.header.block_len, foreign_mag_view.header.file_len,
+                     is_foreign_mag_compressed)
+
+        # delete new created mag path and relplace with (shallow) copy
+        shutil.rmtree(added_mag_view.path)
 
         foreign_normalized_mag_path = (
-            Path(os.path.relpath(foreign_mag_path, self.dataset.path))
+            Path(os.path.relpath(foreign_mag_view.path, self.dataset.path))
             if make_relative
-            else foreign_mag_path
+            else os.path.abspath(foreign_mag_view.path)
         )
 
         if symlink:
             os.symlink(
                 foreign_normalized_mag_path,
-                join(self.dataset.path, self.name, mag_name),
+                join(self.dataset.path, self.name, str(foreign_mag_view.mag)),
             )
         else:
             shutil.copytree(
                 foreign_normalized_mag_path,
-                join(self.dataset.path, self.name, mag_name),
+                join(self.dataset.path, self.name, str(foreign_mag_view.mag)),
             )
-
-        # copy the properties of the layer into the properties of this dataset
-        from .dataset import Dataset  # local import to prevent circular dependency
-
-        original_layer = Dataset(foreign_mag_path.parent.parent).get_layer(
-            foreign_mag_path.parent.name
-        )
-        original_mag = original_layer.get_mag(foreign_mag_path.name)
-        mag_properties = copy.deepcopy(original_mag._properties)
-
-        self.bounding_box = self.bounding_box.extended_by(original_layer.bounding_box)
-        self._properties.wkw_resolutions += [mag_properties]
-        self._setup_mag(mag)
-        self.dataset._export_as_json()
-        return self.mags[mag]
+        return added_mag_view
 
     def add_symlink_mag(
-        self, foreign_mag_path: Union[str, Path], make_relative: bool = False
+        self, foreign_mag_view: MagView, make_relative: bool = False
     ) -> MagView:
         """
         Creates a symlink to the data at `foreign_mag_path` which belongs to another dataset.
@@ -424,19 +409,17 @@ class Layer:
         (or vice versa).
         If make_relative is True, the symlink is made relative to the current dataset path.
         """
-        foreign_mag_path = Path(os.path.abspath(foreign_mag_path))
         return self._add_foreign_mag(
-            foreign_mag_path, symlink=True, make_relative=make_relative
+            foreign_mag_view, symlink=True, make_relative=make_relative
         )
 
-    def add_copy_mag(self, foreign_mag_path: Union[str, Path]) -> MagView:
+    def add_copy_mag(self, foreign_mag_view: MagView) -> MagView:
         """
-        Copies the data at `foreign_mag_path` which belongs to another dataset to the current dataset.
+        Copies the data at `foreign_mag_view` which belongs to another dataset to the current dataset.
         Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied too.
         """
-        foreign_mag_path = Path(os.path.abspath(foreign_mag_path))
         return self._add_foreign_mag(
-            foreign_mag_path, symlink=False, make_relative=False
+            foreign_mag_view, symlink=False, make_relative=False
         )
 
     def _create_dir_for_mag(

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -374,15 +374,21 @@ class Layer:
     def _add_foreign_mag(
         self, foreign_mag_view: MagView, symlink: bool, make_relative: bool
     ) -> MagView:
-        is_foreign_mag_compressed = foreign_mag_view.header.block_type != wkw.Header.BLOCK_TYPE_RAW
-        added_mag_view = self.add_mag(foreign_mag_view.mag, foreign_mag_view.header.block_len, foreign_mag_view.header.file_len,
-                     is_foreign_mag_compressed)
+        is_foreign_mag_compressed = (
+            foreign_mag_view.header.block_type != wkw.Header.BLOCK_TYPE_RAW
+        )
+        added_mag_view = self.add_mag(
+            foreign_mag_view.mag,
+            foreign_mag_view.header.block_len,
+            foreign_mag_view.header.file_len,
+            is_foreign_mag_compressed,
+        )
 
         # delete new created mag path and relplace with (shallow) copy
         shutil.rmtree(added_mag_view.path)
 
         foreign_normalized_mag_path = (
-            Path(os.path.relpath(foreign_mag_view.path, self.dataset.path))
+            Path(os.path.relpath(foreign_mag_view.path, self.path))
             if make_relative
             else os.path.abspath(foreign_mag_view.path)
         )

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -95,12 +95,16 @@ class MagView(View):
 
         if create:
             wkw.Dataset.create(
-                join(layer.dataset.path, layer.name, self.name), self.header
+                str(self.path), self.header
             )
 
     @property
     def layer(self) -> "Layer":
         return self._layer
+
+    @property
+    def path(self) -> Path:
+        return self._path
 
     @property
     def _properties(self) -> MagViewProperties:

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -94,9 +94,7 @@ class MagView(View):
         )
 
         if create:
-            wkw.Dataset.create(
-                str(self.path), self.header
-            )
+            wkw.Dataset.create(str(self.path), self.header)
 
     @property
     def layer(self) -> "Layer":

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -115,7 +115,6 @@ def copy_directory_with_symlinks(
 ) -> None:
     """
     Links all directories in src_path / dir_name to dst_path / dir_name.
-    All links are relative to dst_path.
     """
     for item in os.scandir(src_path):
         if item.name not in ignore:

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -107,9 +107,18 @@ def time_since_epoch_in_ms() -> int:
     return unixtime * 1000
 
 
-def copy_directory_with_symlinks(src_path: Path, dst_path: Path, ignore: Iterable[str] = tuple()):
+def copy_directory_with_symlinks(
+    src_path: Path, dst_path: Path, ignore: Iterable[str] = tuple(), make_relative=False
+):
+    """
+    Links all directories in src_path / dir_name to dst_path / dir_name.
+    All links are relative to dst_path.
+    """
     for item in os.scandir(src_path):
         if item.name not in ignore:
             symlink_path = dst_path / item.name
-            relpath = os.path.relpath(Path(item.path), symlink_path.parent)
-            symlink_path.symlink_to(relpath)
+            if make_relative:
+                rel_or_abspath = os.path.relpath(Path(item.path), symlink_path.parent)
+            else:
+                rel_or_abspath = os.path.abspath(item.path)
+            symlink_path.symlink_to(rel_or_abspath)

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -108,8 +108,11 @@ def time_since_epoch_in_ms() -> int:
 
 
 def copy_directory_with_symlinks(
-    src_path: Path, dst_path: Path, ignore: Iterable[str] = tuple(), make_relative=False
-):
+    src_path: Path,
+    dst_path: Path,
+    ignore: Iterable[str] = tuple(),
+    make_relative: bool = False,
+) -> None:
     """
     Links all directories in src_path / dir_name to dst_path / dir_name.
     All links are relative to dst_path.

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -3,11 +3,13 @@ import calendar
 import functools
 import json
 import logging
+import os
 import time
 from concurrent.futures import as_completed
 from concurrent.futures._base import Future
 from datetime import datetime
 from multiprocessing import cpu_count
+from pathlib import Path
 from typing import Any, Callable, Iterable, List, Optional, Union
 
 from cluster_tools import WrappedProcessPoolExecutor, get_executor
@@ -103,3 +105,11 @@ def time_since_epoch_in_ms() -> int:
     d = datetime.utcnow()
     unixtime = calendar.timegm(d.utctimetuple())
     return unixtime * 1000
+
+
+def copy_directory_with_symlinks(src_path: Path, dst_path: Path, ignore: Iterable[str] = tuple()):
+    for item in os.scandir(src_path):
+        if item.name not in ignore:
+            symlink_path = dst_path / item.name
+            relpath = os.path.relpath(Path(item.path), symlink_path.parent)
+            symlink_path.symlink_to(relpath)


### PR DESCRIPTION
### Description:
- This PR adds a new method to the dataset class: shallow_copy_dataset
- This new method makes publishing datasets to webknossos easier
- In addition, the _add_foreign_mag method does now consume a MagView instead of a path.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] We might want to introduce a read-only flag to linked layers/mags.
 - [ ] Updated Changelog
