### PR TITLE
[wk-libs] use wk test data for tests

### DIFF
--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -28,6 +28,7 @@ def main() -> None:
         annotation.dataset_name,
         organization_name="scalable_minds",
         path=new_dataset_name,
+        webknossos_url="https://webknossos.org",
     )
     dataset.name = new_dataset_name
 
@@ -77,21 +78,17 @@ def main() -> None:
     segmentation_layer.bounding_box = dataset.layers["color"].bounding_box
     segmentation_layer.add_mag(mag, compress=True).write(segmentation)
 
-    # Get your auth token from https://webknossos.org/auth/token
-    with wk.webknossos_context(
-        url="http://localhost:9000", token="secretSampleUserToken"
-    ):
-        url = dataset.upload(
-            layers_to_link=[
-                wk.LayerToLink(
-                    organization_name="scalable_minds",
-                    dataset_name=annotation.dataset_name,
-                    layer_name="color",
-                )
-            ]
-            if "PYTEST_CURRENT_TEST" not in os.environ
-            else None
-        )
+    url = dataset.upload(
+        layers_to_link=[
+            wk.LayerToLink(
+                organization_name="scalable_minds",
+                dataset_name=annotation.dataset_name,
+                layer_name="color",
+            )
+        ]
+        if "PYTEST_CURRENT_TEST" not in os.environ
+        else None
+    )
 
     print(f"Successfully uploaded {url}")
 

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -8,43 +8,40 @@ from webknossos.dataset import COLOR_CATEGORY
 
 
 def main() -> None:
-    with wk.webknossos_context(
-        url="http://localhost:9000", token="secretSampleUserToken"
-    ):
-        # load your data - we use an example 3D dataset here
-        img = data.cells3d()  # (z, c, y, x)
+    # load your data - we use an example 3D dataset here
+    img = data.cells3d()  # (z, c, y, x)
 
-        # make sure that the dimension of your data has the right order
-        # we expect the following dimensions: Channels, X, Y, Z.
-        img = np.transpose(img, [1, 3, 2, 0])
+    # make sure that the dimension of your data has the right order
+    # we expect the following dimensions: Channels, X, Y, Z.
+    img = np.transpose(img, [1, 3, 2, 0])
 
-        # choose a name for our dataset
-        time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
-        name = f"cell_{time_str}"
+    # choose a name for our dataset
+    time_str = strftime("%Y-%m-%d_%H-%M-%S", gmtime())
+    name = f"cell_{time_str}"
 
-        # scale is defined in nm
-        ds = wk.Dataset(name, scale=(260, 260, 290))
+    # scale is defined in nm
+    ds = wk.Dataset(name, scale=(260, 260, 290))
 
-        # The example microscopy data has two channels
-        # Channel 0 contains cell membranes, channel 1 contains nuclei.
-        layer_membranes = ds.add_layer(
-            "cell membranes",
-            COLOR_CATEGORY,
-            dtype_per_layer=img.dtype,
-        )
+    # The example microscopy data has two channels
+    # Channel 0 contains cell membranes, channel 1 contains nuclei.
+    layer_membranes = ds.add_layer(
+        "cell membranes",
+        COLOR_CATEGORY,
+        dtype_per_layer=img.dtype,
+    )
 
-        layer_membranes.add_mag(1, compress=True).write(img[0, :])
+    layer_membranes.add_mag(1, compress=True).write(img[0, :])
 
-        layer_nuclei = ds.add_layer(
-            "nuclei",
-            COLOR_CATEGORY,
-            dtype_per_layer=img.dtype,
-        )
+    layer_nuclei = ds.add_layer(
+        "nuclei",
+        COLOR_CATEGORY,
+        dtype_per_layer=img.dtype,
+    )
 
-        layer_nuclei.add_mag(1, compress=True).write(img[1, :])
+    layer_nuclei.add_mag(1, compress=True).write(img[1, :])
 
-        url = ds.upload()
-        print(f"Successfully uploaded {url}")
+    url = ds.upload()
+    print(f"Successfully uploaded {url}")
 
 
 if __name__ == "__main__":

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -eEuo pipefail
 
+export WK_TOKEN=1b88db86331a38c21a0b235794b9e459856490d70408bcffb767f64ade0f83d2bdb4c4e181b9a9a30cdece7cb7c65208cc43b6c1bb5987f5ece00d348b1a905502a266f8fc64f0371cd6559393d72e031d0c2d0cabad58cccf957bb258bc86f05b5dc3d4fff3d5e3d9c0389a6027d861a21e78e3222fb6c5b7944520ef21761e
+export WK_URL=http://localhost:9000
+
 if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
     if ! curl -sf localhost:9000/api/health; then
         WK_DOCKER_DIR="tests"
@@ -23,6 +26,7 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
         done
     fi
     rm -rf tests/cassettes
+    rm -rf tests/**/cassettes
 
     # Note that pytest should be executed via `python -m`, since
     # this will ensure that the current directory is added to sys.path

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -26,7 +26,7 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
         while ! curl -sf localhost:9000/api/health; do
             sleep 5
         done
-        OUT=$(docker-compose exec webknossos tools/postgres/prepareTestDB.sh 2>&1) || echo $OUT
+        OUT=$(docker-compose exec webknossos tools/postgres/prepareTestDB.sh 2>&1) || echo "$OUT"
         popd > /dev/null
     else
         echo "Using the already running local webknossos setup at localhost:9000"

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -28,7 +28,7 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
         done
         OUT=$(docker-compose exec webknossos tools/postgres/prepareTestDB.sh 2>&1) || echo $OUT
         popd > /dev/null
-    elif
+    else
         echo "Using the already running local webknossos setup at localhost:9000"
     fi
 

--- a/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
+++ b/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
@@ -26780,22 +26780,22 @@ interactions:
           />\n  <volume id=\"0\" location=\"data_Volume.zip\" fallbackLayer=\"segmentation\"
           />\n</things>"
     headers:
-      Connection:
+      connection:
       - keep-alive
-      Content-Disposition:
+      content-disposition:
       - attachment;filename="l4dense_motta_et_al_demo_v2__explorational__potto__4a6356.zip"
