### PR TITLE
Fix __parse_volume

### DIFF
--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -224,3 +224,22 @@ def test_import_export_round_trip(tmp_path: Path) -> None:
 
     nml.save(export_path)
     diff_files(snapshot_path, export_path)
+
+def test_volume_dump_round_trip(tmp_path: Path) -> None:
+    from webknossos.skeleton.nml import Volume, __dump_volume, __parse_volume
+    from loxun import XmlWriter
+    import xml.etree.ElementTree as ET
+
+    export_path = tmp_path / "volume_dump.xml"
+    volume_in = Volume(id=0, location="data_Volume.zip", fallback_layer="my_very_important_layer")
+    volume_out = None
+
+    with open(export_path, 'wb') as f:
+        with XmlWriter(f) as xf:
+            __dump_volume(xf, volume_in)
+
+    with open(export_path, 'rb') as f:
+        tree = ET.parse(export_path)
+        volume_out = __parse_volume(next(tree.iter()))
+
+    assert volume_in == volume_out

--- a/webknossos/webknossos/skeleton/nml/__init__.py
+++ b/webknossos/webknossos/skeleton/nml/__init__.py
@@ -382,7 +382,7 @@ def __parse_volume(nml_volume: Element) -> Volume:
     return Volume(
         int(enforce_not_null(nml_volume.get("id"))),
         enforce_not_null(nml_volume.get("location")),
-        nml_volume.get("fallback_layer", default=None),
+        nml_volume.get("fallbackLayer", default=None),
     )
 
 


### PR DESCRIPTION
### Description:
- Adds a simple round trip test for the `__dump_volume` and `__parse_volume`.
- Enables non-default `Volume.fallback_layer` return values for `__parse_volume`.

Currently the `__dump_volume` never writes the `fallbackLayer` parameter. Instead, a `fallback_layer` parameter is written to the nml file. Thus, `__parse_volume` always returns the default value.

This bug is in particular annoying if you want to use the nml fallback layer information for the programmatic correction of [diff-based downloads](https://forum.image.sc/t/webknossos-web-ui-annotations-and-annotation-downloads-are-inconsistent/62962/2) in hundreds of annotations ...

Best,

Eric
