### PR TITLE
Added method to validate dataset names

### DIFF
--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -140,7 +140,7 @@ class Dataset:
             name = name or basename(normpath(dataset_path))
             assert self._is_valid_dataset_name(
                 name
-            ), "Invalid name. A dataset name can only contain letters, digits and underscores"
+            ), f"Invalid name {name}. A dataset name can only contain letters, digits and underscores."
 
             dataset_properties = DatasetProperties(
                 id={"name": name, "team": ""}, scale=scale, data_layers=[]

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -136,7 +136,12 @@ class Dataset:
             assert (
                 scale is not None
             ), "When creating a new dataset, the scale must be given, e.g. as Dataset(path, scale=(10, 10, 16.8))"
+
             name = name or basename(normpath(dataset_path))
+            assert self._is_valid_dataset_name(
+                name
+            ), "Invalid name. A dataset name can only contain letters, digits and underscores"
+
             dataset_properties = DatasetProperties(
                 id={"name": name, "team": ""}, scale=scale, data_layers=[]
             )
@@ -842,3 +847,24 @@ class Dataset:
             raise RuntimeError(
                 f"Failed to initialize layer: the specified category ({properties.category}) does not exist."
             )
+
+    def _is_valid_dataset_name(self, name: str) -> bool:
+        forbidden_characters = [
+            " ",
+            "!",
+            ":",
+            "#",
+            ";",
+            "@",
+            "+",
+            "*",
+            "?",
+            "=",
+            "(",
+            ")",
+            "/",
+            "%",
+            "&",
+            "$",
+        ]
+        return not any([character in name for character in forbidden_characters])


### PR DESCRIPTION
### Description:
- During our webinar yesterday, I discovered that the webKnossos server blocks the upload of some datasets if the contain forbidden characters / ill-formed dataset names. 
- I added a simple name validation method to block the most common bad characters. I am not sure exactly what the backend check is using. This should hopefully catch most cases.


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