-      Content-Type:
+      content-type:
       - application/zip
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date: Mon, 01 Jan 2000 00:00:00 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
+      transfer-encoding:
       - chunked
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
+++ b/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
@@ -26756,7 +26756,7 @@ interactions:
               DwgADFAAA/0BAA==
         l4dense_motta_et_al_demo_v2__explorational__potto__4a6356.nml: "<things>\n
           \ <meta name=\"writer\" content=\"NmlWriter.scala\" />\n  <meta name=\"writerGitCommit\"
-          content=\"12f1c1970fbc40ada2a530b5e95e75d55dca4009\" />\n  <meta name=\"timestamp\"
+          content=\"573b1a20165d9d67f47566ef9ee806cc2fccd1ad\" />\n  <meta name=\"timestamp\"
           content=\"1643210000000\" />\n  <meta name=\"annotationId\" content=\"61c20205010000cc004a6356\"
           />\n  <meta name=\"username\" content=\"Philipp Otto\" />\n  <parameters>\n
           \   <experiment name=\"l4dense_motta_et_al_demo_v2\" organization=\"scalable_minds\"

--- a/webknossos/tests/cassettes/test_examples/test_upload_image_data.yaml
+++ b/webknossos/tests/cassettes/test_examples/test_upload_image_data.yaml
@@ -19,16 +19,21 @@ interactions:
   response:
     content: '{"token":"xxxsecrettokenxxx"}'
     headers:
-      Content-Length:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
       - '34'
-      Content-Type:
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -48,18 +53,23 @@ interactions:
     method: GET
     uri: http://localhost:9000/api/datastores
   response:
-    content: '[{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
+    content: '[{"name":"connect","url":"http://localhost:8000","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
     headers:
-      Content-Length:
-      - '128'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '253'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -79,18 +89,23 @@ interactions:
     method: GET
     uri: http://localhost:9000/api/user
   response:
-    content: '{"id":"61f273eb0100000100a72f50","email":"sample@scm.io","firstName":"Sample","lastName":"User","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"61f273eb0100000100a72f4e","name":"sample_organization","isTeamManager":true}],"experiences":{"sampleExp":10},"lastActivity":1643279339776,"isAnonymous":false,"isEditable":true,"organization":"sample_organization","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1643279339777,"lastTaskTypeId":null}'
+    content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      Content-Length:
-      - '479'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '611'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -108,23 +123,28 @@ interactions:
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: http://localhost:9000/api/datasets/sample_organization/cell_2000-01-01_00-00-00/isValidNewName
+    uri: http://localhost:9000/api/datasets/Organization_X/cell_2000-01-01_00-00-00/isValidNewName
   response:
     content: ''
     headers:
-      Content-Length:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"uploadId": "2000-01-01T00-00-00__0011", "organization": "sample_organization",
+    body: '{"uploadId": "2000-01-01T00-00-00__0011", "organization": "Organization_X",
       "name": "cell_2000-01-01_00-00-00", "totalFileCount": 5, "initialTeams": [],
       "layersToLink": []}'
     headers:
@@ -135,7 +155,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '209'
+      - '204'
       content-type:
       - application/json
       host:
@@ -147,18 +167,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -171,7 +196,7 @@ interactions:
       form-data; name=\"resumableRelativePath\"\n\ndatasource-properties.json\n--\nContent-Disposition:
       form-data; name=\"resumableTotalChunks\"\n\n1\n--\nContent-Disposition: form-data;
       name=\"resumableChunkNumber\"\n\n1\n--\nContent-Disposition: form-data; name=\"resumableCurrentChunkSize\"\n\n1572\n--\nContent-Disposition:
-      form-data; name=\"owningOrganization\"\n\nsample_organization\n--\nContent-Disposition:
+      form-data; name=\"owningOrganization\"\n\nOrganization_X\n--\nContent-Disposition:
       form-data; name=\"name\"\n\ncell_2000-01-01_00-00-00\n--\nContent-Disposition:
       form-data; name=\"totalFileCount\"\n\n5\n--\nContent-Disposition: form-data;
       name=\"file\"; filename=\"upload\"\nContent-Type: application/octet-stream\n\n{\n
@@ -204,7 +229,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '3148'
+      - '3143'
       content-type:
       - multipart/form-data; boundary=fffffff0000000
       host:
@@ -216,18 +241,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:20 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -299,7 +329,7 @@ interactions:
       Content-Disposition: form-data; name="owningOrganization"
 
 
-      sample_organization
+      Organization_X
 
       --
 
@@ -328,7 +358,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '15349254'
+      - '15349249'
       content-type:
       - multipart/form-data; boundary=fffffff0000000
       host:
@@ -340,18 +370,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:21 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -363,7 +398,7 @@ interactions:
       form-data; name=\"resumableRelativePath\"\n\nnuclei/1/header.wkw\n--\nContent-Disposition:
       form-data; name=\"resumableTotalChunks\"\n\n1\n--\nContent-Disposition: form-data;
       name=\"resumableChunkNumber\"\n\n1\n--\nContent-Disposition: form-data; name=\"resumableCurrentChunkSize\"\n\n16\n--\nContent-Disposition:
-      form-data; name=\"owningOrganization\"\n\nsample_organization\n--\nContent-Disposition:
+      form-data; name=\"owningOrganization\"\n\nOrganization_X\n--\nContent-Disposition:
       form-data; name=\"name\"\n\ncell_2000-01-01_00-00-00\n--\nContent-Disposition:
       form-data; name=\"totalFileCount\"\n\n5\n--\nContent-Disposition: form-data;
       name=\"file\"; filename=\"upload\"\nContent-Type: application/octet-stream\n\nWKW\x01U\x03\x02\x02\0\0\0\0\0\0\0\0\n----\n"
@@ -375,7 +410,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1542'
+      - '1537'
       content-type:
       - multipart/form-data; boundary=fffffff0000000
       host:
@@ -387,18 +422,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:21 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -470,7 +510,7 @@ interactions:
       Content-Disposition: form-data; name="owningOrganization"
 
 
-      sample_organization
+      Organization_X
 
       --
 
@@ -499,7 +539,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '16626815'
+      - '16626810'
       content-type:
       - multipart/form-data; boundary=fffffff0000000
       host:
@@ -511,18 +551,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:21 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -534,7 +579,7 @@ interactions:
       form-data; name=\"resumableRelativePath\"\n\ncell membranes/1/header.wkw\n--\nContent-Disposition:
       form-data; name=\"resumableTotalChunks\"\n\n1\n--\nContent-Disposition: form-data;
       name=\"resumableChunkNumber\"\n\n1\n--\nContent-Disposition: form-data; name=\"resumableCurrentChunkSize\"\n\n16\n--\nContent-Disposition:
