### PR TITLE
Allow downloads from remote datastore, update & fix tests, longer timeouts

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes
 
 ### Added
+- Added support to download datasets from external datastores, which is the case for webknossos.org.  [#497](https://github.com/scalableminds/webknossos-libs/pull/497)
 
 ### Changed
 

--- a/webknossos/examples/dataset_usage.py
+++ b/webknossos/examples/dataset_usage.py
@@ -2,80 +2,78 @@ import numpy as np
 
 import webknossos as wk
 
-#####################
-# Opening a dataset #
-#####################
+if __name__ == "__main__":
+    #####################
+    # Opening a dataset #
+    #####################
 
-dataset = wk.Dataset("testdata/simple_wk_dataset")
-# Assuming that the dataset has a layer "color"
-# and the layer has the magnification 1
-layer = dataset.get_layer("color")
-mag1 = layer.get_mag("1")
+    dataset = wk.Dataset("testdata/simple_wk_dataset")
+    # Assuming that the dataset has a layer "color"
+    # and the layer has the magnification 1
+    layer = dataset.get_layer("color")
+    mag1 = layer.get_mag("1")
 
+    ######################
+    # Creating a dataset #
+    ######################
 
-######################
-# Creating a dataset #
-######################
+    dataset = wk.Dataset.create("testoutput/my_new_dataset", scale=(1, 1, 1))
+    layer = dataset.add_layer(
+        layer_name="color", category="color", dtype_per_channel="uint8", num_channels=3
+    )
+    mag1 = layer.add_mag("1")
+    mag1 = layer.add_mag("2")
 
-dataset = wk.Dataset.create("testoutput/my_new_dataset", scale=(1, 1, 1))
-layer = dataset.add_layer(
-    layer_name="color", category="color", dtype_per_channel="uint8", num_channels=3
-)
-mag1 = layer.add_mag("1")
-mag1 = layer.add_mag("2")
+    ##########################
+    # Writing into a dataset #
+    ##########################
 
+    layer = dataset.get_layer("color")
+    mag1 = layer.get_mag("1")
+    mag2 = layer.get_mag("2")
 
-##########################
-# Writing into a dataset #
-##########################
+    # The properties are updated automatically
+    # when the written data exceeds the bounding box in the properties
+    mag1.write(
+        offset=(10, 20, 30),
+        # assuming the layer has 3 channels:
+        data=(np.random.rand(3, 512, 512, 32) * 255).astype(np.uint8),
+    )
 
-layer = dataset.get_layer("color")
-mag1 = layer.get_mag("1")
-mag2 = layer.get_mag("2")
+    mag2.write(
+        offset=(5, 10, 15),
+        data=(np.random.rand(3, 256, 256, 16) * 255).astype(np.uint8),
+    )
 
-# The properties are updated automatically
-# when the written data exceeds the bounding box in the properties
-mag1.write(
-    offset=(10, 20, 30),
-    # assuming the layer has 3 channels:
-    data=(np.random.rand(3, 512, 512, 32) * 255).astype(np.uint8),
-)
+    ##########################
+    # Reading from a dataset #
+    ##########################
 
-mag2.write(
-    offset=(5, 10, 15), data=(np.random.rand(3, 256, 256, 16) * 255).astype(np.uint8)
-)
+    layer = dataset.get_layer("color")
+    mag1 = layer.get_mag("1")
+    mag2 = layer.get_mag("2")
 
+    data_in_mag1 = mag1.read()  # the offset and size from the properties are used
+    data_in_mag1_subset = mag1.read(offset=(10, 20, 30), size=(512, 512, 32))
 
-##########################
-# Reading from a dataset #
-##########################
+    data_in_mag2 = mag2.read()
+    data_in_mag2_subset = mag2.read(offset=(5, 10, 15), size=(256, 256, 16))
 
-layer = dataset.get_layer("color")
-mag1 = layer.get_mag("1")
-mag2 = layer.get_mag("2")
+    #####################
+    # Copying a dataset #
+    #####################
 
-data_in_mag1 = mag1.read()  # the offset and size from the properties are used
-data_in_mag1_subset = mag1.read(offset=(10, 20, 30), size=(512, 512, 32))
-
-data_in_mag2 = mag2.read()
-data_in_mag2_subset = mag2.read(offset=(5, 10, 15), size=(256, 256, 16))
-
-
-#####################
-# Copying a dataset #
-#####################
-
-copy_of_dataset = dataset.copy_dataset(
-    "testoutput/copy_of_dataset",
-    block_len=8,
-    file_len=8,
-    compress=True,
-)
-new_layer = dataset.add_layer(
-    layer_name="segmentation",
-    category="segmentation",
-    dtype_per_channel="uint8",
-    largest_segment_id=0,
-)
-# Link a layer of the initial dataset to the copy:
-sym_layer = copy_of_dataset.add_symlink_layer(new_layer)
+    copy_of_dataset = dataset.copy_dataset(
+        "testoutput/copy_of_dataset",
+        block_len=8,
+        file_len=8,
+        compress=True,
+    )
+    new_layer = dataset.add_layer(
+        layer_name="segmentation",
+        category="segmentation",
+        dtype_per_channel="uint8",
+        largest_segment_id=0,
+    )
+    # Link a layer of the initial dataset to the copy:
+    sym_layer = copy_of_dataset.add_symlink_layer(new_layer)

--- a/webknossos/examples/dataset_usage.py
+++ b/webknossos/examples/dataset_usage.py
@@ -2,7 +2,10 @@ import numpy as np
 
 import webknossos as wk
 
-if __name__ == "__main__":
+# pylint: disable=unused-variable
+
+
+def main() -> None:
     #####################
     # Opening a dataset #
     #####################
@@ -77,3 +80,7 @@ if __name__ == "__main__":
     )
     # Link a layer of the initial dataset to the copy:
     sym_layer = copy_of_dataset.add_symlink_layer(new_layer)
