### PR TITLE
Allow to configure MaxArraySize and MaxSubmitJobs via env variables

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes
 
 ### Added
+- Allow to configure the MaxArraySize and MaxSubmitJobs slurm limits via the `SLURM_MAX_ARRAY_SIZE` and `SLURM_MAX_SUBMIT_JOBS` environment variables. If the environment variables are not specified, the limits are determined automatically. [#554](https://github.com/scalableminds/webknossos-libs/pull/554)
 
 ### Changed
 

--- a/cluster_tools/README.md
+++ b/cluster_tools/README.md
@@ -20,6 +20,15 @@ if __name__ == '__main__':
     assert result == [4, 9, 16]
 ```
 
+## Configuration
+
+### Slurm
+
+The cluster_tools automatically determine the slurm limit for maximum array job size and split up larger job batches into multiple smaller batches.
+Also, the slurm limit for the maximum number of jobs which are allowed to be submitted by a user at the same time is honored by looking up the number of currently submitted jobs and only submitting new batches if they fit within the limit.
+
+If you would like to configure these limits independently, you can do so by setting the `SLURM_MAX_ARRAY_SIZE` and `SLURM_MAX_SUBMIT_JOBS` environment variables.
+
 ## Dev Setup
 
 ```

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -205,10 +205,8 @@ class SlurmExecutor(ClusterExecutor):
 
         max_array_size = self.get_max_array_size()
         max_submit_jobs = self.get_max_submit_jobs()
-        # Only ever submit at most a third of max_submit_jobs at once (but at least one).
-        # This way, multiple programs submitting slurm jobs will not block each other
-        # by "occupying" more than half of the number of submittable jobs.
-        batch_size = max(min(max_array_size, max_submit_jobs // 3), 1)
+        # Only ever submit at most max_submit_jobs and max_array_size jobs at once (but at least one).
+        batch_size = max(min(max_array_size, max_submit_jobs), 1)
 
         scripts = []
         job_id_futures = []

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -87,10 +87,10 @@ class SlurmExecutor(ClusterExecutor):
     @staticmethod
     @cache_in_production
     def get_max_array_size():
-        max_array_size_env = os.environ.get("MAX_ARRAY_SIZE", None)
+        max_array_size_env = os.environ.get("SLURM_MAX_ARRAY_SIZE", None)
         if max_array_size_env is not None:
             logging.debug(
-                f"MAX_ARRAY_SIZE env variable specified which is {max_array_size_env}."
+                f"SLURM_MAX_ARRAY_SIZE env variable specified which is {max_array_size_env}."
             )
             return int(max_array_size_env)
 
@@ -111,10 +111,10 @@ class SlurmExecutor(ClusterExecutor):
     @staticmethod
     @cache_in_production
     def get_max_submit_jobs():
-        max_submit_jobs_env = os.environ.get("MAX_SUBMIT_JOBS", None)
+        max_submit_jobs_env = os.environ.get("SLURM_MAX_SUBMIT_JOBS", None)
         if max_submit_jobs_env is not None:
             logging.debug(
-                f"MAX_SUBMIT_JOBS env variable specified which is {max_submit_jobs_env}."
+                f"SLURM_MAX_SUBMIT_JOBS env variable specified which is {max_submit_jobs_env}."
             )
             return int(max_submit_jobs_env)
 

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -87,6 +87,13 @@ class SlurmExecutor(ClusterExecutor):
     @staticmethod
     @cache_in_production
     def get_max_array_size():
+        max_array_size_env = os.environ.get("MAX_ARRAY_SIZE", None)
+        if max_array_size_env is not None:
+            logging.debug(
+                f"MAX_ARRAY_SIZE env variable specified which is {max_array_size_env}."
+            )
+            return int(max_array_size_env)
+
         max_array_size = 2 ** 32
         # See https://unix.stackexchange.com/a/364615
         stdout, stderr, exit_code = call(
@@ -104,6 +111,13 @@ class SlurmExecutor(ClusterExecutor):
     @staticmethod
     @cache_in_production
     def get_max_submit_jobs():
+        max_submit_jobs_env = os.environ.get("MAX_SUBMIT_JOBS", None)
+        if max_submit_jobs_env is not None:
+            logging.debug(
+                f"MAX_SUBMIT_JOBS env variable specified which is {max_submit_jobs_env}."
+            )
+            return int(max_submit_jobs_env)
+
         max_submit_jobs = 2 ** 32
         # Check whether there is a limit per user
         stdout_user, stderr_user, _ = call(

--- a/cluster_tools/test.py
+++ b/cluster_tools/test.py
@@ -401,9 +401,8 @@ def test_slurm_max_submit_user():
                 assert result == [i ** 2 for i in range(10)]
 
                 job_ids = {fut.cluster_jobid for fut in futures}
-                # The 10 work packages should have been scheduled as 5 separate jobs,
-                # because the cluster_tools schedule at most 1/3 of MaxSubmitJobs at once.
-                assert len(job_ids) == 5
+                # The 10 work packages should have been scheduled as 2 separate jobs.
+                assert len(job_ids) == 2
         finally:
             _, _, exit_code = call(
                 f"echo y | sacctmgr modify {command} set MaxSubmitJobs=-1"

--- a/cluster_tools/test.py
+++ b/cluster_tools/test.py
@@ -418,7 +418,7 @@ def test_slurm_max_submit_user_env():
     executor = cluster_tools.get_executor("slurm", debug=True)
     original_max_submit_jobs = executor.get_max_submit_jobs()
 
-    os.environ["MAX_SUBMIT_JOBS"] = str(max_submit_jobs)
+    os.environ["SLURM_MAX_SUBMIT_JOBS"] = str(max_submit_jobs)
     new_max_submit_jobs = executor.get_max_submit_jobs()
 
     try:
@@ -434,7 +434,7 @@ def test_slurm_max_submit_user_env():
             # The 10 work packages should have been scheduled as 3 separate jobs.
             assert len(job_ids) == 3
     finally:
-        del os.environ["MAX_SUBMIT_JOBS"]
+        del os.environ["SLURM_MAX_SUBMIT_JOBS"]
         reset_max_submit_jobs = executor.get_max_submit_jobs()
         assert reset_max_submit_jobs == original_max_submit_jobs
 
@@ -577,7 +577,7 @@ def test_slurm_max_array_size_env():
     executor = cluster_tools.get_executor("slurm", debug=True)
     original_max_array_size = executor.get_max_array_size()
 
-    os.environ["MAX_ARRAY_SIZE"] = str(max_array_size)
+    os.environ["SLURM_MAX_ARRAY_SIZE"] = str(max_array_size)
     new_max_array_size = executor.get_max_array_size()
 
     try:
@@ -593,7 +593,7 @@ def test_slurm_max_array_size_env():
 
             assert all(array_size <= max_array_size for array_size in occurences)
     finally:
-        del os.environ["MAX_ARRAY_SIZE"]
+        del os.environ["SLURM_MAX_ARRAY_SIZE"]
         reset_max_array_size = executor.get_max_array_size()
         assert reset_max_array_size == original_max_array_size
 


### PR DESCRIPTION
### Description:
- See title
- Also remove that the batch_size was set to be at most 1/3 of max_array_size and max_submit_jobs. This was added to avoid blocking other jobs if a user runs multiple programs, but it was undocumented and feels unexpected/intransparent. Since this PR allows to easily configure the slurm limits, that should be preferable imo.
- Test the new functionality

### Issues:
- fixes https://github.com/scalableminds/webknossos-libs/issues/537
- supersedes https://github.com/scalableminds/webknossos-libs/pull/538

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