-      form-data; name=\"owningOrganization\"\n\nsample_organization\n--\nContent-Disposition:
+      form-data; name=\"owningOrganization\"\n\nOrganization_X\n--\nContent-Disposition:
       form-data; name=\"name\"\n\ncell_2000-01-01_00-00-00\n--\nContent-Disposition:
       form-data; name=\"totalFileCount\"\n\n5\n--\nContent-Disposition: form-data;
       name=\"file\"; filename=\"upload\"\nContent-Type: application/octet-stream\n\nWKW\x01U\x03\x02\x02\0\0\0\0\0\0\0\0\n----\n"
@@ -546,7 +591,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '1558'
+      - '1553'
       content-type:
       - multipart/form-data; boundary=fffffff0000000
       host:
@@ -558,23 +603,28 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:21 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
 - request:
-    body: '{"uploadId": "2000-01-01T00-00-00__0011", "organization": "sample_organization",
+    body: '{"uploadId": "2000-01-01T00-00-00__0011", "organization": "Organization_X",
       "name": "cell_2000-01-01_00-00-00", "needsConversion": false, "layersToLink":
       []}'
     headers:
@@ -585,7 +635,7 @@ interactions:
       connection:
       - keep-alive
       content-length:
-      - '194'
+      - '189'
       content-type:
       - application/json
       host:
@@ -597,18 +647,23 @@ interactions:
   response:
     content: ''
     headers:
-      Access-Control-Allow-Origin:
+      X-Powered-By:
+      - Express
+      access-control-allow-origin:
       - '*'
-      Access-Control-Max-Age:
+      access-control-max-age:
       - '600'
-      Content-Length:
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:21 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_examples/test_upload_image_data.yaml
+++ b/webknossos/tests/cassettes/test_examples/test_upload_image_data.yaml
@@ -19,16 +19,11 @@ interactions:
   response:
     content: '{"token":"xxxsecrettokenxxx"}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '34'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -55,16 +50,11 @@ interactions:
   response:
     content: '[{"name":"connect","url":"http://localhost:8000","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '253'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -91,16 +81,11 @@ interactions:
   response:
     content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '611'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -127,14 +112,9 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -167,18 +147,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -241,18 +216,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:20 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -370,18 +340,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:21 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -422,18 +387,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:21 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -551,18 +511,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:21 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -603,18 +558,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:21 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -647,18 +597,13 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
       access-control-allow-origin:
       - '*'
       access-control-max-age:
       - '600'
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:21 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_examples/test_user_times.yaml
+++ b/webknossos/tests/cassettes/test_examples/test_user_times.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '2000'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -59,16 +54,11 @@ interactions:
       "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
       2021}, "durationInSeconds": 14}]}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
-      - '555'
+      - '489'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -95,16 +85,11 @@ interactions:
   response:
     content: '{"loggedTime": []}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '17'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -133,16 +118,11 @@ interactions:
       58}, {"paymentInterval": {"month": 1, "year": 2021}, "durationInSeconds": 32},
       {"paymentInterval": {"month": 2, "year": 2021}, "durationInSeconds": 210}]}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '218'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -169,16 +149,11 @@ interactions:
   response:
     content: '{"loggedTime": []}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '17'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_examples/test_user_times.yaml
+++ b/webknossos/tests/cassettes/test_examples/test_user_times.yaml
@@ -9,35 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users
+    uri: http://localhost:9000/api/users
   response:
-    content: '[{"id":"5bfecf6e010000fa035248bb","email":"tony.tester@mail.com","firstName":"Tony","lastName":"Tester","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":true}],"experiences":{},"lastActivity":1543425902059,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"shouldSeeModernControlsModal":true,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1543425902059,"lastTaskTypeId":null},{"id":"60f17acf0100008e003484ea","email":"taylor.tester@mail.com","firstName":"Taylor","lastName":"Tester","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1626438351807,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1626438351807,"lastTaskTypeId":null}]'
+    content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '2000'
+      content-type:
       - application/json
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -51,31 +45,35 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users/5bfecf6e010000fa035248bb/loggedTime
+    uri: http://localhost:9000/api/users/570b9f4d2a7c0e4d008da6ef/loggedTime
   response:
-    content: '{"loggedTime":[{"paymentInterval":{"month":10,"year":2021},"durationInSeconds":40}]}'
+    content: '{"loggedTime": [{"paymentInterval": {"month": 8, "year": 2018}, "durationInSeconds":
+      265}, {"paymentInterval": {"month": 5, "year": 2021}, "durationInSeconds": 158},
+      {"paymentInterval": {"month": 11, "year": 2021}, "durationInSeconds": 12}, {"paymentInterval":
+      {"month": 1, "year": 2021}, "durationInSeconds": 510}, {"paymentInterval": {"month":
+      4, "year": 2016}, "durationInSeconds": 58}, {"paymentInterval": {"month": 3,
+      "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
+      2021}, "durationInSeconds": 14}]}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '84'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '555'
+      content-type:
       - application/json
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -89,29 +87,103 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users/60f17acf0100008e003484ea/loggedTime
+    uri: http://localhost:9000/api/users/670b9f4d2a7c0e4d008da6ef/loggedTime
   response:
-    content: '{"loggedTime":[{"paymentInterval":{"month":5,"year":2019},"durationInSeconds":0},{"paymentInterval":{"month":7,"year":2021},"durationInSeconds":10},{"paymentInterval":{"month":2,"year":2019},"durationInSeconds":452},{"paymentInterval":{"month":12,"year":2018},"durationInSeconds":116},{"paymentInterval":{"month":1,"year":2021},"durationInSeconds":13},{"paymentInterval":{"month":3,"year":2021},"durationInSeconds":152},{"paymentInterval":{"month":1,"year":2019},"durationInSeconds":365},{"paymentInterval":{"month":9,"year":2021},"durationInSeconds":98}]}'
+    content: '{"loggedTime": []}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
       - '17'
