### PR TITLE
skeleton.Graph inheriting from nx.Graph

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -10,6 +10,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-cuber/compare/v0.8.22...HEAD)
 
 ### Breaking Changes
+- `wk.Graph` now inherits from `networkx.Graph` directly. Therefore, the `nx_graph` attribute is removed. [#481](https://github.com/scalableminds/webknossos-libs/pull/481)
+
 ### Added
 ### Changed
 ### Fixed

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -83,7 +83,7 @@ def test_skeleton_creation() -> None:
     assert len(graphs) == 3
 
     g1 = nml.get_graph_by_id(1)
-    assert len(g1.get_nodes()) == 3
+    assert g1.number_of_nodes() == 3
 
     assert g1.get_node_by_id(2).comment == "A comment 1"
     assert g1.get_node_by_id(2).is_branchpoint
@@ -208,8 +208,7 @@ def test_simple_initialization_and_representations(tmp_path: Path) -> None:
     )
     assert str(my_group) == "Group(_id=1, name='my_group', _children=<2 children>)"
     assert (
-        str(nml.get_graph_by_id(9))
-        == "Graph(name='my_tree', _id=9, nx_graph=<n=1,e=0>, color=(0.1, 0.2, 0.3, 1.0))"
+        str(nml.get_graph_by_id(9)) == "Graph named 'my_tree' with 1 nodes and 0 edges"
     )
 
 

--- a/webknossos/webknossos/skeleton/graph.py
+++ b/webknossos/webknossos/skeleton/graph.py
@@ -1,6 +1,6 @@
-from typing import TYPE_CHECKING, List, Optional, Tuple, Union
+from collections.abc import MutableMapping
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Union
 
-import attr
 import networkx as nx
 import numpy as np
 
@@ -13,51 +13,115 @@ Vector3 = Tuple[float, float, float]
 Vector4 = Tuple[float, float, float, float]
 
 
-@attr.define(kw_only=True)
-class Graph:
+def _get_id(node_or_id: Union[Node, int]) -> int:
+    if isinstance(node_or_id, Node):
+        return node_or_id.id
+    else:
+        return node_or_id
+
+
+class _AdjDict(MutableMapping):
+    def __init__(self, *, node_dict: "_NodeDict") -> None:
+        self._id_to_attrs: Dict[int, Any] = {}
+        self._node_dict = node_dict
+
+    def __getitem__(self, key: Union[Node, int]) -> Any:
+        return self._id_to_attrs[_get_id(key)]
+
+    def __setitem__(self, key: Node, value: Dict) -> None:
+        self._id_to_attrs[_get_id(key)] = value
+
+    def __delitem__(self, key: Union[Node, int]) -> None:
+        del self._id_to_attrs[_get_id(key)]
+
+    def __iter__(self) -> Iterator[Node]:
+        return (self._node_dict.get_node(i) for i in self._id_to_attrs)
+
+    def __len__(self) -> int:
+        return len(self._id_to_attrs)
+
+
+class _NodeDict(MutableMapping):
+    def __init__(self) -> None:
+        self._id_to_attrs: Dict[int, Any] = {}
+        self._id_to_node: Dict[int, Node] = {}
+
+    def __getitem__(self, key: Union[Node, int]) -> Any:
+        return self._id_to_attrs[_get_id(key)]
+
+    def __setitem__(self, key: Node, value: Dict) -> None:
+        self._id_to_node[key.id] = key
+        self._id_to_attrs[key.id] = value
+
+    def __delitem__(self, key: Union[Node, int]) -> None:
+        del self._id_to_node[_get_id(key)]
+        del self._id_to_attrs[_get_id(key)]
+
+    def __iter__(self) -> Iterator[Node]:
+        return iter(self._id_to_node.values())
+
+    def __len__(self) -> int:
+        return len(self._id_to_attrs)
+
+    def get_node(self, id_: int) -> Node:
+        return self._id_to_node[id_]
+
+
+class Graph(nx.Graph):
     """
     Contains a collection of nodes and edges.
+    This class inherits from [`networkx.Graph`](https://networkx.org/documentation/stable/reference/classes/graph.html).
+    For further methods, please [check the networkx documentation](https://networkx.org/documentation/stable/reference/classes/graph.html#methods).
     """
 