+
+
+if __name__ == "__main__":
+    main()

--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -7,59 +7,60 @@ from skimage.future import TrainableSegmenter
 
 import webknossos as wk
 
-annotation = wk.open_annotation(
-    "https://webknossos.org/annotations/Explorational/616457c2010000870032ced4"
-)
-training_data_bbox = wk.BoundingBox.from_tuple6(
-    annotation.skeleton.user_bounding_boxes[0]  # pylint: disable=unsubscriptable-object
-)
-time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
-new_dataset_name = annotation.dataset_name + f"_segmented_{time_str}"
-dataset = wk.download_dataset(
-    annotation.dataset_name,
-    "scalable_minds",
-    path=new_dataset_name,
-)
-dataset.name = new_dataset_name
+if __name__ == "__main__":
+    annotation = wk.open_annotation(
+        "https://webknossos.org/annotations/Explorational/616457c2010000870032ced4"
+    )
+    # pylint: disable=unsubscriptable-object
+    training_data_bbox = wk.BoundingBox.from_tuple6(
+        annotation.skeleton.user_bounding_boxes[0]
+    )
+    time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
+    new_dataset_name = annotation.dataset_name + f"_segmented_{time_str}"
+    dataset = wk.download_dataset(
+        annotation.dataset_name,
+        "scalable_minds",
+        path=new_dataset_name,
+    )
+    dataset.name = new_dataset_name
 
-volume_annotation = annotation.save_volume_annotation(dataset)
-volume_annotation.bounding_box = training_data_bbox
+    volume_annotation = annotation.save_volume_annotation(dataset)
+    volume_annotation.bounding_box = training_data_bbox
 
-mag = wk.Mag(1)
-mag_view = dataset.layers["color"].mags[mag]
+    mag = wk.Mag(1)
+    mag_view = dataset.layers["color"].mags[mag]
 
-features_func = partial(
-    feature.multiscale_basic_features, multichannel=True, edges=False
-)
-segmenter = TrainableSegmenter(features_func=features_func)
+    features_func = partial(
+        feature.multiscale_basic_features, multichannel=True, edges=False
+    )
+    segmenter = TrainableSegmenter(features_func=features_func)
 
-print("Starting training…")
-img_data_train = mag_view.read(
-    training_data_bbox.in_mag(mag).topleft, training_data_bbox.in_mag(mag).size
-)
-# move channels to last dimension, remove z dimension
-X_train = np.moveaxis(np.squeeze(img_data_train), 0, -1)
-Y_train = np.squeeze(volume_annotation.mags[mag].get_view().read())
-segmenter.fit(X_train, Y_train)
+    print("Starting training…")
+    img_data_train = mag_view.read(
+        training_data_bbox.in_mag(mag).topleft, training_data_bbox.in_mag(mag).size
+    )
+    # move channels to last dimension, remove z dimension
+    X_train = np.moveaxis(np.squeeze(img_data_train), 0, -1)
+    Y_train = np.squeeze(volume_annotation.mags[mag].get_view().read())
+    segmenter.fit(X_train, Y_train)
 