-      Content-Type:
+      content-type:
       - application/json
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - localhost:9000
+      user-agent:
+      - python-httpx/0.18.2
+    method: GET
+    uri: http://localhost:9000/api/users/770b9f4d2a7c0e4d008da6ef/loggedTime
+  response:
+    content: '{"loggedTime": [{"paymentInterval": {"month": 4, "year": 2016}, "durationInSeconds":
+      58}, {"paymentInterval": {"month": 1, "year": 2021}, "durationInSeconds": 32},
+      {"paymentInterval": {"month": 2, "year": 2021}, "durationInSeconds": 210}]}'
+    headers:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '218'
+      content-type:
+      - application/json
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      x-permitted-cross-domain-policies:
+      - master-only
+      x-xss-protection:
+      - 1; mode=block
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: ''
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - localhost:9000
+      user-agent:
+      - python-httpx/0.18.2
+    method: GET
+    uri: http://localhost:9000/api/users/870b9f4d2a7c0e4d008da6ef/loggedTime
+  response:
+    content: '{"loggedTime": []}'
+    headers:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '17'
+      content-type:
+      - application/json
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
+      - origin-when-cross-origin, strict-origin-when-cross-origin
+      x-permitted-cross-domain-policies:
+      - master-only
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
@@ -15,18 +15,13 @@ interactions:
     method: GET
     uri: http://localhost:9000/api/annotations/Explorational/570ba0092a7c0e980056fe9b/info
   response:
-    content: '{"modified":0,"state":"Active","id":"570ba0092a7c0e980056fe9b","name":"","description":"","typ":"Explorational","task":null,"stats":{"edgeCount":28965,"nodeCount":28967,"treeCount":2,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"56fe9b","annotationLayers":[{"tracingId":"ae417175-f7bb-4a34-8187-d9c3b50143ae","typ":"Skeleton"}],"dataSetName":"2012-06-28_Cortex","organization":"Organization_X","dataStore":{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"http://localhost:9000"},"visibility":"Internal","settings":{"allowedModes":["orthogonal","oblique","flight"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":0,"tags":["2012-06-28_Cortex","skeleton"],"user":{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isAnonymous":false,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}]},"meshes":[]}'
+    content: '{"modified":0,"state":"Active","id":"570ba0092a7c0e980056fe9b","name":"","description":"","viewConfiguration":null,"typ":"Explorational","task":null,"stats":{"edgeCount":28965,"nodeCount":28967,"treeCount":2,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"56fe9b","annotationLayers":[{"tracingId":"ae417175-f7bb-4a34-8187-d9c3b50143ae","typ":"Skeleton"}],"dataSetName":"2012-06-28_Cortex","organization":"Organization_X","dataStore":{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"http://localhost:9000"},"visibility":"Internal","settings":{"allowedModes":["orthogonal","oblique","flight"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":null,"tags":["2012-06-28_Cortex","skeleton"],"user":{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isAnonymous":false,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}]},"meshes":[]}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
-      - '1343'
+      - '1371'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_annotation_info.yaml
@@ -9,31 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/annotations/Explorational/616457c2010000870032ced4/info
+    uri: http://localhost:9000/api/annotations/Explorational/570ba0092a7c0e980056fe9b/info
   response:
-    content: '{"modified":1639054055786,"state":"Active","id":"616457c2010000870032ced4","name":"Training
-      Data Example for Skin Layers","description":"Example Annotation to reproduce
-      [the scikit-image example with a trainable segmenter](https://scikit-image.org/docs/0.18.x/auto_examples/segmentation/plot_trainable_segmentation.html#sphx-glr-auto-examples-segmentation-plot-trainable-segmentation-py).","typ":"Explorational","task":null,"stats":{"edgeCount":0,"nodeCount":0,"treeCount":0,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"32ced4","annotationLayers":[{"tracingId":"65029191-14f6-49d1-a946-11496d249e1e","typ":"Volume"},{"tracingId":"bd0e7b0b-0902-47df-a2de-91f8250c0189","typ":"Skeleton"}],"dataSetName":"skin","organization":"scalable_minds","dataStore":{"name":"webknossos.org","url":"https://data-humerus.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"https://webknossos.org"},"visibility":"Public","settings":{"allowedModes":["orthogonal","oblique","flight","volume"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":896477,"tags":["skin","hybrid"],"user":{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isAnonymous":false,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}]},"meshes":[]}'
+    content: '{"modified":0,"state":"Active","id":"570ba0092a7c0e980056fe9b","name":"","description":"","typ":"Explorational","task":null,"stats":{"edgeCount":28965,"nodeCount":28967,"treeCount":2,"branchPointCount":0},"restrictions":{"allowAccess":true,"allowUpdate":true,"allowFinish":true,"allowDownload":true},"formattedHash":"56fe9b","annotationLayers":[{"tracingId":"ae417175-f7bb-4a34-8187-d9c3b50143ae","typ":"Skeleton"}],"dataSetName":"2012-06-28_Cortex","organization":"Organization_X","dataStore":{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true},"tracingStore":{"name":"localhost","url":"http://localhost:9000"},"visibility":"Internal","settings":{"allowedModes":["orthogonal","oblique","flight"],"branchPointsAllowed":true,"somaClickingAllowed":true,"mergerMode":false,"resolutionRestrictions":{}},"tracingTime":0,"tags":["2012-06-28_Cortex","skeleton"],"user":{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isAnonymous":false,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}]},"meshes":[]}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '1568'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '1343'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
@@ -15,20 +15,15 @@ interactions:
     method: GET
     uri: http://localhost:9000/api/buildinfo
   response:
-    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"12f1c1970fbc40ada2a530b5e95e75d55dca4009","ciBuild":"","scalaVersion":"2.12.12","version":"dev","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Wed
-      Jan 26 15:18:52 2022 +0000"},"webknossos-wrap":{"builtAtMillis":"1640035836569","name":"webknossos-wrap","commitHash":"8b842648702f469a3ffd90dc8a68c4310e64b351","scalaVersion":"2.12.7","version":"1.1.15","sbtVersion":"1.4.1","builtAtString":"2021-12-20
-      21:30:36.569"},"schemaVersion":80,"token":"xxxsecrettokenxxx","localDataStoreEnabled":true,"localTracingStoreEnabled":true}'
+    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"9e5cf915409dd896239d2cd03988924a4405c4b3","ciBuild":"16745","scalaVersion":"2.12.12","version":"16745","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Tue
+      Feb 1 11:20:15 2022 +0100"},"webknossos-wrap":{"builtAtMillis":"1640035836569","name":"webknossos-wrap","commitHash":"8b842648702f469a3ffd90dc8a68c4310e64b351","scalaVersion":"2.12.7","version":"1.1.15","sbtVersion":"1.4.1","builtAtString":"2021-12-20
+      21:30:36.569"},"schemaVersion":81,"token":"xxxsecrettokenxxx","localDataStoreEnabled":true,"localTracingStoreEnabled":true}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
-      - '604'
+      - '610'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_build_info.yaml
@@ -9,30 +9,31 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/buildinfo
+    uri: http://localhost:9000/api/buildinfo
   response:
-    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"12f1c1970fbc40ada2a530b5e95e75d55dca4009","ciBuild":"16685","scalaVersion":"2.12.12","version":"16685","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Wed
+    content: '{"webknossos":{"name":"webknossos","ciTag":"","commitHash":"12f1c1970fbc40ada2a530b5e95e75d55dca4009","ciBuild":"","scalaVersion":"2.12.12","version":"dev","sbtVersion":"1.4.1","datastoreApiVersion":"1.0","commitDate":"Wed
       Jan 26 15:18:52 2022 +0000"},"webknossos-wrap":{"builtAtMillis":"1640035836569","name":"webknossos-wrap","commitHash":"8b842648702f469a3ffd90dc8a68c4310e64b351","scalaVersion":"2.12.7","version":"1.1.15","sbtVersion":"1.4.1","builtAtString":"2021-12-20
-      21:30:36.569"},"schemaVersion":80,"token":"xxxsecrettokenxxx","localDataStoreEnabled":false,"localTracingStoreEnabled":true}'
+      21:30:36.569"},"schemaVersion":80,"token":"xxxsecrettokenxxx","localDataStoreEnabled":true,"localTracingStoreEnabled":true}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '612'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '604'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_current_user_info_and_user_logged_time.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_current_user_info_and_user_logged_time.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '611'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -59,16 +54,11 @@ interactions:
       "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
       2021}, "durationInSeconds": 14}]}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '555'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_current_user_info_and_user_logged_time.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_current_user_info_and_user_logged_time.yaml
