### PR TITLE
Fix and adapt changelog to newest releases

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,7 +15,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Changed
 
-## [v0.8.24](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.25) - 2021-12-07
+## [v0.8.25](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.25) - 2021-12-07
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.24...v0.8.25)
 
 ### Added

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -7,9 +7,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.23...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.25...HEAD)
 
 ### Breaking Changes
+
+### Added
+
+### Changed
+
+## [v0.8.24](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.25) - 2021-12-07
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.24...v0.8.25)
 
 ### Added
 - Added support to download datasets from external datastores, which is the case for webknossos.org.  [#497](https://github.com/scalableminds/webknossos-libs/pull/497)
@@ -17,8 +24,13 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 - Adapt the dataset upload to new webKnossos api. [#484](https://github.com/scalableminds/webknossos-libs/pull/484)
 - `get_segmentation_layer()` and `get_color_layer()` were deprecated and should not be used, anymore, as they will fail if no or more than one layer exists for each category. Instead, `get_segmentation_layers()` and `get_color_layers()` should be used (if desired in combination with `[0]` to get the old, error-prone behavior).
+- Renamed the folder webknossos/script-collection to webknossos/script_collection to enable module imports. [#505](https://github.com/scalableminds/webknossos-libs/pull/505)
+
+## [v0.8.24](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.24) - 2021-11-30
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.23...v0.8.24)
 
 ### Fixed
+- Fixed `--version` CLI argument. [#493](https://github.com/scalableminds/webknossos-libs/pull/493)
 
 
 ## [v0.8.23](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.23) - 2021-11-29
@@ -34,7 +46,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Changed
 - Improved performance for calculations with `Vec3Int` and `BoundingBox`. [#461](https://github.com/scalableminds/webknossos-libs/pull/461)
-- Renamed the folder webknossos/script-collection to webknossos/script_collection to enable module imports. [#505](https://github.com/scalableminds/webknossos-libs/pull/505)
 
 ### Fixed
 - Resolve path when symlinking layer and make_relative is False (instead of only making it absolute). [#492](https://github.com/scalableminds/webknossos-libs/pull/492)


### PR DESCRIPTION
Adapts the changelog for v0.8.24 and v0.8.25.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [X] Updated Changelog