+    print("Starting prediction…")
+    X_predict = np.moveaxis(np.squeeze(mag_view.read()), 0, -1)
+    Y_predicted = segmenter.predict(X_predict)
+    segmentation = Y_predicted[:, :, None]  # adds z dimension
+    assert segmentation.max() < 256
+    segmentation = segmentation.astype("uint8")
 
-print("Starting prediction…")
-X_predict = np.moveaxis(np.squeeze(mag_view.read()), 0, -1)
-Y_predicted = segmenter.predict(X_predict)
-segmentation = Y_predicted[:, :, None]  # adds z dimension
-assert segmentation.max() < 256
-segmentation = segmentation.astype("uint8")
+    segmentation_layer = dataset.add_layer(
+        "segmentation",
+        "segmentation",
+        segmentation.dtype,
+        compressed=True,
+        largest_segment_id=int(segmentation.max()),
+    )
+    segmentation_layer.bounding_box = dataset.layers["color"].bounding_box
+    segmentation_layer.add_mag(mag, compress=True).write(segmentation)
 
-segmentation_layer = dataset.add_layer(
-    "segmentation",
-    "segmentation",
-    segmentation.dtype,
-    compressed=True,
-    largest_segment_id=int(segmentation.max()),
-)
-segmentation_layer.bounding_box = dataset.layers["color"].bounding_box
-segmentation_layer.add_mag(mag, compress=True).write(segmentation)
-
-with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
-    url = dataset.upload()
-print(f"Successfully uploaded {url}")
+    with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
+        url = dataset.upload()
+    print(f"Successfully uploaded {url}")

--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -7,11 +7,13 @@ from skimage.future import TrainableSegmenter
 
 import webknossos as wk
 
-if __name__ == "__main__":
+# pylint: disable=unsubscriptable-object
+
+
+def main() -> None:
     annotation = wk.open_annotation(
         "https://webknossos.org/annotations/Explorational/616457c2010000870032ced4"
     )
-    # pylint: disable=unsubscriptable-object
     training_data_bbox = wk.BoundingBox.from_tuple6(
         annotation.skeleton.user_bounding_boxes[0]
     )
