### PR TITLE
FinishUpload: stop retrying on error

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Fixed
 
+- Fixed a bug where the server’s error message during dataset upload was not displayed to the user. [#702](https://github.com/scalableminds/webknossos-libs/pull/702)
+
 
 ## [0.9.19](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.9.19) - 2022-04-11
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.9.18...v0.9.19)

--- a/webknossos/webknossos/client/_upload_dataset.py
+++ b/webknossos/webknossos/client/_upload_dataset.py
@@ -174,9 +174,8 @@ def upload_dataset(
                 }
             ),
         )
-        if response.status_code == 200:
+        if response.status_code == 200 or response.status_code == 400:
             break
-    else:
-        assert response.status_code == 200, response
+    assert response.status_code == 200, response
 
     return f"{context.url}/datasets/{context.organization_id}/{new_dataset_name}/view"


### PR DESCRIPTION
In the webKnossos backend API, the finishUpload call is not idempotent. It should thus not be retried if the server has answered with 400 (only if there was a network error).

Note that the for/else statement had to go, as the break in the 400 case led to the assertion not being executed.

### Todos:
 - [x] Updated Changelog
