### PR TITLE
bugfix: Move warning to correct function, extension of #624

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -14,7 +14,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
-- Dataset: Moved the deprecation warning from `get_color_layers()` to the actually deprecate method `get_color_layer()`.
+- Dataset: Moved the deprecation warning from `get_color_layers()` to the actually deprecated method `get_color_layer()`.
   [#635](https://github.com/scalableminds/webknossos-libs/pull/635)
 
 ### Fixed

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -14,6 +14,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Dataset: Moved the deprecation warning from `get_color_layers()` to the actually deprecate method `get_color_layer()`.
+  [#635](https://github.com/scalableminds/webknossos-libs/pull/635)
 
 ### Fixed
 

--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -1758,13 +1758,11 @@ def test_get_or_add_layer_by_type(tmp_path: Path) -> None:
     )  # adds another layer
     assert len(ds.get_segmentation_layers()) == 2
 
-    with pytest.raises(IndexError):
-        ds.get_color_layer()  # fails
+    assert len(ds.get_color_layers()) == 0
     _ = ds.add_layer("color", COLOR_CATEGORY)  # adds layer
-    _ = ds.get_color_layer()  # works
+    assert len(ds.get_color_layers()) == 1
     _ = ds.add_layer("different_color", COLOR_CATEGORY)  # adds another layer
-    with pytest.raises(IndexError):
-        ds.get_color_layer()  # fails
+    assert len(ds.get_color_layers()) == 2
 
     assure_exported_properties(ds)
 

--- a/webknossos/tests/test_dataset_deprecated.py
+++ b/webknossos/tests/test_dataset_deprecated.py
@@ -1745,13 +1745,11 @@ def test_get_or_add_layer_by_type(tmp_path: Path) -> None:
     )  # adds another layer
     assert len(ds.get_segmentation_layers()) == 2
 
-    with pytest.raises(IndexError):
-        ds.get_color_layer()  # fails
+    assert len(ds.get_color_layers()) == 0
     _ = ds.add_layer("color", COLOR_CATEGORY)  # adds layer
-    _ = ds.get_color_layer()  # works
+    assert len(ds.get_color_layers()) == 1
     _ = ds.add_layer("different_color", COLOR_CATEGORY)  # adds another layer
-    with pytest.raises(IndexError):
-        ds.get_color_layer()  # fails
+    assert len(ds.get_color_layers()) == 2
 
     assure_exported_properties(ds)
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -504,9 +504,9 @@ class Dataset:
 
     def get_segmentation_layer(self) -> SegmentationLayer:
         """
-        Returns the only segmentation layer. Prefer `get_segmentation_layers`,
-        because multiple segmentation layers can exist.
+        Deprecated, please use `get_segmentation_layers()`.
 
+        Returns the only segmentation layer.
         Fails with a IndexError if there are multiple segmentation layers or none.
         """
 
@@ -530,20 +530,20 @@ class Dataset:
 
     def get_color_layer(self) -> Layer:
         """
-        Returns the only color layer. Prefer `get_color_layers`, because multiple
-        color layers can exist.
+        Deprecated, please use `get_color_layers()`.
 
+        Returns the only color layer.
         Fails with a RuntimeError if there are multiple color layers or none.
         """
+        warnings.warn(
+            "[DEPRECATION] get_color_layer() fails if no or more than one color layer exists. Prefer get_color_layers()."
+        )
         return self._get_layer_by_category(COLOR_CATEGORY)
 
     def get_color_layers(self) -> List[Layer]:
         """
         Returns all color layers.
         """
-        warnings.warn(
-            "[DEPRECATION] get_color_layer() fails if no or more than one color layer exists. Prefer get_color_layers()."
-        )
         return [
             cast(Layer, layer)
             for layer in self.layers.values()


### PR DESCRIPTION
Moved the deprecation warning from `Dataset.get_color_layers()` to the actually deprecated method `get_color_layer()`.

Credits to go @erjel for providing the original PR #624, thanks a lot! This PR adds some minor fixes in the tests.

### Todos:
 - [x] Updated Changelog
