### PR TITLE
[wk-libs] Skeleton: allow comparison of graphs and other types, fix node-order for equality check

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,13 +16,13 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-
+- Skeleton: Fixed a bug when comparing `Graph` instances, this fixes failing loads which had the error message `Can only compare wk.Graph to another wk.Graph.` before. [#593](https://github.com/scalableminds/webknossos-libs/pull/593)
 
 ## [0.9.4](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.9.4) - 2022-02-09
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.9.3...v0.9.4)
 
 ### Added
- - Added AnnotationInfo, Project and Task classes for handling annotation information and annotation project administration. [#574](https://github.com/scalableminds/webknossos-libs/pull/574):
+- Added AnnotationInfo, Project and Task classes for handling annotation information and annotation project administration. [#574](https://github.com/scalableminds/webknossos-libs/pull/574)
 
 ### Changed
 - Lifted the restriction that `BoundingBox` cannot have a negative topleft (introduced in v0.9.0). Also, negative size dimensions are flipped, so that the topleft <= bottomright,

--- a/webknossos/testdata/nmls/test_a.nml
+++ b/webknossos/testdata/nmls/test_a.nml
@@ -1,0 +1,37 @@
+<things>
+  <parameters>
+    <experiment name="ds_name" organization="orga" description="" />
+    <scale x="4.0" y="4.0" z="35.0" />
+    <offset x="0" y="0" z="0" />
+    <time ms="1644425515615" />
+    <editPosition x="199480" y="199906" z="3593" />
+    <editRotation xRot="0.0" yRot="0.0" zRot="0.0" />
+    <zoomLevel zoom="2.0" />
+    <activeNode id="3" />
+  </parameters>
+  <thing id="3" color.r="0.8509804010391235" color.g="0.5215686559677124" color.b="0.07058823853731155" color.a="1.0" name="003" groupId="2">
+    <nodes>
+      <node id="3" radius="1.0" x="199480" y="199906" z="3593" rotX="0.0" rotY="0.0" rotZ="0.0" inVp="0" inMag="1" bitDepth="8" interpolation="true" time="1644425546725" />
+    </nodes>
+    <edges />
+  </thing>
+  <thing id="2" color.r="0.0" color.g="0.0" color.b="1.0" color.a="1.0" name="002" groupId="2">
+    <nodes>
+      <node id="2" radius="1.0" x="199355" y="199679" z="3593" rotX="0.0" rotY="0.0" rotZ="0.0" inVp="0" inMag="1" bitDepth="8" interpolation="true" time="1644425544361" />
+    </nodes>
+    <edges />
+  </thing>
+  <thing id="1" color.r="0.6784313917160034" color.g="0.1411764770746231" color.b="0.05098039284348488" color.a="1.0" name="001">
+    <nodes>
+      <node id="1" radius="1.0" x="199196" y="199290" z="3593" rotX="0.0" rotY="0.0" rotZ="0.0" inVp="0" inMag="1" bitDepth="8" interpolation="true" time="1644425520594" />
+    </nodes>
+    <edges />
+  </thing>
+  <branchpoints />
+  <comments />
+  <groups>
+    <group name="Group 1" id="1">
+      <group name="Group 2" id="2" />
+    </group>
+  </groups>
+</things>

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -137,7 +137,6 @@ def test_import_from_nml() -> None:
     loaded_nml = wk.Skeleton.load(snapshot_path)
 
     assert nml == loaded_nml
-    nml.get_graph_by_id(1) == 3
 
 
 def test_simple_initialization_and_representations(tmp_path: Path) -> None:

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -131,6 +131,14 @@ def test_export_to_nml(tmp_path: Path) -> None:
     diff_files(output_path, snapshot_path)
 
 
+def test_import_from_nml() -> None:
+    nml = create_dummy_skeleton()
+    snapshot_path = TESTDATA_DIR / "nmls" / "generated_snapshot.nml"
+    loaded_nml = wk.Skeleton.load(snapshot_path)
+
+    assert nml == loaded_nml
+
+
 def test_simple_initialization_and_representations(tmp_path: Path) -> None:
     nml = wk.Skeleton(name="my_skeleton", scale=(0.5, 0.5, 0.5), time=12345)
     nml_path = tmp_path / "my_skeleton.nml"

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -256,3 +256,11 @@ def test_volume_dump_round_trip(tmp_path: Path) -> None:
         volume_out = __parse_volume(next(tree.iter()))
 
     assert volume_in == volume_out
+
+
+def test_load_nml(tmp_path: Path) -> None:
+    input_path = TESTDATA_DIR / "nmls" / "test_a.nml"
+    output_path = tmp_path / "test_a.nml"
+    skeleton_a = wk.Skeleton.load(input_path)
+    skeleton_a.save(output_path)
+    assert skeleton_a == wk.Skeleton.load(output_path)

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -137,6 +137,7 @@ def test_import_from_nml() -> None:
     loaded_nml = wk.Skeleton.load(snapshot_path)
 
     assert nml == loaded_nml
+    nml.get_graph_by_id(1) == 3
 
 
 def test_simple_initialization_and_representations(tmp_path: Path) -> None:

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -136,7 +136,7 @@ def test_import_from_nml() -> None:
     snapshot_path = TESTDATA_DIR / "nmls" / "generated_snapshot.nml"
     loaded_nml = wk.Skeleton.load(snapshot_path)
 
-    assert nml == loaded_nml
+    assert nml == loaded_nml, "NML created by create_dummy_skeleton() should equal NML loaded from disk."
 
 
 def test_simple_initialization_and_representations(tmp_path: Path) -> None:

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -136,7 +136,9 @@ def test_import_from_nml() -> None:
     snapshot_path = TESTDATA_DIR / "nmls" / "generated_snapshot.nml"
     loaded_nml = wk.Skeleton.load(snapshot_path)
 
-    assert nml == loaded_nml, "NML created by create_dummy_skeleton() should equal NML loaded from disk."
+    assert (
+        nml == loaded_nml
+    ), "NML created by create_dummy_skeleton() should equal NML loaded from disk."
 
 
 def test_simple_initialization_and_representations(tmp_path: Path) -> None:

--- a/webknossos/webknossos/skeleton/graph.py
+++ b/webknossos/webknossos/skeleton/graph.py
@@ -1,5 +1,5 @@
 from collections.abc import MutableMapping
-from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Union, cast
+from typing import TYPE_CHECKING, Any, Dict, Iterator, Optional, Tuple, Union
 
 import networkx as nx
 import numpy as np

--- a/webknossos/webknossos/skeleton/graph.py
+++ b/webknossos/webknossos/skeleton/graph.py
@@ -144,12 +144,8 @@ class Graph(nx.Graph):
         )
 
     def __eq__(self, o: object) -> bool:
-        assert isinstance(
-            o, type(self)
-        ), "Can only compare wk.Graph to another wk.Graph."
-        return (
-            self.__to_tuple_for_comparison()
-            == cast("Graph", o).__to_tuple_for_comparison()
+        return isinstance(o, Graph) and (
+            self.__to_tuple_for_comparison() == o.__to_tuple_for_comparison()
         )
 
     @property

--- a/webknossos/webknossos/skeleton/node.py
+++ b/webknossos/webknossos/skeleton/node.py
@@ -8,10 +8,10 @@ if TYPE_CHECKING:
 Vector3 = Tuple[float, float, float]
 
 
-@attr.define()
+@attr.define(order=True)
 class Node:
     position: Vector3
-    _skeleton: "Skeleton" = attr.ib(eq=False, repr=False)
+    _skeleton: "Skeleton" = attr.ib(eq=False, repr=False, order=False)
     _id: int = attr.ib(init=False)
     comment: Optional[str] = None
     radius: Optional[float] = None

--- a/webknossos/webknossos/skeleton/node.py
+++ b/webknossos/webknossos/skeleton/node.py
@@ -8,6 +8,8 @@ if TYPE_CHECKING:
 Vector3 = Tuple[float, float, float]
 
 
+# Defining an order on nodes is necessary to allow to sort them,
+# which is used in the graph's equality check, see Graph.__eq__().
 @attr.define(order=True)
 class Node:
     position: Vector3


### PR DESCRIPTION
### Description:
- Allows to check equality between a Graph and another type, e.g. `my_graph == 3` is false instead of raising an exception.
- Fixes graph equality checks by ordering nodes.

### Issues:
- potential fix for #591

### Todos:
 - [x] Updated Changelog