@@ -9,29 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/user
+    uri: http://localhost:9000/api/user
   response:
-    content: '{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1611048013169,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"lastViewedWhatsNewTimestamp":1643210728966,"shouldSeeModernControlsModal":false,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1611048013169,"lastTaskTypeId":null}'
+    content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '582'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '611'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -45,32 +45,35 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users/6006a44d0100007e0070d734/loggedTime
+    uri: http://localhost:9000/api/users/570b9f4d2a7c0e4d008da6ef/loggedTime
   response:
-    content: '{"loggedTime": [{"paymentInterval": {"month": 10, "year": 2021}, "durationInSeconds":
-      1169}, {"paymentInterval": {"month": 1, "year": 1970}, "durationInSeconds":
-      16}, {"paymentInterval": {"month": 12, "year": 2021}, "durationInSeconds": 10},
-      {"paymentInterval": {"month": 9, "year": 2021}, "durationInSeconds": 17}, {"paymentInterval":
-      {"month": 8, "year": 2021}, "durationInSeconds": 0}]}'
+    content: '{"loggedTime": [{"paymentInterval": {"month": 8, "year": 2018}, "durationInSeconds":
+      265}, {"paymentInterval": {"month": 5, "year": 2021}, "durationInSeconds": 158},
+      {"paymentInterval": {"month": 11, "year": 2021}, "durationInSeconds": 12}, {"paymentInterval":
+      {"month": 1, "year": 2021}, "durationInSeconds": 510}, {"paymentInterval": {"month":
+      4, "year": 2016}, "durationInSeconds": 58}, {"paymentInterval": {"month": 3,
+      "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
+      2021}, "durationInSeconds": 14}]}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '421'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '555'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
@@ -24,20 +24,20 @@ interactions:
       in *Science* on 24 October 2019. [10.1126/science.aay3134](https://science.sciencemag.org/content/early/2019/10/23/science.aay3134)\n","displayName":"L4
       Mouse Cortex Demo","created":1597232436055,"isEditable":false,"lastUsedByUser":1010101010101,"logoUrl":"https://static.webknossos.org/logos/scalableminds.svg","sortingKey":1597232436055,"details":null,"publication":null,"isUnreported":false,"isForeign":false,"jobsEnabled":true,"tags":["demo","l4dense"]}'
     headers:
-      Connection:
+      connection:
       - keep-alive
-      Content-Length:
+      content-length:
       - '2308'
-      Content-Type:
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date: Mon, 01 Jan 2000 00:00:00 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
+      strict-transport-security:
       - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_dataset_info.yaml
@@ -22,12 +22,12 @@ interactions:
       reconstruction in layer 4 of the somatosensory cortex* by A Motta, M Berning,
       KM Boergens, B Staffler, M Beining, S Loomba, P Hennig, H Wissler, M Helmstaedter
       in *Science* on 24 October 2019. [10.1126/science.aay3134](https://science.sciencemag.org/content/early/2019/10/23/science.aay3134)\n","displayName":"L4
-      Mouse Cortex Demo","created":1597232436055,"isEditable":true,"lastUsedByUser":1010101010101,"logoUrl":"https://static.webknossos.org/logos/scalableminds.svg","sortingKey":1597232436055,"details":null,"publication":null,"isUnreported":false,"isForeign":false,"jobsEnabled":true,"tags":["demo","l4dense"]}'
+      Mouse Cortex Demo","created":1597232436055,"isEditable":false,"lastUsedByUser":1010101010101,"logoUrl":"https://static.webknossos.org/logos/scalableminds.svg","sortingKey":1597232436055,"details":null,"publication":null,"isUnreported":false,"isForeign":false,"jobsEnabled":true,"tags":["demo","l4dense"]}'
     headers:
       Connection:
       - keep-alive
       Content-Length:
-      - '2319'
+      - '2308'
       Content-Type:
       - application/json
       Date: Mon, 01 Jan 2000 00:00:00 GMT

--- a/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '[{"name":"connect","url":"http://localhost:8000","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '253'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_datastore_list.yaml
@@ -9,28 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/datastores
+    uri: http://localhost:9000/api/datastores
   response:
-    content: '[{"name":"data5.connect","url":"https://data5.connect.demo.webknossos.org","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"demo-mhlab","url":"https://demo.data1-brain.esc.rzg.mpg.de","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":false},{"name":"webknossos.org","url":"https://data-humerus.webknossos.org","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
+    content: '[{"name":"connect","url":"http://localhost:8000","isForeign":false,"isScratch":false,"isConnector":true,"allowsUpload":false},{"name":"localhost","url":"http://localhost:9000","isForeign":false,"isScratch":false,"isConnector":false,"allowsUpload":true}]'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '445'
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '253'
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_generate_token_for_data_store.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_generate_token_for_data_store.yaml
@@ -11,28 +11,29 @@ interactions:
       content-length:
       - '0'
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: POST
-    uri: https://webknossos.org/api/userToken/generate
+    uri: http://localhost:9000/api/userToken/generate
   response:
     content: '{"token":"xxxsecrettokenxxx"}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
       - '34'
-      Content-Type:
+      content-type:
       - application/json
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_generate_token_for_data_store.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_generate_token_for_data_store.yaml
@@ -19,16 +19,11 @@ interactions:
   response:
     content: '{"token":"xxxsecrettokenxxx"}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '34'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_health.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_health.yaml
@@ -17,14 +17,9 @@ interactions:
   response:
     content: ''
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '0'
-      date:
-      - Mon, 31 Jan 2022 16:35:36 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_health.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_health.yaml
@@ -9,26 +9,27 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/health
+    uri: http://localhost:9000/api/health
   response:
     content: ''
     headers:
-      Connection:
-      - keep-alive
-      Content-Length:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
       - '0'
-      Date: Mon, 01 Jan 2000 00:00:00 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:36 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/cassettes/test_generated_client/test_user_list.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_user_list.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '2000'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/cassettes/test_generated_client/test_user_list.yaml
+++ b/webknossos/tests/cassettes/test_generated_client/test_user_list.yaml
@@ -9,36 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users
+    uri: http://localhost:9000/api/users
   response:
-    content: '[{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1611048013169,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"lastViewedWhatsNewTimestamp":1643210728966,"shouldSeeModernControlsModal":false,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1611048013169,"lastTaskTypeId":null}]'
+    content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '2000'
+      content-type:
       - application/json
-      Date:
-      - Tue, 26 Oct 2021 15:29:45 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/client/cassettes/test_context/test_user_organization.yaml
+++ b/webknossos/tests/client/cassettes/test_context/test_user_organization.yaml
@@ -9,36 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/user
+    uri: http://localhost:9000/api/user
   response:
-    content: '{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1611048013169,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"lastViewedWhatsNewTimestamp":1634559953377,"shouldSeeModernControlsModal":false,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1611048013169,"lastTaskTypeId":null}'
+    content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '611'
+      content-type:
       - application/json
-      Date:
-      - Wed, 27 Oct 2021 09:33:08 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/client/cassettes/test_context/test_user_organization.yaml
+++ b/webknossos/tests/client/cassettes/test_context/test_user_organization.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '611'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/client/cassettes/test_user/test_get_all_managed_users.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_all_managed_users.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '2000'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/client/cassettes/test_user/test_get_all_managed_users.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_all_managed_users.yaml
@@ -9,37 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users
+    uri: http://localhost:9000/api/users
   response:
-    content: '[{"id":"5bfecf6e010000fa035248bb","email":"tony.tester@mail.com","firstName":"Tony","lastName":"Tester","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":true}],"experiences":{},"lastActivity":1543425902059,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"shouldSeeModernControlsModal":true,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1543425902059,"lastTaskTypeId":null},{"id":"60f17acf0100008e003484ea","email":"taylor.tester@mail.com","firstName":"Taylor","lastName":"Tester","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1626438351807,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1626438351807,"lastTaskTypeId":null}]'
+    content: '[{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"670b9f4d2a7c0e4d008da6ef","email":"user_B@scalableminds.com","firstName":"user_B","lastName":"BoyB","isAdmin":false,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true}],"experiences":{},"lastActivity":1460465869053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"770b9f4d2a7c0e4d008da6ef","email":"user_C@scalableminds.com","firstName":"user_C","lastName":"BoyC","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":false}],"experiences":{},"lastActivity":1460552269053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null},{"id":"870b9f4d2a7c0e4d008da6ef","email":"user_D@scalableminds.com","firstName":"user_D","lastName":"BoyD","isAdmin":false,"isDatasetManager":false,"isActive":true,"teams":[{"id":"69882b370d889b84020efd4f","name":"team_X2","isTeamManager":true}],"experiences":{},"lastActivity":1460638669053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"light","created":1460379469000,"lastTaskTypeId":null}]'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '2000'
+      content-type:
       - application/json
-      Date:
-      - Wed, 27 Oct 2021 09:41:53 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/client/cassettes/test_user/test_get_current_user.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_current_user.yaml
@@ -9,36 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/user
+    uri: http://localhost:9000/api/user
   response:
-    content: '{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1611048013169,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"lastViewedWhatsNewTimestamp":1634559953377,"shouldSeeModernControlsModal":false,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1611048013169,"lastTaskTypeId":null}'
+    content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '611'
+      content-type:
       - application/json
-      Date:
-      - Wed, 27 Oct 2021 09:41:52 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/client/cassettes/test_user/test_get_current_user.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_current_user.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '611'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/client/cassettes/test_user/test_get_logged_time.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_logged_time.yaml
@@ -17,16 +17,11 @@ interactions:
   response:
     content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '611'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:
@@ -59,16 +54,11 @@ interactions:
       "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
       2021}, "durationInSeconds": 14}]}'
     headers:
