### PR TITLE
bugfix: Missing default values for optional parameters in _get_volume_layer

### DIFF
--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -453,8 +453,8 @@ class Annotation:
 
     def _get_volume_layer(
         self,
-        volume_layer_name: Optional[str],
-        volume_layer_id: Optional[int],
+        volume_layer_name: Optional[str] = None,
+        volume_layer_id: Optional[int] = None,
     ) -> _VolumeLayer:
         assert len(self._volume_layers) > 0, "No volume annotations present."
 


### PR DESCRIPTION
### Description:
Missing default parameters for method `_get_volume_layer`.

Currently, the method can not be used without parameters.
So either delete the `Optional` or add default parameters.

Otherwise the first `if` [statement](https://github.com/erjel/webknossos-libs/blob/a5550c1833e6b11f7ca5993f08925b98269c415d/webknossos/webknossos/annotation/annotation.py#L461
) is only a special case of the ones that follow.

