### PR TITLE
Annotation: read correct volume-data-zip from nml

### DIFF
--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -70,7 +70,6 @@ class Annotation:
         self, dataset: Dataset, layer_name: str = "volume_annotation"
     ) -> Layer:
         # todo pylint: disable=fixme
-        # the name is about to change with multiple volume annotations
         assert self._nml.volume is not None
         volume_zip_path = self._nml.volume.location
         assert volume_zip_path in self._filelist


### PR DESCRIPTION
### Description:
- Uses the volume.location info from the annotation's nml to find the correct volume data zipfile.

### Todos:
 - [ ] Updated Changelog
