### PR TITLE
Fix upsampling with constant z

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixed upsampling with constant z in certain anisotropic cases. [#720](https://github.com/scalableminds/webknossos-libs/pull/720)
 
 
 ## [0.9.23](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.9.23) - 2022-05-03

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -924,7 +924,7 @@ class Layer:
             finest_mag_with_fixed_z = finest_mag.to_list()
             finest_mag_with_fixed_z[2] = from_mag.to_list()[2]
             finest_mag = Mag(finest_mag_with_fixed_z)
-            voxel_size = self.dataset.voxel_size
+            voxel_size = None
         else:
             raise AttributeError(
                 f"Upsampling failed: {sampling_mode} is not a valid UpsamplingMode ({SamplingModes.ANISOTROPIC}, {SamplingModes.ISOTROPIC}, {SamplingModes.CONSTANT_Z})"


### PR DESCRIPTION
### Description:
The previous upsampling code broke with constant z upsampling, when the voxel-size ratio was not constant, see #713.
`calculate_mags_to_upsample` / `calculate_mags_to_downsample` expects the `voxel_size` to be None in case of constant z, which is fixed in this PR.

### Issues:
- fixes #713

### Todos:
 - [x] Updated Changelog
