### PR TITLE
Share dataset instances by caching them

### DIFF
--- a/webknossos/stubs/boltons/cacheutils/__init__.py
+++ b/webknossos/stubs/boltons/cacheutils/__init__.py
@@ -20,3 +20,6 @@ class cachedproperty(Generic[T, KT]):
 class LRU(dict):
     def __init__(self, max_size: Optional[int]):
         ...
+
+    def clear(self) -> None:
+        ...

--- a/webknossos/stubs/boltons/cacheutils/__init__.py
+++ b/webknossos/stubs/boltons/cacheutils/__init__.py
@@ -15,3 +15,8 @@ class cachedproperty(Generic[T, KT]):
 
     def __get__(self, obj: Any, objtype: Optional[Type]) -> T:
         ...
+
+
+class LRU(dict):
+    def __init__(self, max_size: Optional[int]):
+        ...

--- a/webknossos/tests/conftest.py
+++ b/webknossos/tests/conftest.py
@@ -17,6 +17,7 @@ from vcr.stubs import httpx_stubs
 
 import webknossos as wk
 from webknossos.client.context import _clear_all_context_caches
+from webknossos.dataset.dataset import _clear_instance_cache
 
 from .constants import TESTOUTPUT_DIR
 
@@ -63,6 +64,12 @@ def clear_testoutput() -> Generator:
 @pytest.fixture(autouse=True, scope="function")
 def clear_context_caches() -> Generator:
     _clear_all_context_caches()
+    yield
+
+
+@pytest.fixture(autouse=True, scope="function")
+def clear_instance_cache() -> Generator:
+    _clear_instance_cache()
     yield
 
 

--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -19,7 +19,7 @@ from webknossos.dataset import (
     SegmentationLayer,
     View,
 )
-from webknossos.dataset.dataset import PROPERTIES_FILE_NAME, _clear_instance_cache
+from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
 from webknossos.dataset.properties import (
     DatasetProperties,
     DatasetViewConfiguration,

--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -19,7 +19,7 @@ from webknossos.dataset import (
     SegmentationLayer,
     View,
 )
-from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
+from webknossos.dataset.dataset import PROPERTIES_FILE_NAME, _clear_instance_cache
 from webknossos.dataset.properties import (
     DatasetProperties,
     DatasetViewConfiguration,
@@ -1346,7 +1346,9 @@ def test_search_dataset_also_for_long_layer_name() -> None:
     mag.read(absolute_offset=(20, 20, 20), size=(20, 20, 20))
 
     # when opening the dataset, it searches both for the long and the short path
-    layer = Dataset.open(TESTOUTPUT_DIR / "long_layer_name").get_layer("color")
+    layer = Dataset.open(
+        TESTOUTPUT_DIR / "long_layer_name", dont_use_instance_cache=True
+    ).get_layer("color")
     mag = layer.get_mag("2")
     assert np.array_equal(
         mag.read(absolute_offset=(20, 20, 20), size=(20, 20, 20)),

--- a/webknossos/tests/test_dataset_deprecated.py
+++ b/webknossos/tests/test_dataset_deprecated.py
@@ -1285,7 +1285,9 @@ def test_search_dataset_also_for_long_layer_name() -> None:
     mag.read(relative_offset=(10, 10, 10), size=(10, 10, 10))
 
     # when opening the dataset, it searches both for the long and the short path
-    layer = Dataset.open(TESTOUTPUT_DIR / "long_layer_name").get_layer("color")
+    layer = Dataset.open(
+        TESTOUTPUT_DIR / "long_layer_name", dont_use_instance_cache=True
+    ).get_layer("color")
     mag = layer.get_mag("2")
     assert np.array_equal(
         mag.read(offset=(10, 10, 10), size=(10, 10, 10)), np.expand_dims(write_data, 0)

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -887,12 +887,12 @@ class Dataset:
 
     def _assert_equal_scale(
         self, dataset_path: Path, scale: Tuple[float, float, float]
-    ):
+    ) -> None:
         assert self.scale == tuple(
             scale
         ), f"Cannot open Dataset: The dataset {dataset_path} already exists, but the scales do not match ({self.scale} != {scale})"
 
-    def _assert_equal_name(self, dataset_path: Path, name: str):
+    def _assert_equal_name(self, dataset_path: Path, name: str) -> None:
         assert (
             self.name == name
         ), f"Cannot open Dataset: The dataset {dataset_path} already exists, but the names do not match ({self.name} != {name})"

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -76,7 +76,7 @@ _UNSPECIFIED_SCALE_FROM_OPEN = make_sentinel(
 instance_cache = LRU(max_size=1024)
 
 
-def _clear_instance_cache():
+def _clear_instance_cache() -> None:
     instance_cache.clear()
 
 
@@ -126,7 +126,7 @@ class Dataset:
 
         return instance
 
-    def __reduce__(self):
+    def __reduce__(self) -> Tuple[Any, Any]:
         # When unpickling an instance of Dataset, __new__ will be called
         # with __class__ and the following parameters.
         # Defining this __reduce__ method is necessary, as we are overriding
@@ -277,9 +277,6 @@ class Dataset:
         instance_cache[dataset_path] = instance
 
         return instance
-
-    def __reduce__(self):
-        return (self.__class__, (self.path, self.scale, self.name, True))
 
     @classmethod
     def download(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -24,7 +24,7 @@ from typing import (
 import attr
 import numpy as np
 import wkw
-from boltons.cacheutils import LRU, cachedmethod
+from boltons.cacheutils import LRU
 from boltons.typeutils import make_sentinel
 
 if TYPE_CHECKING:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -20,11 +20,11 @@ from typing import (
     Union,
     cast,
 )
-from boltons.cacheutils import cachedmethod, LRU
 
 import attr
 import numpy as np
 import wkw
+from boltons.cacheutils import LRU, cachedmethod
 from boltons.typeutils import make_sentinel
 
 if TYPE_CHECKING:

--- a/wkcuber/tests/test_downsampling.py
+++ b/wkcuber/tests/test_downsampling.py
@@ -83,9 +83,9 @@ def test_non_linear_filter_reshape() -> None:
     assert np.all(expected_result == a_filtered)
 
 
-def downsample_test_helper(use_compress: bool) -> None:
+def downsample_test_helper(use_compress: bool, output_suffix: str) -> None:
     source_path = TESTDATA_DIR / "WT1_wkw"
-    target_path = TESTOUTPUT_DIR / "WT1_wkw"
+    target_path = TESTOUTPUT_DIR / f"WT1_wkw_{output_suffix}"
 
     source_ds = Dataset.open(source_path)
     target_ds = source_ds.copy_dataset(target_path, block_len=16, file_len=16)
@@ -135,13 +135,13 @@ def downsample_test_helper(use_compress: bool) -> None:
 
 
 def test_downsample_cube_job() -> None:
-    downsample_test_helper(False)
+    downsample_test_helper(False, "no_compression")
 
 
 def test_compressed_downsample_cube_job() -> None:
     with warnings.catch_warnings():
         warnings.filterwarnings("error")  # This escalates the warning to an error
-        downsample_test_helper(True)
+        downsample_test_helper(True, "with_compression")
 
 
 def test_downsample_multi_channel() -> None:


### PR DESCRIPTION
### Description:
- By default, dataset instances are now shared by caching them.
- Use `dont_use_instance_cache=True` to avoid this (used in one test, too)

### Issues:
- contributes to [#524](https://github.com/scalableminds/webknossos-libs/issues/524)

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
