### PR TITLE
adapt to new wk sample user token

### DIFF
--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -75,7 +75,7 @@ def main() -> None:
     segmentation_layer.add_mag(mag, compress=True).write(segmentation)
 
     # Get your auth token from https://webknossos.org/auth/token
-    with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
+    with wk.webknossos_context(url="http://localhost:9000", token="secretSampleUserToken"):
         url = dataset.upload()
     print(f"Successfully uploaded {url}")
 

--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -75,7 +75,9 @@ def main() -> None:
     segmentation_layer.add_mag(mag, compress=True).write(segmentation)
 
     # Get your auth token from https://webknossos.org/auth/token
-    with wk.webknossos_context(url="http://localhost:9000", token="secretSampleUserToken"):
+    with wk.webknossos_context(
+        url="http://localhost:9000", token="secretSampleUserToken"
+    ):
         url = dataset.upload()
     print(f"Successfully uploaded {url}")
 

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -8,7 +8,7 @@ from webknossos.dataset import COLOR_CATEGORY
 
 
 def main() -> None:
-    with wk.webknossos_context(url="http://localhost:9000", token="secretScmBoyToken"):
+    with wk.webknossos_context(url="http://localhost:9000", token="secretSampleUserToken"):
         # load your data - we use an example 3D dataset here
         img = data.cells3d()  # (z, c, y, x)
 

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -8,7 +8,9 @@ from webknossos.dataset import COLOR_CATEGORY
 
 
 def main() -> None:
-    with wk.webknossos_context(url="http://localhost:9000", token="secretSampleUserToken"):
+    with wk.webknossos_context(
+        url="http://localhost:9000", token="secretSampleUserToken"
+    ):
         # load your data - we use an example 3D dataset here
         img = data.cells3d()  # (z, c, y, x)
 

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -10,7 +10,7 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
         pushd $WK_DOCKER_DIR > /dev/null
         sed -i -e 's/webKnossos.sampleOrganization.enabled=false/webKnossos.sampleOrganization.enabled=true/g' docker-compose.yml
         mkdir -p binaryData
-        export DOCKER_TAG=master__16177
+        export DOCKER_TAG=master__16396
         docker-compose pull webknossos
         # TODO: either remove pg/db before starting or run tools/postgres/apply_evolutions.sh
         USER_UID=$(id -u) USER_GID=$(id -g) docker-compose up -d --no-build webknossos


### PR DESCRIPTION
The wk sample user token was changed in https://github.com/scalableminds/webknossos/pull/5931 – the examples need to be adapted here.

Do you know if the test cassettes need to be updated as well?