### PR TITLE
CI: run on tag pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
     - master
+    tags:        
+    - '**'
   pull_request: {}
 
 concurrency:


### PR DESCRIPTION
### Description:
- When fixing duplicated runs in #616 I also blocked tags from running accidentally, this PR fixes it.

see https://stackoverflow.com/questions/61891328/trigger-github-action-only-on-new-tags