### PR TITLE
Python client: Mark viewConfiguration as varying json field

### DIFF
--- a/webknossos/__generate_client.py
+++ b/webknossos/__generate_client.py
@@ -121,7 +121,7 @@ def iterate_request_ids_with_responses() -> Iterable[Tuple[str, bytes]]:
     yield "userLoggedTime", user_logged_time_response.content
 
 
-FIELDS_WITH_VARYING_CONTENT = ["adminViewConfiguration", "novelUserExperienceInfos"]
+FIELDS_WITH_VARYING_CONTENT = ["adminViewConfiguration", "novelUserExperienceInfos", "viewConfiguration"]
 
 
 def make_properties_required(x: Any) -> None:

--- a/webknossos/__generate_client.py
+++ b/webknossos/__generate_client.py
@@ -121,7 +121,11 @@ def iterate_request_ids_with_responses() -> Iterable[Tuple[str, bytes]]:
     yield "userLoggedTime", user_logged_time_response.content
 
 
-FIELDS_WITH_VARYING_CONTENT = ["adminViewConfiguration", "novelUserExperienceInfos", "viewConfiguration"]
+FIELDS_WITH_VARYING_CONTENT = [
+    "adminViewConfiguration",
+    "novelUserExperienceInfos",
+    "viewConfiguration",
+]
 
 
 def make_properties_required(x: Any) -> None:


### PR DESCRIPTION
new varying field in wk json response for annotation json, introduced in https://github.com/scalableminds/webknossos/pull/5967