-      X-Powered-By:
-      - Express
-      connection:
-      - close
       content-length:
       - '555'
       content-type:
       - application/json
-      date:
-      - Mon, 31 Jan 2022 16:35:37 GMT
+      date: Mon, 01 Jan 2000 00:00:00 GMT
       referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
       x-permitted-cross-domain-policies:

--- a/webknossos/tests/client/cassettes/test_user/test_get_logged_time.yaml
+++ b/webknossos/tests/client/cassettes/test_user/test_get_logged_time.yaml
@@ -9,36 +9,29 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/user
+    uri: http://localhost:9000/api/user
   response:
-    content: '{"id":"6006a44d0100007e0070d734","email":"jonathan@scm.io","firstName":"Jonathan","lastName":"Striebel","isAdmin":true,"isDatasetManager":false,"isActive":true,"teams":[{"id":"5b3ce78557b7414e59269427","name":"scalable
-      minds","isTeamManager":false}],"experiences":{},"lastActivity":1611048013169,"isAnonymous":false,"isEditable":true,"organization":"scalable_minds","novelUserExperienceInfos":{"lastViewedWhatsNewTimestamp":1634559953377,"shouldSeeModernControlsModal":false,"hasSeenDashboardWelcomeBanner":true},"selectedTheme":"auto","created":1611048013169,"lastTaskTypeId":null}'
+    content: '{"id":"570b9f4d2a7c0e4d008da6ef","email":"user_A@scalableminds.com","firstName":"user_A","lastName":"BoyA","isAdmin":true,"isDatasetManager":true,"isActive":true,"teams":[{"id":"570b9f4b2a7c0e3b008da6ec","name":"team_X1","isTeamManager":true},{"id":"59882b370d889b84020efd3f","name":"team_X3","isTeamManager":false},{"id":"59882b370d889b84020efd6f","name":"team_X4","isTeamManager":true}],"experiences":{"abc":5},"lastActivity":1460379469053,"isAnonymous":false,"isEditable":true,"organization":"Organization_X","novelUserExperienceInfos":{},"selectedTheme":"auto","created":1460379469000,"lastTaskTypeId":null}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '611'
+      content-type:
       - application/json
