### PR TITLE
Restrict pyproject.toml to Python 3.7 and 3.8

### DIFF
--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -10,7 +10,7 @@ homepage = "https://docs.webknossos.org/webknossos-py"
 include = ["webknossos/version.py"]  # included explicitly since it's in .gitignore
 
 [tool.poetry.dependencies]
-python = "^3.7,>=3.7.1"
+python = ">=3.7.1,<3.9"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
 cattrs = "1.7.1"


### PR DESCRIPTION
### Description:
- As noted in #https://github.com/scalableminds/webknossos-libs/issues/257, PyPi and the widget in our readme lists `webKnossos` as Py `3.9`, and `3.10` compatible, which is not the case.
- This PR restricts the supported versions in the `pyproject.toml`, to Python `3.7` and `3.8` as tested by the CI.

### Issues:
- related to #257 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
