### PR TITLE
compute the largestSegmentId only from available bboxes

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -27,6 +27,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Changed
 - Always use the sampling mode `CONSTANT_Z` when downsampling 2D data. [#516](https://github.com/scalableminds/webknossos-libs/pull/516)
+- Make computation of `largestSegmentId` more efficient for volume annotations. [#531](https://github.com/scalableminds/webknossos-libs/pull/531)
 
 ### Fixed
 

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -11,6 +11,7 @@ from boltons.cacheutils import cachedproperty
 
 import webknossos.skeleton.nml as wknml
 from webknossos.dataset import Dataset, Layer, SegmentationLayer
+from webknossos.geometry import Vec3Int
 from webknossos.skeleton import Skeleton
 
 MAG_RE = r"((\d+-\d+-)?\d+)"
@@ -91,10 +92,15 @@ class Annotation:
             ),
         )
         min_mag_view = layer.mags[min(layer.mags)]
-        # todo pylint: disable=fixme
-        # this tries to read the entire DS into memory (beginning from 0, 0, 0).
-        # if the annotation begins at some other point, this will blow up the RAM unnecessarily.
-        layer.largest_segment_id = int(min_mag_view.read().max())
+        max_value = max(
+            [
+                min_mag_view.read(
+                    Vec3Int(offset) - min_mag_view.global_offset, size
+                ).max()
+                for offset, size in min_mag_view.get_bounding_boxes_on_disk()
+            ]
+        )
+        layer.largest_segment_id = int(max_value)
         return layer
 
     @classmethod

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -93,12 +93,10 @@ class Annotation:
         )
         min_mag_view = layer.mags[min(layer.mags)]
         max_value = max(
-            [
-                min_mag_view.read(
-                    Vec3Int(offset) - min_mag_view.global_offset, size
-                ).max()
-                for offset, size in min_mag_view.get_bounding_boxes_on_disk()
-            ]
+            min_mag_view.read(
+                Vec3Int(offset) - min_mag_view.global_offset, size
+            ).max()
+            for offset, size in min_mag_view.get_bounding_boxes_on_disk()
         )
         layer.largest_segment_id = int(max_value)
         return layer

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -93,9 +93,7 @@ class Annotation:
         )
         min_mag_view = layer.mags[min(layer.mags)]
         max_value = max(
-            min_mag_view.read(
-                Vec3Int(offset) - min_mag_view.global_offset, size
-            ).max()
+            min_mag_view.read(Vec3Int(offset) - min_mag_view.global_offset, size).max()
             for offset, size in min_mag_view.get_bounding_boxes_on_disk()
         )
         layer.largest_segment_id = int(max_value)


### PR DESCRIPTION
### Description:
- Only computes the `largestSegmentId` from available bboxes in a volume annotation


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
