### PR TITLE
Use annotation-provided scale for temp volume annotation

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Annotation: `Annotation.temporary_volume_layer_copy` now uses the NML-provided `scale`. [#644](https://github.com/scalableminds/webknossos-libs/pull/644)
 - Dataset: Moved the deprecation warning from `get_color_layers()` to the actually deprecated method `get_color_layer()`.
   [#635](https://github.com/scalableminds/webknossos-libs/pull/635)
 - Inconsistent writes to datasets properties (e.g., caused due to multiprocessing) are detected automatically. The warning can be escalated to an exception with `warnings.filterwarnings("error", module="webknossos", message=r"\[WARNING\]")`. [#633](https://github.com/scalableminds/webknossos-libs/pull/633)

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import (
+from typing import ((
     BinaryIO,
     ContextManager,
     Dict,
@@ -600,7 +600,7 @@ class Annotation:
             )
 
         input_annotation_dataset = Dataset(
-            str(tmp_annotation_dataset_path), scale=(1, 1, 1), exist_ok=True
+            str(tmp_annotation_dataset_path), scale=self.scale, exist_ok=True
         )
 
         input_annotation_layer = self.export_volume_layer_to_dataset(

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -599,18 +599,20 @@ class Annotation:
                 Path(tmp_annotation_dir) / "tmp_annotation_dataset"
             )
 
-        input_annotation_dataset = Dataset(
-            str(tmp_annotation_dataset_path), scale=self.scale, exist_ok=True
-        )
+            input_annotation_dataset = Dataset(
+                tmp_annotation_dataset_path,
+                scale=self.scale,
+                name="tmp_annotation_dataset",
+            )
 
-        input_annotation_layer = self.export_volume_layer_to_dataset(
-            input_annotation_dataset,
-            "volume_layer",
-            volume_layer_name=volume_layer_name,
-            volume_layer_id=volume_layer_id,
-        )
+            input_annotation_layer = self.export_volume_layer_to_dataset(
+                input_annotation_dataset,
+                "volume_layer",
+                volume_layer_name=volume_layer_name,
+                volume_layer_id=volume_layer_id,
+            )
 
-        yield input_annotation_layer
+            yield input_annotation_layer
 
 
 Annotation._set_init_docstring()

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -7,7 +7,7 @@ from io import BytesIO
 from os import PathLike
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import ((
+from typing import (
     BinaryIO,
     ContextManager,
     Dict,

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -595,14 +595,11 @@ class Annotation:
         """
 
         with TemporaryDirectory() as tmp_annotation_dir:
-            tmp_annotation_dataset_path = (
-                Path(tmp_annotation_dir) / "tmp_annotation_dataset"
-            )
-
             input_annotation_dataset = Dataset(
-                tmp_annotation_dataset_path,
-                scale=self.scale,
+                tmp_annotation_dir,
                 name="tmp_annotation_dataset",
+                scale=self.scale,
+                exist_ok=True,
             )
 
             input_annotation_layer = self.export_volume_layer_to_dataset(


### PR DESCRIPTION
### Description:
- Use the scale that is provided in the NML for the temp volume annotation in `Annotation.temporary_volume_layer_copy`

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