-      Date:
-      - Wed, 27 Oct 2021 09:41:52 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200
@@ -52,35 +45,35 @@ interactions:
       connection:
       - keep-alive
       host:
-      - webknossos.org
+      - localhost:9000
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/users/6006a44d0100007e0070d734/loggedTime
+    uri: http://localhost:9000/api/users/570b9f4d2a7c0e4d008da6ef/loggedTime
   response:
-    content: '{"loggedTime":[{"paymentInterval":{"month":10,"year":2021},"durationInSeconds":1169},{"paymentInterval":{"month":8,"year":2021},"durationInSeconds":0},{"paymentInterval":{"month":9,"year":2021},"durationInSeconds":17}]}'
+    content: '{"loggedTime": [{"paymentInterval": {"month": 8, "year": 2018}, "durationInSeconds":
+      265}, {"paymentInterval": {"month": 5, "year": 2021}, "durationInSeconds": 158},
+      {"paymentInterval": {"month": 11, "year": 2021}, "durationInSeconds": 12}, {"paymentInterval":
+      {"month": 1, "year": 2021}, "durationInSeconds": 510}, {"paymentInterval": {"month":
+      4, "year": 2016}, "durationInSeconds": 58}, {"paymentInterval": {"month": 3,
+      "year": 2021}, "durationInSeconds": 24}, {"paymentInterval": {"month": 8, "year":
+      2021}, "durationInSeconds": 14}]}'
     headers:
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
+      X-Powered-By:
+      - Express
+      connection:
+      - close
+      content-length:
+      - '555'
+      content-type:
       - application/json
-      Date:
-      - Wed, 27 Oct 2021 09:41:52 GMT
-      Referrer-Policy:
+      date:
+      - Mon, 31 Jan 2022 16:35:37 GMT
+      referrer-policy:
       - origin-when-cross-origin, strict-origin-when-cross-origin
-      Server:
-      - nginx/1.17.10
-      Strict-Transport-Security:
-      - max-age=15724800; includeSubDomains
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Permitted-Cross-Domain-Policies:
+      x-permitted-cross-domain-policies:
       - master-only
-      X-XSS-Protection:
+      x-xss-protection:
       - 1; mode=block
     http_version: HTTP/1.1
     status_code: 200

--- a/webknossos/tests/client/test_context.py
+++ b/webknossos/tests/client/test_context.py
@@ -13,4 +13,4 @@ def env_context() -> _WebknossosContext:
 
 @pytest.mark.vcr()
 def test_user_organization(env_context: _WebknossosContext) -> None:
-    assert env_context.organization == "scalable_minds"
+    assert env_context.organization == "Organization_X"

--- a/webknossos/tests/client/test_user.py
+++ b/webknossos/tests/client/test_user.py
@@ -13,7 +13,9 @@ def assert_valid_user(user: User) -> None:
 
 @pytest.mark.vcr()
 def test_get_current_user() -> None:
-    assert_valid_user(User.get_current_user())
+    user = User.get_current_user()
+    assert_valid_user(user)
+    assert user.email == "user_A@scalableminds.com"
 
 
 @pytest.mark.vcr()

--- a/webknossos/tests/conftest.py
+++ b/webknossos/tests/conftest.py
@@ -143,7 +143,9 @@ def _before_record_response(response: Dict[str, Any]) -> Dict[str, Any]:
     for key, value in sorted(response["headers"].items()):
         del response["headers"][key]
         if key.lower() not in _HEADERS_TO_REMOVE:
-            if not (key.lower() == "connection" and (value == "close" or "close" in value)):
+            if not (
+                key.lower() == "connection" and (value == "close" or "close" in value)
+            ):
                 response["headers"][key.lower()] = value
     if "date" in response["headers"]:
         response["headers"]["date"] = "Mon, 01 Jan 2000 00:00:00 GMT"

