### PR TITLE
Resolve path when symlinking layer and make_relative is False

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Changed
 - Improved performance for calculations with `Vec3Int` and `BoundingBox`. [#461](https://github.com/scalableminds/webknossos-libs/pull/461)
+- Resolve path when symlinking layer and make_relative is False (instead of only making it absolute). [#492](https://github.com/scalableminds/webknossos-libs/pull/492)
 
 ### Fixed
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -411,7 +411,7 @@ class Dataset:
         foreign_layer_symlink_path = (
             Path(os.path.relpath(foreign_layer_path, self.path))
             if make_relative
-            else Path(os.path.abspath(foreign_layer_path))
+            else foreign_layer_path.resolve()
         )
         os.symlink(foreign_layer_symlink_path, join(self.path, layer_name))
         original_layer = Dataset(foreign_layer_path.parent).get_layer(
@@ -443,7 +443,6 @@ class Dataset:
         else:
             foreign_layer_path = Path(foreign_layer)
 
-        foreign_layer_path = Path(os.path.abspath(foreign_layer_path))
         foreign_layer_name = foreign_layer_path.name
         layer_name = (
             new_layer_name if new_layer_name is not None else foreign_layer_name


### PR DESCRIPTION
### Description:
- abspath resulted in paths pointing into specific user directories which may not always be accessible. Instead, all symlinks should be resolved so that the resulting symlink points to the actual location on disk.
- I'll share the test workflow results privately

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