-    name: str
-    group: "Group" = attr.ib(eq=False, repr=False)
-    _nml: "Skeleton" = attr.ib(eq=False, repr=False)
-    _id: int = attr.ib(init=False)
-    nx_graph: nx.Graph = attr.ib(
-        init=False,
-        repr=lambda nx_graph: f"<n={len(nx_graph.nodes)},e={len(nx_graph.edges)}>",
-        eq=lambda nx_graph: (
-            sorted(nx_graph.nodes(data="obj")),
-            sorted(nx_graph.edges),
-        ),
-    )
-    color: Optional[Vector4] = None
-    _enforced_id: Optional[int] = attr.ib(None, eq=False, repr=False)
+    def __init__(
+        self,
+        name: str,
+        group: "Group",
+        skeleton: "Skeleton",
+        color: Optional[Vector4] = None,
+        enforced_id: Optional[int] = None,
+    ) -> None:
+        self.node_dict_factory = _NodeDict
+        self.adjlist_outer_dict_factory = lambda: _AdjDict(node_dict=self._node)
+        self.adjlist_inner_dict_factory = lambda: _AdjDict(node_dict=self._node)
 
-    def __attrs_post_init__(self) -> None:
-        self.nx_graph = nx.Graph()
-        if self._enforced_id is not None:
-            self._id = self._enforced_id
+        super().__init__()
+
+        self.name = name
+        self.group = group
+        self.color = color
+
+        # read-only member, exposed via properties
+        if enforced_id is not None:
+            self._id = enforced_id
         else:
-            self._id = self._nml.element_id_generator.__next__()
+            self._id = skeleton.element_id_generator.__next__()
+
+        # only used internally
+        self._skeleton = skeleton
+
+    def __eq__(self, o: object) -> bool:
+        get_comparable = lambda graph: (
+            graph.name,
+            graph.id,
+            graph.color,
+            sorted(graph.nodes),
+            sorted(graph.edges),
+        )
+        return get_comparable(self) == get_comparable(o)
 
     @property
     def id(self) -> int:
         return self._id
 
-    def get_nodes(self) -> List[Node]:
-        return [node_view[1] for node_view in self.nx_graph.nodes(data="obj")]
-
     def get_node_positions(self) -> np.ndarray:
-        return np.array([node.position for node in self.get_nodes()])
+        return np.array([node.position for node in self.nodes])
 
     def get_node_by_id(self, node_id: int) -> Node:
-        return self.nx_graph.nodes[node_id]["obj"]
+        return self._node.get_node(node_id)
 
-    def has_node_id(self, node_id: int) -> bool:
-        return node_id in self.nx_graph.nodes
-
-    def add_node(
+    def add_node(  # pylint: disable=arguments-differ
         self,
         position: Vector3,
         comment: Optional[str] = None,
@@ -71,7 +135,6 @@ class Graph:
         is_branchpoint: bool = False,
         branchpoint_time: Optional[int] = None,
         _enforced_id: Optional[int] = None,
-        _nml: Optional["Skeleton"] = None,
     ) -> Node:
         node = Node(
             position=position,
@@ -86,18 +149,13 @@ class Graph:
             is_branchpoint=is_branchpoint,
             branchpoint_time=branchpoint_time,
             enforced_id=_enforced_id,
-            nml=_nml or self._nml,
+            skeleton=self._skeleton,
         )
-        self.nx_graph.add_node(node.id, obj=node)
+        super().add_node(node)
         return node
 
-    def add_edge(self, node_1: Union[int, Node], node_2: Union[int, Node]) -> None:
-        id_1 = node_1.id if isinstance(node_1, Node) else node_1
-        id_2 = node_2.id if isinstance(node_2, Node) else node_2
-        self.nx_graph.add_edge(id_1, id_2)
-
     def get_max_node_id(self) -> int:
-        return max((node.id for node in self.get_nodes()), default=0)
+        return max((node.id for node in self.nodes), default=0)
 
     def __hash__(self) -> int:
         return self._id

--- a/webknossos/webknossos/skeleton/group.py
+++ b/webknossos/webknossos/skeleton/group.py
@@ -25,14 +25,14 @@ class Group:
         init=False,
         repr=lambda children: f"<{unit_len(children, 'children')}>",
     )
-    _nml: "Skeleton" = attr.ib(eq=False, repr=False)
+    _skeleton: "Skeleton" = attr.ib(eq=False, repr=False)
     _enforced_id: Optional[int] = attr.ib(None, eq=False, repr=False)
 
     def __attrs_post_init__(self) -> None:
         if self._enforced_id is not None:
             self._id = self._enforced_id
         else:
-            self._id = self._nml.element_id_generator.__next__()
+            self._id = self._skeleton.element_id_generator.__next__()
 
     @property
     def id(self) -> int:
@@ -51,7 +51,7 @@ class Group:
             name=name,
             color=color,
             group=self,
-            nml=self._nml,
+            skeleton=self._skeleton,
             enforced_id=_enforced_id,
         )
         self._children.add(new_graph)
@@ -67,12 +67,12 @@ class Group:
         name: str,
         _enforced_id: Optional[int] = None,
     ) -> "Group":
