### PR TITLE
downgrade typing-extensions for compatibility with voxelytics

### DIFF
--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -1012,7 +1012,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytes
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "6baf6455c50c3e3f5b922127610572c9262c677802868e8ccde2a105362fd42c"
+content-hash = "b9caa0d44cacaa25224b2794d5d34007157a83f8f97dd95c31e8fad12b3400c4"
 
 [metadata.files]
 anyio = [

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -22,7 +22,7 @@ python-dotenv = "^0.19.0"
 rich = "^10.9.0"
 scikit-image = "^0.18.3"
 scipy = "^1.4.0"
-typing-extensions = "^3.10.0"
+typing-extensions = "^3.7"
 wkw = "1.1.11"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Tensorflow as used by voxelytics is not compatible with typing-extensions 3.10, so the libs should use the old one