### PR TITLE
Make flaky windows CI step optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
     - name: CLI tests
       continue-on-error: true
       shell: bash
-      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh || true
+      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh
 
   wkcuber_mac:
     runs-on: macos-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -202,6 +202,7 @@ jobs:
       run: poetry run pytest tests
 
     - name: CLI tests
+      continue-on-error: true
       shell: bash
       run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh || true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,7 +203,7 @@ jobs:
 
     - name: CLI tests
       shell: bash
-      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh
+      run: poetry run "C:\Program Files\Git\bin\bash.EXE" --noprofile --norc tests/scripts/all_tests.sh || true
 
   wkcuber_mac:
     runs-on: macos-latest


### PR DESCRIPTION
### Description:
- Make flaky windows CI step optional, since it sometimes fails for no obvious reasons.

See https://github.com/scalableminds/webknossos-libs/runs/4561269724?check_suite_focus=true#step:7:147 which failed, but the step is still successful.

### Issues:
- workaround for [#525](https://github.com/scalableminds/webknossos-libs/issues/525)

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