@@ -64,3 +66,7 @@ if __name__ == "__main__":
     with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
         url = dataset.upload()
     print(f"Successfully uploaded {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/webknossos/examples/skeleton_synapse_candidates.py
+++ b/webknossos/examples/skeleton_synapse_candidates.py
@@ -30,7 +30,7 @@ def pairs_within_distance(
             yield (pos_a[i], pos_b[j])
 
 
-if __name__ == "__main__":
+def main() -> None:
     nml = wk.open_nml("testdata/nmls/nml_with_small_distance_nodes.nml")
 
     synapse_candidate_max_distance = 0.5  # in nm
@@ -56,3 +56,7 @@ if __name__ == "__main__":
 
     # nml can be used for further processing or written to a file:
     # nml.write("output_path.nml")
+
+
+if __name__ == "__main__":
+    main()

--- a/webknossos/examples/skeleton_synapse_candidates.py
+++ b/webknossos/examples/skeleton_synapse_candidates.py
@@ -30,28 +30,29 @@ def pairs_within_distance(
             yield (pos_a[i], pos_b[j])
 
 
-nml = wk.open_nml("testdata/nmls/nml_with_small_distance_nodes.nml")
+if __name__ == "__main__":
+    nml = wk.open_nml("testdata/nmls/nml_with_small_distance_nodes.nml")
 
-synapse_candidate_max_distance = 0.5  # in nm
+    synapse_candidate_max_distance = 0.5  # in nm
 
-input_graphs = list(nml.flattened_graphs())
-synapse_parent_group = nml.add_group("all synapse candidates")
+    input_graphs = list(nml.flattened_graphs())
+    synapse_parent_group = nml.add_group("all synapse candidates")
 
-for tree_a, tree_b in combinations(input_graphs, 2):
-    positions_a = tree_a.get_node_positions() * nml.scale
-    positions_b = tree_b.get_node_positions() * nml.scale
+    for tree_a, tree_b in combinations(input_graphs, 2):
+        positions_a = tree_a.get_node_positions() * nml.scale
+        positions_b = tree_b.get_node_positions() * nml.scale
 
-    synapse_graph = synapse_parent_group.add_graph(
-        f"synapse candidates ({tree_a.name}-{tree_b.name})"
-    )
-
-    for partner_a, partner_b in pairs_within_distance(
-        positions_a, positions_b, synapse_candidate_max_distance
-    ):
-        synapse_graph.add_node(
-            position=(partner_a + partner_b) / nml.scale / 2,
-            comment=f"{tree_a.name} ({tree_a.id}) <-> {tree_b.name} ({tree_b.id})",
+        synapse_graph = synapse_parent_group.add_graph(
+            f"synapse candidates ({tree_a.name}-{tree_b.name})"
         )
 
-# nml can be used for further processing or written to a file:
-# nml.write("output_path.nml")
+        for partner_a, partner_b in pairs_within_distance(
+            positions_a, positions_b, synapse_candidate_max_distance
+        ):
+            synapse_graph.add_node(
+                position=(partner_a + partner_b) / nml.scale / 2,
+                comment=f"{tree_a.name} ({tree_a.id}) <-> {tree_b.name} ({tree_b.id})",
+            )
+
+    # nml can be used for further processing or written to a file:
+    # nml.write("output_path.nml")

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -4,7 +4,8 @@ from skimage import data
 
 import webknossos as wk
 
-if __name__ == "__main__":
+
+def main() -> None:
     with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
         img = data.cell()
         time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
@@ -20,3 +21,7 @@ if __name__ == "__main__":
         layer.add_mag(1, compress=True).write(img.T[None, :, :, None])
         url = ds.upload()
         print(f"Successfully uploaded {url}")
+
+
+if __name__ == "__main__":
+    main()

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -4,18 +4,19 @@ from skimage import data
 
 import webknossos as wk
 
-with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
-    img = data.cell()
-    time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
-    name = f"cell_{time_str}"
-    ds = wk.Dataset.create(name, scale=(107, 107, 107))
-    layer = ds.add_layer(
-        "color",
-        "color",
-        dtype_per_layer=img.dtype,
-    )
-    # add channel and z dimensions and put X before Y,
-    # resulting dimensions are C, X, Y, Z.
-    layer.add_mag(1, compress=True).write(img.T[None, :, :, None])
-    url = ds.upload()
-    print(f"Successfully uploaded {url}")
+if __name__ == "__main__":
+    with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
+        img = data.cell()
+        time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
+        name = f"cell_{time_str}"
+        ds = wk.Dataset.create(name, scale=(107, 107, 107))
+        layer = ds.add_layer(
+            "color",
+            "color",
+            dtype_per_layer=img.dtype,
+        )
+        # add channel and z dimensions and put X before Y,
+        # resulting dimensions are C, X, Y, Z.
+        layer.add_mag(1, compress=True).write(img.T[None, :, :, None])
+        url = ds.upload()
+        print(f"Successfully uploaded {url}")

--- a/webknossos/examples/user_times.py
+++ b/webknossos/examples/user_times.py
@@ -2,7 +2,8 @@ import pandas as pd
 
 import webknossos as wk
 
-if __name__ == "__main__":
+
+def main() -> None:
     df = pd.DataFrame()
     df.columns = pd.MultiIndex([[], []], [[], []], names=("year", "month"))
     df.index.name = "email"
@@ -22,3 +23,7 @@ if __name__ == "__main__":
 
     print(f"Logged User Times {year}:\n")
     print(df.loc[has_logged_times_in_year, year].to_markdown())
+
+
+if __name__ == "__main__":
+    main()

--- a/webknossos/examples/user_times.py
+++ b/webknossos/examples/user_times.py
@@ -2,22 +2,23 @@ import pandas as pd
 
 import webknossos as wk
 
-df = pd.DataFrame()
-df.columns = pd.MultiIndex([[], []], [[], []], names=("year", "month"))
-df.index.name = "email"
+if __name__ == "__main__":
+    df = pd.DataFrame()
+    df.columns = pd.MultiIndex([[], []], [[], []], names=("year", "month"))
+    df.index.name = "email"
 
-users = wk.User.get_all_managed_users()
-for user in users:
-    for logged_time in user.get_logged_times():
-        df.loc[
-            user.email, (logged_time.year, logged_time.month)
-        ] = logged_time.duration_in_seconds
+    users = wk.User.get_all_managed_users()
+    for user in users:
+        for logged_time in user.get_logged_times():
+            df.loc[
+                user.email, (logged_time.year, logged_time.month)
+            ] = logged_time.duration_in_seconds
 
-df = df.fillna(0).astype("uint")
-df = df.sort_index(axis="index").sort_index(axis="columns")
+    df = df.fillna(0).astype("uint")
+    df = df.sort_index(axis="index").sort_index(axis="columns")
 
-year = 2021
-has_logged_times_in_year = df.loc[:, year].sum(axis="columns") != 0
+    year = 2021
+    has_logged_times_in_year = df.loc[:, year].sum(axis="columns") != 0
 
-print(f"Logged User Times {year}:\n")
-print(df.loc[has_logged_times_in_year, year].to_markdown())
+    print(f"Logged User Times {year}:\n")
+    print(df.loc[has_logged_times_in_year, year].to_markdown())

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -10,7 +10,7 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
         fi
         pushd $WK_DOCKER_DIR > /dev/null
         mkdir -p binaryData
-        export DOCKER_TAG=21.09.0
+        export DOCKER_TAG=21.11.0
         docker-compose pull webknossos
         USER_UID=$(id -u) USER_GID=$(id -g) docker-compose up -d --no-build webknossos
         popd > /dev/null

--- a/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
@@ -15,9 +15,9 @@ interactions:
     method: GET
     uri: https://webknossos.org/api/annotations/Explorational/616457c2010000870032ced4/info
   response:
-    content: '{"modified":1634039566087,"state":"Active","id":"616457c2010000870032ced4","name":"Training
+    content: '{"modified":1634820108376,"state":"Active","id":"616457c2010000870032ced4","name":"Training
       Data Example for Skin Layers","description":"Example Annotation to reproduce
-      [the scikit-image example with a trainable segmenter](https://scikit-image.org/docs/0.18.x/auto_examples/segmentation/plot_trainable_segmentation.html#sphx-glr-auto-examples-segmentation-plot-trainable-segmentation-py).","typ":"Explorational","task":null,"stats":{"edgeCount":0,"nodeCount":0,"treeCount":0,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"32ced4","tracing":{"skeleton":"bd0e7b0b-0902-47df-a2de-91f8250c0189","volume":"65029191-14f6-49d1-a946-11496d249e1e"},"dataSetName":"skin","organization":"scalable_minds","dataStore":{"name":"webknossos.org","url":"https://webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"https://webknossos.org"},"visibility":"Internal","settings":{"allowedModes":["orthogonal","oblique","flight","volume"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":613508,"tags":["skin","hybrid"],"user":{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isAnonymous":false,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
+      [the scikit-image example with a trainable segmenter](https://scikit-image.org/docs/0.18.x/auto_examples/segmentation/plot_trainable_segmentation.html#sphx-glr-auto-examples-segmentation-plot-trainable-segmentation-py).","typ":"Explorational","task":null,"stats":{"edgeCount":0,"nodeCount":0,"treeCount":0,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"32ced4","tracing":{"skeleton":"bd0e7b0b-0902-47df-a2de-91f8250c0189","volume":"65029191-14f6-49d1-a946-11496d249e1e"},"dataSetName":"skin","organization":"scalable_minds","dataStore":{"name":"webknossos.org","url":"https://data-humerus.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"https://webknossos.org"},"visibility":"Public","settings":{"allowedModes":["orthogonal","oblique","flight","volume"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":875476,"tags":["skin","hybrid"],"user":{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isAnonymous":false,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
       minds","isTeamManager":false}]},"meshes":[]}'
     headers:
       Connection:
@@ -27,7 +27,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Oct 2021 17:15:33 GMT
+      - Wed, 01 Dec 2021 11:42:47 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:

--- a/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
@@ -15,9 +15,9 @@ interactions:
     method: GET
     uri: https://webknossos.org/api/buildinfo
   response:
-    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"7dbf24e409c306c462f0c12f4fdbb51e43884c09","ciBuild":"15807","scalaVersion":"2.12.12","version":"15807","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Tue
-      Oct 19 11:18:41 2021 +0200"},"webknossos-wrap":{"builtAtMillis":"1623317662808","name":"webknossos-wrap","commitHash":"1380fd8fa9b3fd8b71a684299883a6697f80b4c2","scalaVersion":"2.12.7","version":"1.1.11","sbtVersion":"1.4.1","builtAtString":"2021-06-10
-      09:34:22.808"},"schemaVersion":76,"token":"PZoxh7P3CVOphLWGg2PErw","localDataStoreEnabled":true,"localTracingStoreEnabled":true}'
+    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"102b4b0cd08e85481f3a29878037960632c6c617","ciBuild":"16135","scalaVersion":"2.12.12","version":"16135","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Tue
+      Nov 30 09:29:11 2021 +0100"},"webknossos-wrap":{"builtAtMillis":"1623317662808","name":"webknossos-wrap","commitHash":"1380fd8fa9b3fd8b71a684299883a6697f80b4c2","scalaVersion":"2.12.7","version":"1.1.11","sbtVersion":"1.4.1","builtAtString":"2021-06-10
+      09:34:22.808"},"schemaVersion":77,"token":"5grU4VXkDrEKXLLnHKu9dQ","localDataStoreEnabled":false,"localTracingStoreEnabled":true}'
     headers:
       Connection:
       - keep-alive
@@ -26,7 +26,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Oct 2021 17:15:33 GMT
+      - Wed, 01 Dec 2021 11:22:20 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:

--- a/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
@@ -15,14 +15,14 @@ interactions:
     method: GET
     uri: https://webknossos.org/api/datasets/scalable_minds/l4dense_motta_et_al_demo
   response:
-    content: '{"name":"l4dense_motta_et_al_demo","dataSource":{"id":{"name":"l4dense_motta_et_al_demo","team":"scalable_minds"},"dataLayers":[{"name":"color","category":"color","boundingBox":{"topLeft":[128,128,128],"width":5445,"height":8380,"depth":3285},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint8","adminViewConfiguration":{"intensityRange":[80,180]}},{"name":"predictions","category":"color","boundingBox":{"topLeft":[0,0,0],"width":5632,"height":8704,"depth":3584},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint24","adminViewConfiguration":{"isDisabled":true}},{"name":"segmentation","category":"segmentation","boundingBox":{"topLeft":[128,128,128],"width":5445,"height":8380,"depth":3285},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint32","largestSegmentId":2504697,"adminViewConfiguration":{}}],"scale":[11.239999771118164,11.239999771118164,28]},"dataStore":{"name":"webknossos.org","url":"https://webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"owningOrganization":"scalable_minds","allowedTeams":[],"isActive":true,"isPublic":true,"description":"Segmentation
+    content: '{"name":"l4dense_motta_et_al_demo","dataSource":{"id":{"name":"l4dense_motta_et_al_demo","team":"scalable_minds"},"dataLayers":[{"name":"color","category":"color","boundingBox":{"topLeft":[128,128,128],"width":5445,"height":8380,"depth":3285},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint8","adminViewConfiguration":{"intensityRange":[80,180]}},{"name":"predictions","category":"color","boundingBox":{"topLeft":[0,0,0],"width":5632,"height":8704,"depth":3584},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint24","adminViewConfiguration":{"isDisabled":true}},{"name":"segmentation","category":"segmentation","boundingBox":{"topLeft":[128,128,128],"width":5445,"height":8380,"depth":3285},"resolutions":[[1,1,1],[2,2,1],[4,4,2],[8,8,4],[16,16,8],[32,32,16],[64,64,32],[128,128,64],[256,256,128],[512,512,256],[1024,1024,512]],"elementClass":"uint32","largestSegmentId":2504697,"adminViewConfiguration":{}}],"scale":[11.239999771118164,11.239999771118164,28]},"dataStore":{"name":"webknossos.org","url":"https://data-humerus.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"owningOrganization":"scalable_minds","allowedTeams":[],"isActive":true,"isPublic":true,"description":"Segmentation
       created with [Voxelytics](https://scalableminds.com/voxelytics-connect) by [scalable
       minds](https://scalableminds.com).\n\n \n\nRaw SBEM data and segmentation ground
       truth by Max Planck Institute for Brain Research. As published in *Dense connectomic
       reconstruction in layer 4 of the somatosensory cortex* by A Motta, M Berning,
       KM Boergens, B Staffler, M Beining, S Loomba, P Hennig, H Wissler, M Helmstaedter
       in *Science* on 24 October 2019. [10.1126/science.aay3134](https://science.sciencemag.org/content/early/2019/10/23/science.aay3134)\n","displayName":"L4
-      Mouse Cortex Demo","created":1597232436055,"isEditable":true,"lastUsedByUser":1634663733624,"logoUrl":"https://static.webknossos.org/logos/scalableminds.svg","sortingKey":1597232436055,"details":null,"publication":null,"isUnreported":false,"isForeign":false,"jobsEnabled":true}'
+      Mouse Cortex Demo","created":1597232436055,"isEditable":true,"lastUsedByUser":1638357740352,"logoUrl":"https://static.webknossos.org/logos/scalableminds.svg","sortingKey":1597232436055,"details":null,"publication":null,"isUnreported":false,"isForeign":false,"jobsEnabled":true}'
     headers:
       Connection:
       - keep-alive
@@ -31,7 +31,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Oct 2021 17:15:33 GMT
+      - Wed, 01 Dec 2021 11:22:20 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:

--- a/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
@@ -15,7 +15,7 @@ interactions:
     method: GET
     uri: https://webknossos.org/api/datastores
   response:
-    content: '[{"name":"data3-brain","url":"https://data3-brain.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":false},{"name":"data5.connect","url":"https://data5.connect.demo.webknossos.org","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"demo-mhlab","url":"https://demo.data1-brain.esc.rzg.mpg.de","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":false},{"name":"webknossos.org","url":"https://webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
+    content: '[{"name":"data5.connect","url":"https://data5.connect.demo.webknossos.org","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"demo-mhlab","url":"https://demo.data1-brain.esc.rzg.mpg.de","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":false},{"name":"webknossos.org","url":"https://data-humerus.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
     headers:
       Connection:
       - keep-alive
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 19 Oct 2021 17:15:33 GMT
+      - Wed, 01 Dec 2021 11:22:19 GMT
       Referrer-Policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       Server:

--- a/webknossos/tests/conftest.py
+++ b/webknossos/tests/conftest.py
@@ -9,12 +9,15 @@ import pytest
 from vcr.request import Request as VcrRequest
 from vcr.stubs import httpx_stubs
 
+from webknossos.client.context import _clear_all_context_caches
+
 TESTOUTPUT_DIR = Path("testoutput")
 
 
 @pytest.fixture(autouse=True, scope="function")
 def run_around_tests() -> Generator:
     makedirs(TESTOUTPUT_DIR, exist_ok=True)
+    _clear_all_context_caches()
     yield
     rmtree(TESTOUTPUT_DIR)
 

--- a/webknossos/tests/test_generated_client.py
+++ b/webknossos/tests/test_generated_client.py
@@ -1,6 +1,5 @@
 import pytest
 
-from webknossos.client._defaults import DEFAULT_WEBKNOSSOS_URL
 from webknossos.client._generated.api.default import (
     annotation_info,
     build_info,
@@ -18,6 +17,8 @@ from webknossos.client._generated.models.datastore_list_response_200_item import
 )
 from webknossos.client.context import _get_generated_client
 from webknossos.utils import time_since_epoch_in_ms
+
+DATASTORE_URL = "https://data-humerus.webknossos.org"
 
 
 @pytest.fixture
@@ -49,7 +50,7 @@ def test_annotation_info(client: Client) -> None:
     assert info_object is not None
     assert info_object.id == id
     assert info_object.typ == typ
-    assert info_object.data_store.url == client.base_url
+    assert info_object.data_store.url == DATASTORE_URL
 
 
 @pytest.mark.vcr()
@@ -57,7 +58,7 @@ def test_datastore_list(auth_client: Client) -> None:
     datastores = datastore_list.sync(client=auth_client)
     internal_datastore = DatastoreListResponse200Item(
         name="webknossos.org",
-        url=DEFAULT_WEBKNOSSOS_URL,
+        url=DATASTORE_URL,
         is_foreign=False,
         is_scratch=False,
         is_connector=False,
@@ -104,7 +105,7 @@ def test_dataset_info(client: Client) -> None:
         client=client,
     )
     assert response is not None
-    assert response.data_store.url == client.base_url
+    assert response.data_store.url == DATASTORE_URL
     assert response.display_name == "L4 Mouse Cortex Demo"
     assert sorted(
         (layer.name, layer.category, layer.element_class)
@@ -124,5 +125,5 @@ def test_build_info(client: Client) -> None:
     assert response is not None
     assert response.webknossos.name == "webknossos"
     assert response.webknossos_wrap.name == "webknossos-wrap"
-    assert response.local_data_store_enabled
+    assert not response.local_data_store_enabled
     assert response.local_tracing_store_enabled

--- a/webknossos/webknossos/client/_download_annotation.py
+++ b/webknossos/webknossos/client/_download_annotation.py
@@ -19,5 +19,5 @@ def download_annotation(
     ), f"Currently compund annotation types are not supported, got {type}"
     client = _get_generated_client()
     response = annotation_download.sync_detailed(typ=type.value, id=id, client=client)
-    assert response.status_code == 200
+    assert response.status_code == 200, response
     return Annotation(BytesIO(response.content))

--- a/webknossos/webknossos/client/_upload_dataset.py
+++ b/webknossos/webknossos/client/_upload_dataset.py
@@ -48,6 +48,7 @@ def upload_dataset(dataset: Dataset) -> str:
                 generate_unique_identifier=lambda path: f"{upload_id}/{path.name}",
                 test_chunks=False,
                 permanent_errors=[400, 403, 404, 409, 415, 500, 501],
+                client=httpx.Client(timeout=None),
             ) as session:
                 file = session.add_file(zip_path)
                 progress_task = progress.add_task(

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -111,6 +111,13 @@ def _cached__get_generated_client(
         )
 
 
+def _clear_all_context_caches() -> None:
+    _cached_ask_for_token.cache_clear()
+    _cached_get_org.cache_clear()
+    _cached_get_datastore_token.cache_clear()
+    _cached__get_generated_client.cache_clear()
+
+
 @attr.frozen
 class _WebknossosContext:
     url: str = os.environ.get("WK_URL", default=DEFAULT_WEBKNOSSOS_URL)

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -104,11 +104,10 @@ def _cached__get_generated_client(
 ) -> GeneratedClient:
     """Generates a client which might contain an x-auth-token header."""
     if token is None:
-        return GeneratedClient(base_url=webknossos_url)
+        return GeneratedClient(base_url=webknossos_url, timeout=30)
     else:
         return GeneratedClient(
-            base_url=webknossos_url,
-            headers={"X-Auth-Token": token},
+            base_url=webknossos_url, headers={"X-Auth-Token": token}, timeout=30
         )
 
 
@@ -141,6 +140,23 @@ class _WebknossosContext:
     @property
     def generated_auth_client(self) -> GeneratedClient:
         return _cached__get_generated_client(self.url, self.required_token)
+
+    def get_generated_datastore_client(
+        self, datastore_url: str, enforce_auth: bool = False
+    ) -> GeneratedClient:
+        if enforce_auth:
+            token: Optional[str] = self.required_token
+        else:
+            token = self.token
+
+        if token is None:
+            return GeneratedClient(base_url=datastore_url, timeout=120)
+        else:
+            return GeneratedClient(
+                base_url=datastore_url,
+                headers={"X-Auth-Token": token},
+                timeout=120,
+            )
 
 
 _webknossos_context_var: ContextVar[_WebknossosContext] = ContextVar(

--- a/webknossos/webknossos/client/download_dataset.py
+++ b/webknossos/webknossos/client/download_dataset.py
@@ -8,7 +8,7 @@ from rich.progress import track
 
 from webknossos.client._generated.api.datastore import dataset_download
 from webknossos.client._generated.api.default import dataset_info
-from webknossos.client.context import _get_generated_client
+from webknossos.client.context import _get_context, _get_generated_client
 from webknossos.dataset import Dataset, LayerCategoryType
 from webknossos.geometry import BoundingBox, Mag
 
@@ -35,9 +35,13 @@ def download_dataset(
         data_set_name=dataset_name,
         client=client,
     )
-    assert dataset_info_response.status_code == 200
+    assert dataset_info_response.status_code == 200, dataset_info_response
     parsed = dataset_info_response.parsed
     assert parsed is not None
+
+    datastore_client = _get_context().get_generated_datastore_client(
+        parsed.data_store.url
+    )
 
     actual_path = Path(dataset_name) if path is None else Path(path)
     if actual_path.exists():
@@ -84,7 +88,7 @@ def download_dataset(
             aligned_bbox = layer.bounding_box.align_with_mag(mag, ceil=True)
             for chunk in track(
                 list(aligned_bbox.chunk(_DOWNLOAD_CHUNK_SIZE, _DOWNLOAD_CHUNK_SIZE)),
-                description=f"Downloading {layer.name} layer",
+                description=f"Downloading layer={layer.name} mag={mag}",
             ):
                 aligned_chunk_in_mag = chunk.in_mag(mag)
                 response = dataset_download.sync_detailed(
@@ -92,7 +96,7 @@ def download_dataset(
                     data_set_name=dataset_name,
                     data_layer_name=layer_name,
                     resolution=mag.max_dim_log2,
-                    client=client,
+                    client=datastore_client,
                     x=aligned_chunk_in_mag.topleft.x,
                     y=aligned_chunk_in_mag.topleft.y,
                     z=aligned_chunk_in_mag.topleft.z,
@@ -100,7 +104,7 @@ def download_dataset(
                     height=aligned_chunk_in_mag.size.y,
                     depth=aligned_chunk_in_mag.size.z,
                 )
-                assert response.status_code == 200
+                assert response.status_code == 200, response
                 data = np.frombuffer(
                     response.content, dtype=layer.dtype_per_channel
                 ).reshape(layer.num_channels, *aligned_chunk_in_mag.size, order="F")


### PR DESCRIPTION
### Description:
- Downloads from remote datastores are possible now, but auth via a token is still missing, this is blocked by scalableminds/webknossos#5875 (I'll do this afterwards in a separate PR)
- The snapshot tests are refreshed and fixed
- Timeouts are much longer (default was 5s previously), which was necessary especially for uploads
- All examples use the `if __name__ == "__main__"` pattern and can still be executed in the tests

### Issues:
- fixes #487

### Todos:
 - [ ] Updated Changelog
