### PR TITLE
CI: use ref_type for checks if branch or tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -332,7 +332,7 @@ jobs:
         docker push scalableminds/webknossos-cuber:$GITHUB_SHA
 
     - name: Push docker images (for tag)
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.ref_type == 'tag'
       run: |
         CI_TAG=$(git describe --tags)
         docker tag \
@@ -341,7 +341,7 @@ jobs:
         docker push scalableminds/webknossos-cuber:$CI_TAG
 
     - name: Push docker images (for branch)
-      if: startsWith(github.event.ref, 'refs/heads')
+      if: github.ref_type == 'branch'
       run: |
         CI_BRANCH=${GITHUB_REF##*/}
         NORMALIZED_CI_BRANCH=${CI_BRANCH//[\/-]/_}
@@ -386,7 +386,7 @@ jobs:
         docs/generate.sh --persist
 
     - name: Push docs (for branch)
-      if: startsWith(github.event.ref, 'refs/heads')
+      if: github.ref_type == 'branch'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -397,7 +397,7 @@ jobs:
         aws s3 sync --acl public-read docs/out s3://static.webknossos.org/docs/${NORMALIZED_CI_BRANCH}
 
     - name: Push docs (for tag)
-      if: startsWith(github.event.ref, 'refs/tags')
+      if: github.ref_type == 'tag'
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -423,7 +423,7 @@ jobs:
       always() &&
       !contains(needs.*.result, 'failure') &&
       !contains(needs.*.result, 'cancelled') &&
-      startsWith(github.event.ref, 'refs/tags') &&
+      github.ref_type == 'tag' &&
       !github.event.pull_request.head.repo.fork
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
### Description:
Before, steps that should only run on branches did not run for pull-requests (push on master still worked, though). This PR fixes this by using the [`github.ref_type` context variable](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context) for the branch vs tag checks.
See [this CI run](https://github.com/scalableminds/webknossos-libs/runs/5542507187?check_suite_focus=true) for a skipped step (`Push docs (for branch)`) that should have been run instead.

