### PR TITLE
added name from user_bounding_boxes to returned tuple of coordinates

### DIFF
--- a/webknossos/testdata/nmls/test_sk_bbox_name.nml
+++ b/webknossos/testdata/nmls/test_sk_bbox_name.nml
@@ -1,0 +1,22 @@
+<things>
+  <meta name="writer" content="NmlWriter.scala" />
+  <meta name="writerGitCommit" content="0fd9157b33a02236ba0664de6f682ed5f4d1f056" />
+  <meta name="timestamp" content="1645536953837" />
+  <meta name="annotationId" content="6214d85f010000b40049dd33" />
+  <meta name="username" content="Norman Rzepka" />
+  <parameters>
+    <experiment name="l4dense_motta_et_al_demo" organization="scalable_minds" description="" />
+    <scale x="11.24" y="11.24" z="28.0" />
+    <offset x="0" y="0" z="0" />
+    <time ms="1645533279398" />
+    <editPosition x="2948" y="4359" z="1792" />
+    <editRotation xRot="0.0" yRot="0.0" zRot="0.0" />
+    <zoomLevel zoom="1.0" />
+    <userBoundingBox id="1" name="Foo" isVisible="true" color.r="0.9058823585510254" color.g="0.9686274528503418" color.b="0.05882352963089943" color.a="1.0" topLeftX="2718" topLeftY="4255" topLeftZ="1753" width="196" height="194" depth="78" />
+    <userBoundingBox id="2" name="Bar" isVisible="true" color.r="0.3490196168422699" color.g="0.7058823704719543" color.b="0.5215686559677124" color.a="1.0" topLeftX="2956" topLeftY="4240" topLeftZ="1753" width="196" height="194" depth="78" />
+  </parameters>
+  <branchpoints />
+  <comments />
+  <groups />
+  <volume id="0" location="data_Volume.zip" name="Volume" fallbackLayer="segmentation" />
+</things>

--- a/webknossos/webknossos/skeleton/nml/__init__.py
+++ b/webknossos/webknossos/skeleton/nml/__init__.py
@@ -7,6 +7,7 @@ from loxun import XmlWriter
 Vector3 = Tuple[float, float, float]
 Vector4 = Tuple[float, float, float, float]
 IntVector6 = Tuple[int, int, int, int, int, int]
+MixVector7 = Tuple[int, int, int, int, int, int, str]
 
 T = TypeVar("T")
 
