### PR TITLE
Adapt to change in wk upload api (layersToLink)

### DIFF
--- a/webknossos/webknossos/client/_upload_dataset.py
+++ b/webknossos/webknossos/client/_upload_dataset.py
@@ -46,6 +46,7 @@ def upload_dataset(dataset: Dataset) -> str:
                         "name": dataset.name,
                         "totalFileCount": 1,
                         "initialTeams": [],
+                        "layersToLink": [],
                     },
                     timeout=60,
                 ).raise_for_status()
@@ -84,6 +85,7 @@ def upload_dataset(dataset: Dataset) -> str:
                     "organization": context.organization,
                     "name": dataset.name,
                     "needsConversion": False,
+                    "layersToLink": [],
                 },
                 timeout=None,
             ).raise_for_status()


### PR DESCRIPTION
### Description:
- wk’s upload api changes in https://github.com/scalableminds/webknossos/pull/5863
- This PR adds the layersToLink field to upload requests, for now as empty list.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
