### PR TITLE
CI: don't run everything twice in PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - master
-  pull_request:
+  pull_request: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+    - master
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Runs CI only for push on master, to get CI feedback on branches, please open a draft PR

Taken from https://github.community/t/how-to-trigger-an-action-on-push-or-pull-request-but-not-both/16662

before:
![Screenshot from 2022-02-28 17-37-34](https://user-images.githubusercontent.com/7216331/156021992-8f060b97-2913-4c72-83dd-665d9c80ac06.png)

after (see the names, job status does not matter):
![Screenshot from 2022-02-28 17-37-48](https://user-images.githubusercontent.com/7216331/156021987-2cd05b28-5fe8-4b54-94e4-ad54d71be06d.png)