@@ -39,7 +40,7 @@ class NMLParameters(NamedTuple):
         editRotation (Optional[Vector3[float]]): The rotation of the wK camera when creating/downloading an annotation
         zoomLevel (Optional[float]): The zoomLevel of the wK camera when creating/downloading an annotation
         taskBoundingBox (Optional[IntVector6[int]]): A custom bounding box specified as part of a [wK task](https://docs.webknossos.org/webknossos/tasks.html). Will be rendered in wK.
-        userBoundingBoxes (Optional[List[IntVector6[int]]]): A list of custom user-defined bounding boxes. Will be rendered in wK.
+        userBoundingBoxes (Optional[List[MixVector7[int]]]): A list of custom user-defined bounding boxes. Will be rendered in wK.
     """
 
     name: str
@@ -50,7 +51,7 @@ class NMLParameters(NamedTuple):
     editRotation: Optional[Vector3] = None
     zoomLevel: Optional[float] = None
     taskBoundingBox: Optional[IntVector6] = None
-    userBoundingBoxes: Optional[List[IntVector6]] = None
+    userBoundingBoxes: Optional[List[MixVector7]] = None
 
 
 class Node(NamedTuple):
@@ -194,7 +195,7 @@ class NML(NamedTuple):
     volumes: List[Volume] = []
 
 
-def __parse_user_bounding_boxes(nml_parameters: Element) -> Optional[List[IntVector6]]:
+def __parse_user_bounding_boxes(nml_parameters: Element) -> Optional[List[MixVector7]]:
     # ToDo support color, id, name, isVisible attributes pylint: disable=fixme
     # https://github.com/scalableminds/wknml/issues/46
     if nml_parameters.find("userBoundingBox") is None:
@@ -211,7 +212,7 @@ def __parse_task_bounding_box(nml_parameters: Element) -> Optional[IntVector6]:
     return None
 
 
-def __parse_bounding_box(bounding_box_element: Element) -> IntVector6:
+def __parse_bounding_box(bounding_box_element: Element) -> MixVector7:
     return (
         int(bounding_box_element.get("topLeftX", 0)),
         int(bounding_box_element.get("topLeftY", 0)),
@@ -219,6 +220,7 @@ def __parse_bounding_box(bounding_box_element: Element) -> IntVector6:
         int(bounding_box_element.get("width", 0)),
         int(bounding_box_element.get("height", 0)),
         int(bounding_box_element.get("depth", 0)),
+        int(bounding_box_element.get("name", 0)),
     )
 
 
@@ -484,7 +486,7 @@ def __dump_user_bounding_boxes(xf: XmlWriter, parameters: NMLParameters) -> None
 
 
 def __dump_bounding_box(
-    xf: XmlWriter, bounding_box: IntVector6, tag_name: Text
+    xf: XmlWriter, bounding_box: MixVector7, tag_name: Text
 ) -> None:
     xf.tag(
         tag_name,
@@ -495,6 +497,7 @@ def __dump_bounding_box(
             "width": str(bounding_box[3]),
             "height": str(bounding_box[4]),
             "depth": str(bounding_box[5]),
+            "name": str(bounding_box[6]),
         },
     )
 

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -17,6 +17,7 @@ from .group import Group
 
 Vector3 = Tuple[float, float, float]
 IntVector6 = Tuple[int, int, int, int, int, int]
+MixVector7 = Tuple[int, int, int, int, int, int, str]
 
 GroupOrGraph = Union[Group, Graph]
 
@@ -44,7 +45,7 @@ class Skeleton(Group):
     edit_rotation: Optional[Vector3] = None
     zoom_level: Optional[float] = None
     task_bounding_box: Optional[IntVector6] = None
-    user_bounding_boxes: Optional[List[IntVector6]] = None
+    user_bounding_boxes: Optional[List[MixVector7]] = None
 
     _id: int = attr.ib(init=False, repr=False)
     element_id_generator: Iterator[int] = attr.ib(init=False, eq=False, repr=False)


### PR DESCRIPTION
### Description:
- when calling the parameter user_bounding_boxes from a skeleton NML file, this fix adds the name of the user bbox in addition to its coordinates:
```
sk = wk.Skeleton.load("webknossos-libs/webknossos/testdata/nmls/test_sk_bbox_name.nml")
print(sk.user_bounding_boxes)
>>> [(2718, 4255, 1753, 196, 194, 78, 'Foo'), (2956, 4240, 1753, 196, 194, 78, 'Bar')]
```

### Issues:
- fixes #482 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
- [ ] Updated Changelog

- [ ] Pass all tests:
  - for now I get `vcr.errors.CannotOverwriteExistingCassetteException` when calling `poetry run bash test.sh`
  - and `AssertionError: b'{"messages":[{"error":"Annotation couldn\xe2\x80\x99t be found. If the annotation is not public, you need to log in to see it."},{"chain":"[Server Time 2022-02-27 22:40]  <~ Annotation couldn\xe2\x80\x99t be found <~ Annotation couldn\xe2\x80\x99t be found"}]}'` when calling `python __generate_client.py`
  - I am running the webknossos docker container in the background with `./start-docker.sh`
  - If I run the script `./webknossos/tools/postgres/prepareTestDB.sh` followed by `poetry run bash test.sh --refresh-snapshots` I get `The login user user_A@scalableminds.com could not be found or changed.`

- [ ] Make Docs