### PR TITLE
Consistently use resolved instead of absolute path

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -30,6 +30,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 - The detailed output of e.g. downsampling was replaced with a progress bar. [#527](https://github.com/scalableminds/webknossos-libs/pull/527)
 - Always use the sampling mode `CONSTANT_Z` when downsampling 2D data. [#516](https://github.com/scalableminds/webknossos-libs/pull/516)
 - Make computation of `largestSegmentId` more efficient for volume annotations. [#531](https://github.com/scalableminds/webknossos-libs/pull/531)
+- Consistently use resolved instead of absolute path if make_relative is False. [#536](https://github.com/scalableminds/webknossos-libs/pull/536)
 
 ### Fixed
 

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -414,7 +414,7 @@ class Layer:
         foreign_normalized_mag_path = (
             Path(os.path.relpath(foreign_mag_view.path, self.path))
             if make_relative
-            else Path(os.path.abspath(foreign_mag_view.path))
+            else foreign_mag_view.path.resolve()
         )
 
         if symlink:

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -136,7 +136,7 @@ def copy_directory_with_symlinks(
             if make_relative:
                 rel_or_abspath = os.path.relpath(item, symlink_path.parent)
             else:
-                rel_or_abspath = os.path.abspath(item)
+                rel_or_abspath = item.resolve()
             symlink_path.symlink_to(rel_or_abspath)
 
 

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -134,7 +134,7 @@ def copy_directory_with_symlinks(
         if item.name not in ignore:
             symlink_path = dst_path / item.name
             if make_relative:
-                rel_or_abspath = os.path.relpath(item, symlink_path.parent)
+                rel_or_abspath = Path(os.path.relpath(item, symlink_path.parent))
             else:
                 rel_or_abspath = item.resolve()
             symlink_path.symlink_to(rel_or_abspath)


### PR DESCRIPTION
### Description:
- Consistently use pathlib.path.resolve instead of os.path.abspath to avoid issues like https://github.com/scalableminds/voxelytics/pull/2851
- We have started to do that in https://github.com/scalableminds/webknossos-libs/pull/492 but overlooked these last two occurrences
- I checked that there are no other occurrences of abspath in the code base

- [x] Test downsampling to check whether this works correctly now
  - See results in https://github.com/scalableminds/voxelytics/pull/2853

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
