### PR TITLE
Restore cubing main method which takes namespace args 

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -29,9 +29,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ## [v0.8.24](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.24) - 2021-11-30
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.23...v0.8.24)
 
-### Fixed
-- Fixed `--version` CLI argument. [#493](https://github.com/scalableminds/webknossos-libs/pull/493)
-
 
 ## [v0.8.23](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.23) - 2021-11-29
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.22...v0.8.23)

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -12,13 +12,25 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes in Config & CLI
 
 ### Added
-- `wkcuber.convert_raw` conversion tool for raw binary data files. [#498](https://github.com/scalableminds/webknossos-libs/pull/498)
-- Added the `wkcuber` executable that is installed when the package is installed. [#495](https://github.com/scalableminds/webknossos-libs/pull/495)
+- Added importable `cube_with_args` function to main module of wkcuber. [#507](https://github.com/scalableminds/webknossos-libs/pull/507)
 
 ### Changed
 
 ### Fixed
 
+
+## [v0.8.25](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.25) - 2021-12-07
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.24...v0.8.25)
+
+### Added
+- `wkcuber.convert_raw` conversion tool for raw binary data files. [#498](https://github.com/scalableminds/webknossos-libs/pull/498)
+- Added the `wkcuber` executable that is installed when the package is installed. [#495](https://github.com/scalableminds/webknossos-libs/pull/495)
+
+## [v0.8.24](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.24) - 2021-11-30
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.23...v0.8.24)
+
+### Fixed
+- Fixed `--version` CLI argument. [#493](https://github.com/scalableminds/webknossos-libs/pull/493)
 
 ## [v0.8.23](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.8.23) - 2021-11-29
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.8.18...v0.8.23)

--- a/wkcuber/wkcuber/__main__.py
+++ b/wkcuber/wkcuber/__main__.py
@@ -15,7 +15,7 @@ from .converter import (
     main as auto_detect_and_run_conversion,
 )
 from .versioning import get_available_version
-from argparse import ArgumentParser
+from argparse import Namespace, ArgumentParser
 from pathlib import Path
 
 
@@ -71,10 +71,7 @@ def create_parser() -> ArgumentParser:
     return parser
 
 
-def main() -> None:
-    args = create_parser().parse_args()
-    setup_logging(args)
-
+def cube_with_args(args: Namespace) -> None:
     if args.isotropic is not None:
         raise DeprecationWarning(
             "The flag 'isotropic' is deprecated. Consider using '--sampling_mode isotropic' instead."
@@ -105,6 +102,12 @@ def main() -> None:
         )
 
     refresh_metadata(args.target_path)
+
+
+def main() -> None:
+    args = create_parser().parse_args()
+    setup_logging(args)
+    cube_with_args(args)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Description:
- [#495](https://github.com/scalableminds/webknossos-libs/pull/495) adapted the main-method so that no parameters are necessary so that `wkcuber` can be an executable. However, vx imports the `main` method and passes args which is why this was a breaking change. To fulfill both requirements I added a new `cube_with_args` function. In the long run, `typer` would probably help a great deal with this.

### Issues:
- follow-up for #495

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