--- a/webknossos/tests/conftest.py
+++ b/webknossos/tests/conftest.py
@@ -101,6 +101,7 @@ _REPLACE_IN_REQUEST_MULTIFORM = {
 def _before_record_request(request: VcrRequest) -> VcrRequest:
     """This function formats and cleans request data to make it
     more readable and idempotent when re-snapshotting"""
+
     request.uri = re.sub(
         r"\d{4}-\d{2}-\d{2}_\d{2}-\d{2}-\d{2}", "2000-01-01_00-00-00", request.uri
     )
@@ -140,6 +141,10 @@ _HEADERS_TO_REMOVE = ["x-powered-by"]
 
 
 def _before_record_response(response: Dict[str, Any]) -> Dict[str, Any]:
+    """This function formats and cleans response data to make it
+    more readable and idempotent when re-snapshotting"""
+
+    # sort and lower-case all headers to stay consistent across servers, also cleanup:
     for key, value in sorted(response["headers"].items()):
         del response["headers"][key]
         if key.lower() not in _HEADERS_TO_REMOVE:
@@ -149,6 +154,7 @@ def _before_record_response(response: Dict[str, Any]) -> Dict[str, Any]:
                 response["headers"][key.lower()] = value
     if "date" in response["headers"]:
         response["headers"]["date"] = "Mon, 01 Jan 2000 00:00:00 GMT"
+
     if isinstance(response["content"], str):
         for regex_to_replace, replace_with in _REPLACE_IN_RESPONSE_CONTENT.items():
             response["content"] = re.sub(
@@ -162,6 +168,7 @@ def _before_record_response(response: Dict[str, Any]) -> Dict[str, Any]:
                 if i["paymentInterval"]["year"] <= 2021
             ]
             response["content"] = json.dumps(json_content)
+
     return response
 
 

--- a/webknossos/tests/conftest.py
+++ b/webknossos/tests/conftest.py
@@ -136,9 +136,17 @@ _REPLACE_IN_RESPONSE_CONTENT = {
 }
 
 
+_HEADERS_TO_REMOVE = ["x-powered-by"]
+
+
 def _before_record_response(response: Dict[str, Any]) -> Dict[str, Any]:
-    if "Date" in response["headers"]:
-        response["headers"]["Date"] = "Mon, 01 Jan 2000 00:00:00 GMT"
+    for key, value in sorted(response["headers"].items()):
+        del response["headers"][key]
+        if key.lower() not in _HEADERS_TO_REMOVE:
+            if not (key.lower() == "connection" and (value == "close" or "close" in value)):
+                response["headers"][key.lower()] = value
+    if "date" in response["headers"]:
+        response["headers"]["date"] = "Mon, 01 Jan 2000 00:00:00 GMT"
     if isinstance(response["content"], str):
         for regex_to_replace, replace_with in _REPLACE_IN_RESPONSE_CONTENT.items():
             response["content"] = re.sub(

--- a/webknossos/tests/docker-compose.yml
+++ b/webknossos/tests/docker-compose.yml
@@ -17,7 +17,6 @@ services:
       - -Dtracingstore.redis.address=redis
       - -Ddatastore.redis.address=redis
       - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
-      - -DwebKnossos.sampleOrganization.enabled=true
     volumes:
       - ./binaryData:/webknossos/binaryData
     environment:

--- a/webknossos/tests/test_examples.py
+++ b/webknossos/tests/test_examples.py
@@ -82,9 +82,7 @@ def test_upload_image_data() -> None:
         )
 
         assert layer_nuclei.bounding_box.size == img.shape[1:]
-        assert url.startswith(
-            "http://localhost:9000/datasets/sample_organization/cell_"
-        )
+        assert url.startswith("http://localhost:9000/datasets/Organization_X/cell_")
 
 
 class _DummyNearestNeighborClassifier:
@@ -138,7 +136,7 @@ def test_learned_segmenter() -> None:
         counts = dict(zip(*np.unique(segmentation_data, return_counts=True)))
         assert counts == {1: 209066, 2: 37803, 3: 164553, 4: 817378}
         assert url.startswith(
-            "http://localhost:9000/datasets/sample_organization/skin_segmented_"
+            "http://localhost:9000/datasets/Organization_X/skin_segmented_"
         )
 
         if old_default_classifier is None:
@@ -155,5 +153,5 @@ def test_user_times() -> None:
     (df,) = exec_main_and_get_vars(example, "df")
 
     assert len(df) > 0
-    assert sum(df.loc[:, (2021, 10)]) > 0
-    assert "taylor.tester@mail.com" in df.index
+    assert sum(df.loc[:, (2021, 5)]) > 11
+    assert "user_A@scalableminds.com" in df.index

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -140,7 +140,7 @@ class Annotation:
         if webknossos_url != _get_context().url:
             warnings.warn(
                 f"The supplied url {webknossos_url} does not match your current context {_get_context().url}. "
-                + "Only public annotations can be downloaded this way, using no token. "
+                + "Using no token, only public annotations can be downloaded. "
                 + "Please see https://docs.webknossos.org/api/webknossos/client/context.html to adapt the URL and token."
             )
             context: ContextManager[None] = webknossos_context(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -233,7 +233,7 @@ class Dataset:
         if webknossos_url is not None and webknossos_url != _get_context().url:
             warnings.warn(
                 f"The supplied url {webknossos_url} does not match your current context {_get_context().url}. "
-                + "Only public datasets can be downloaded this way, using no token. "
+                + "Using no token, only public datasets can be downloaded. "
                 + "Please see https://docs.webknossos.org/api/webknossos/client/context.html to adapt the URL and token."
             )
             context: ContextManager[None] = webknossos_context(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -4,11 +4,22 @@ import os
 import shutil
 import warnings
 from argparse import Namespace
+from contextlib import nullcontext
 from os import PathLike, makedirs
 from os.path import basename, join, normpath
 from pathlib import Path
 from shutil import rmtree
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ContextManager,
+    Dict,
+    List,
+    Optional,
+    Tuple,
+    Union,
+    cast,
+)
 
 import attr
 import numpy as np
@@ -214,12 +225,27 @@ class Dataset:
         mags: Optional[List[Mag]] = None,
         path: Optional[Union[PathLike, str]] = None,
         exist_ok: bool = False,
+        webknossos_url: Optional[str] = None,
     ) -> "Dataset":
         from webknossos.client._download_dataset import download_dataset
+        from webknossos.client.context import _get_context, webknossos_context
 
-        return download_dataset(
-            dataset_name, organization_name, bbox, layers, mags, path, exist_ok
-        )
+        if webknossos_url is not None and webknossos_url != _get_context().url:
+            warnings.warn(
+                f"The supplied url {webknossos_url} does not match your current context {_get_context().url}. "
+                + "Only public datasets can be downloaded this way, using no token. "
+                + "Please see https://docs.webknossos.org/api/webknossos/client/context.html to adapt the URL and token."
+            )
+            context: ContextManager[None] = webknossos_context(
+                webknossos_url, token=None
+            )
+        else:
+            context = nullcontext()
+
+        with context:
+            return download_dataset(
+                dataset_name, organization_name, bbox, layers, mags, path, exist_ok
+            )
 
     @property
     def layers(self) -> Dict[str, Layer]:


### PR DESCRIPTION
### Description:
- uses the e2e testdata for the tests where possible, adapts the tests accordingly
- uses the e2e user token for the tests
- ensures that local setup snapshots and docker snapshots are (almost) the same
- allows the download of public annotations and datasets from wk-instances that are not in the current token-context

### Issues:
- fixes most things from #514