-        new_group = Group(name, nml=self._nml, enforced_id=_enforced_id)
+        new_group = Group(name, skeleton=self._skeleton, enforced_id=_enforced_id)
         self._children.add(new_group)
         return new_group
 
     def get_total_node_count(self) -> int:
-        return sum(len(graph.get_nodes()) for graph in self.flattened_graphs())
+        return sum(graph.number_of_nodes() for graph in self.flattened_graphs())
 
     def get_max_graph_id(self) -> int:
         return max((graph.id for graph in self.flattened_graphs()), default=0)
@@ -98,7 +98,7 @@ class Group:
 
     def get_node_by_id(self, node_id: int) -> "Node":
         for graph in self.flattened_graphs():
-            if graph.has_node_id(node_id):
+            if graph.has_node(node_id):
                 return graph.get_node_by_id(node_id)
 
         raise ValueError("Node id not found")

--- a/webknossos/webknossos/skeleton/nml/from_skeleton.py
+++ b/webknossos/webknossos/skeleton/nml/from_skeleton.py
@@ -67,14 +67,14 @@ def from_skeleton(
     comments = [
         NmlComment(node.id, node.comment)
         for graph in group.flattened_graphs()
-        for _id, node in graph.nx_graph.nodes(data="obj")
+        for node in graph.nodes
         if node.comment is not None
     ]
 
     branchpoints = [
         NmlBranchpoint(node.id, node.time)
         for graph in group.flattened_graphs()
-        for _id, node in graph.nx_graph.nodes(data="obj")
+        for node in graph.nodes
         if node.is_branchpoint
     ]
 
@@ -138,11 +138,11 @@ def _extract_nodes_and_edges_from_graph(
             interpolation=node.interpolation,
             time=node.time,
         )
-        for _id, node in graph.nx_graph.nodes(data="obj")
+        for node in graph.nodes
     ]
 
     edge_nml = [
-        NmlEdge(source=edge[0], target=edge[1]) for edge in graph.nx_graph.edges
+        NmlEdge(source=edge_a.id, target=edge_b.id) for edge_a, edge_b in graph.edges
     ]
 
     return node_nml, edge_nml

--- a/webknossos/webknossos/skeleton/nml/from_skeleton.py
+++ b/webknossos/webknossos/skeleton/nml/from_skeleton.py
@@ -142,7 +142,7 @@ def _extract_nodes_and_edges_from_graph(
     ]
 
     edge_nml = [
-        NmlEdge(source=edge_a.id, target=edge_b.id) for edge_a, edge_b in graph.edges
+        NmlEdge(source=source.id, target=target.id) for source, target in graph.edges
     ]
 
     return node_nml, edge_nml

--- a/webknossos/webknossos/skeleton/node.py
+++ b/webknossos/webknossos/skeleton/node.py
@@ -11,7 +11,7 @@ Vector3 = Tuple[float, float, float]
 @attr.define()
 class Node:
     position: Vector3
-    _nml: "Skeleton" = attr.ib(eq=False, repr=False)
+    _skeleton: "Skeleton" = attr.ib(eq=False, repr=False)
     _id: int = attr.ib(init=False)
     comment: Optional[str] = None
     radius: Optional[float] = None
@@ -30,7 +30,7 @@ class Node:
         if self._enforced_id is not None:
             self._id = self._enforced_id
         else:
-            self._id = self._nml.element_id_generator.__next__()
+            self._id = self._skeleton.element_id_generator.__next__()
 
     @property
     def id(self) -> int:

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -47,11 +47,11 @@ class Skeleton(Group):
 
     _id: int = attr.ib(init=False, repr=False)
     element_id_generator: Iterator[int] = attr.ib(init=False, eq=False, repr=False)
-    _nml: "Skeleton" = attr.ib(init=False, eq=False, repr=False)
+    _skeleton: "Skeleton" = attr.ib(init=False, eq=False, repr=False)
 
     def __attrs_post_init__(self) -> None:
         self.element_id_generator = itertools.count()
-        self._nml = self
+        self._skeleton = self
         super().__attrs_post_init__()
 
     @staticmethod


### PR DESCRIPTION
### Description:
Changes the `Graph` class to inherit from the networkx-Graph directly instead of using composition. This allows users to run networkx-algorithms directly on the Graph. Additionally we can add support for manipulating the graph directly. Currently the main barrier is to set the `_skeleton` and id of the nodes. This could be done lazily when inserting the objects into the graph (also mentioned in https://github.com/scalableminds/webknossos-libs/issues/380#issuecomment-923995846). I'd defer this for now, since it does not have highest prio. However I think this PR already can be merged without those changes. Do you agree, @philippotto?

### Issues:
- part of  #380

### Todos:
 - [x] Updated Changelog
