### PR TITLE
Add websites metadata to pyproject.toml

### DIFF
--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -5,6 +5,8 @@ description = "Python package to work with webKnossos datasets and annotations"
 authors = ["scalable minds <hello@scalableminds.com>"]
 readme = "README.md"
 license = "AGPL-3.0"
+repository = "https://github.com/scalableminds/webknossos-libs"
+homepage = "https://docs.webknossos.org"
 
 [tool.poetry.dependencies]
 python = "^3.7,>=3.7.1"


### PR DESCRIPTION
### Description:
Added `homepage` and `repository` to the pyproject.toml since no such information is available on the package's PyPi projects website yet. Hopefully, this will add this missing information there.

