### PR TITLE
update generated client & use for dataset upload

### DIFF
--- a/webknossos/__generate_client.py
+++ b/webknossos/__generate_client.py
@@ -172,6 +172,16 @@ def set_response_schema_by_example(
     request_schema["responses"]["200"]["content"] = recorded_response_schema
 
 
+def fix_request_body(openapi_schema: Dict) -> None:
+    assert_valid_schema(openapi_schema)
+    for path_val in openapi_schema["paths"].values():
+        for method_val in path_val.values():
+            if "requestBody" in method_val:
+                method_val["requestBody"]["content"] = {
+                    "application/json": {"schema": {"type": "object"}}
+                }
+
+
 def bootstrap_response_schemas(openapi_schema: Dict) -> None:
     """Inserts the response schemas into openapi_schema (in-place),
     as recorded by example requests."""
@@ -188,5 +198,6 @@ if __name__ == "__main__":
     schema = json.loads(response.text)
     add_api_prefix_for_non_data_paths(schema)
     generate_client(schema)
+    fix_request_body(schema)
     bootstrap_response_schemas(schema)
     generate_client(schema)

--- a/webknossos/webknossos/client/_generated/api/datastore/dataset_download.py
+++ b/webknossos/webknossos/client/_generated/api/datastore/dataset_download.py
@@ -12,6 +12,7 @@ def _get_kwargs(
     data_layer_name: str,
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
     x: int,
     y: int,
     z: int,
@@ -32,6 +33,7 @@ def _get_kwargs(
     cookies: Dict[str, Any] = client.get_cookies()
 
     params: Dict[str, Any] = {
+        "token": token,
         "x": x,
         "y": y,
         "z": z,
@@ -67,6 +69,7 @@ def sync_detailed(
     data_layer_name: str,
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
     x: int,
     y: int,
     z: int,
@@ -81,6 +84,7 @@ def sync_detailed(
         data_set_name=data_set_name,
         data_layer_name=data_layer_name,
         client=client,
+        token=token,
         x=x,
         y=y,
         z=z,
@@ -104,6 +108,7 @@ async def asyncio_detailed(
     data_layer_name: str,
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
     x: int,
     y: int,
     z: int,
@@ -118,6 +123,7 @@ async def asyncio_detailed(
         data_set_name=data_set_name,
         data_layer_name=data_layer_name,
         client=client,
+        token=token,
         x=x,
         y=y,
         z=z,

--- a/webknossos/webknossos/client/_generated/api/datastore/dataset_finish_upload.py
+++ b/webknossos/webknossos/client/_generated/api/datastore/dataset_finish_upload.py
@@ -1,25 +1,37 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...models.dataset_finish_upload_json_body import DatasetFinishUploadJsonBody
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     client: Client,
+    json_body: DatasetFinishUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/data/datasets/finishUpload".format(client.base_url)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
 
+    params: Dict[str, Any] = {
+        "token": token,
+    }
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    json_json_body = json_body.to_dict()
+
     return {
         "url": url,
         "headers": headers,
         "cookies": cookies,
         "timeout": client.get_timeout(),
+        "json": json_json_body,
+        "params": params,
     }
 
 
@@ -35,9 +47,13 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
 def sync_detailed(
     *,
     client: Client,
+    json_body: DatasetFinishUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        json_body=json_body,
+        token=token,
     )
 
     response = httpx.post(
@@ -50,9 +66,13 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: Client,
+    json_body: DatasetFinishUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        json_body=json_body,
+        token=token,
     )
 
     async with httpx.AsyncClient() as _client:

--- a/webknossos/webknossos/client/_generated/api/datastore/dataset_reserve_upload.py
+++ b/webknossos/webknossos/client/_generated/api/datastore/dataset_reserve_upload.py
@@ -1,25 +1,37 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...models.dataset_reserve_upload_json_body import DatasetReserveUploadJsonBody
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     client: Client,
+    json_body: DatasetReserveUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/data/datasets/reserveUpload".format(client.base_url)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
 
+    params: Dict[str, Any] = {
+        "token": token,
+    }
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
+    json_json_body = json_body.to_dict()
+
     return {
         "url": url,
         "headers": headers,
         "cookies": cookies,
         "timeout": client.get_timeout(),
+        "json": json_json_body,
+        "params": params,
     }
 
 
@@ -35,9 +47,13 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
 def sync_detailed(
     *,
     client: Client,
+    json_body: DatasetReserveUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        json_body=json_body,
+        token=token,
     )
 
     response = httpx.post(
@@ -50,9 +66,13 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: Client,
+    json_body: DatasetReserveUploadJsonBody,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        json_body=json_body,
+        token=token,
     )
 
     async with httpx.AsyncClient() as _client:

--- a/webknossos/webknossos/client/_generated/api/datastore/dataset_upload_chunk.py
+++ b/webknossos/webknossos/client/_generated/api/datastore/dataset_upload_chunk.py
@@ -1,25 +1,32 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 import httpx
 
 from ...client import Client
-from ...types import Response
+from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Dict[str, Any]:
     url = "{}/data/datasets".format(client.base_url)
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
 
+    params: Dict[str, Any] = {
+        "token": token,
+    }
+    params = {k: v for k, v in params.items() if v is not UNSET and v is not None}
+
     return {
         "url": url,
         "headers": headers,
         "cookies": cookies,
         "timeout": client.get_timeout(),
+        "params": params,
     }
 
 
@@ -35,9 +42,11 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
 def sync_detailed(
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        token=token,
     )
 
     response = httpx.post(
@@ -50,9 +59,11 @@ def sync_detailed(
 async def asyncio_detailed(
     *,
     client: Client,
+    token: Union[Unset, None, str] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
         client=client,
+        token=token,
     )
 
     async with httpx.AsyncClient() as _client:

--- a/webknossos/webknossos/client/_generated/models/__init__.py
+++ b/webknossos/webknossos/client/_generated/models/__init__.py
@@ -40,6 +40,7 @@ from .current_user_info_response_200_novel_user_experience_infos import (
 from .current_user_info_response_200_teams_item import (
     CurrentUserInfoResponse200TeamsItem,
 )
+from .dataset_finish_upload_json_body import DatasetFinishUploadJsonBody
 from .dataset_info_response_200 import DatasetInfoResponse200
 from .dataset_info_response_200_data_source import DatasetInfoResponse200DataSource
 from .dataset_info_response_200_data_source_data_layers_item import (
@@ -53,6 +54,7 @@ from .dataset_info_response_200_data_source_data_layers_item_bounding_box import
 )
 from .dataset_info_response_200_data_source_id import DatasetInfoResponse200DataSourceId
 from .dataset_info_response_200_data_store import DatasetInfoResponse200DataStore
+from .dataset_reserve_upload_json_body import DatasetReserveUploadJsonBody
 from .datastore_list_response_200_item import DatastoreListResponse200Item
 from .generate_token_for_data_store_response_200 import (
     GenerateTokenForDataStoreResponse200,

--- a/webknossos/webknossos/client/_generated/models/dataset_finish_upload_json_body.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_finish_upload_json_body.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="DatasetFinishUploadJsonBody")
+
+
+@attr.s(auto_attribs=True)
+class DatasetFinishUploadJsonBody:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        dataset_finish_upload_json_body = cls()
+
+        dataset_finish_upload_json_body.additional_properties = d
+        return dataset_finish_upload_json_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/webknossos/webknossos/client/_generated/models/dataset_reserve_upload_json_body.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_reserve_upload_json_body.py
@@ -1,0 +1,44 @@
+from typing import Any, Dict, List, Type, TypeVar
+
+import attr
+
+T = TypeVar("T", bound="DatasetReserveUploadJsonBody")
+
+
+@attr.s(auto_attribs=True)
+class DatasetReserveUploadJsonBody:
+    """ """
+
+    additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+
+        field_dict: Dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({})
+
+        return field_dict
+
+    @classmethod
+    def from_dict(cls: Type[T], src_dict: Dict[str, Any]) -> T:
+        d = src_dict.copy()
+        dataset_reserve_upload_json_body = cls()
+
+        dataset_reserve_upload_json_body.additional_properties = d
+        return dataset_reserve_upload_json_body
+
+    @property
+    def additional_keys(self) -> List[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/webknossos/webknossos/client/download_dataset.py
+++ b/webknossos/webknossos/client/download_dataset.py
@@ -40,7 +40,7 @@ def download_dataset(
     assert parsed is not None
 
     datastore_client = _get_context().get_generated_datastore_client(
-        parsed.data_store.url
+        parsed.data_store.url, enforce_auth=True
     )
 
     actual_path = Path(dataset_name) if path is None else Path(path)

--- a/webknossos/webknossos/client/download_dataset.py
+++ b/webknossos/webknossos/client/download_dataset.py
@@ -40,7 +40,7 @@ def download_dataset(
     assert parsed is not None
 
     datastore_client = _get_context().get_generated_datastore_client(
-        parsed.data_store.url, enforce_auth=True
+        parsed.data_store.url
     )
 
     actual_path = Path(dataset_name) if path is None else Path(path)


### PR DESCRIPTION
### Description:
- updates the generated client to the newest wk API, including swagger documentation for the token and json body for dataset upload reserve & finish. The json body annotations needed some manual corrections, which are automated in `__generate_client.py`
- uses the generated client during dataset upload for reserve & finish

