### PR TITLE
webknossos_context: Guard against trailing slashes in URL

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,7 +20,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 - added Python 3.9 support to wk-libs [#716](https://github.com/scalableminds/webknossos-libs/pull/716)
 
 ### Fixed
-
+- URLs for the webknossos-context (e.g. in the `WK_URL` env var or via `webknossos_context(url=…)`) may now contain `/` in the end and are sanitized. Before, requests would fail if the URL contained a final `/`. [#733](https://github.com/scalableminds/webknossos-libs/pull/733)
 
 ## [0.10.1](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.1) - 2022-05-10
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.0...v0.10.1)

--- a/webknossos/tests/client/test_context.py
+++ b/webknossos/tests/client/test_context.py
@@ -1,6 +1,10 @@
 import pytest
 
-from webknossos.client.context import _get_context, _WebknossosContext, webknossos_context
+from webknossos.client.context import (
+    _get_context,
+    _WebknossosContext,
+    webknossos_context,
+)
 
 pytestmark = [pytest.mark.with_vcr]
 
@@ -18,5 +22,5 @@ def test_user_organization(env_context: _WebknossosContext) -> None:
 
 
 def test_trailing_slash_in_url(env_context: _WebknossosContext) -> None:
-    with webknossos_context(url=env_context + "/"):
+    with webknossos_context(url=env_context.url + "/"):
         assert env_context.url == _get_context().url

--- a/webknossos/tests/client/test_context.py
+++ b/webknossos/tests/client/test_context.py
@@ -1,6 +1,6 @@
 import pytest
 
-from webknossos.client.context import _get_context, _WebknossosContext
+from webknossos.client.context import _get_context, _WebknossosContext, webknossos_context
 
 pytestmark = [pytest.mark.with_vcr]
 
@@ -15,3 +15,8 @@ def env_context() -> _WebknossosContext:
 
 def test_user_organization(env_context: _WebknossosContext) -> None:
     assert env_context.organization_id == "Organization_X"
+
+
+def test_trailing_slash_in_url(env_context: _WebknossosContext) -> None:
+    with webknossos_context(url=env_context + "/"):
+        assert env_context.url == _get_context().url

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -123,7 +123,7 @@ def _clear_all_context_caches() -> None:
 
 @attr.frozen
 class _WebknossosContext:
-    url: str = os.environ.get("WK_URL", default=DEFAULT_WEBKNOSSOS_URL)
+    url: str = os.environ.get("WK_URL", default=DEFAULT_WEBKNOSSOS_URL).rstrip("/")
     token: Optional[str] = os.environ.get("WK_TOKEN", default=None)
     timeout: int = int(os.environ.get("WK_TIMEOUT", default=DEFAULT_HTTP_TIMEOUT))
 
@@ -204,7 +204,7 @@ class webknossos_context(ContextDecorator):
         `url` and `timeout` are taken from the previous context (e.g. environment variables) if not specified.
         `token` must be set explicitly, it is not available when not specified.
         """
-        self._url = _get_context().url if url is None else url
+        self._url = _get_context().url if url is None else url.rstrip("/")
         self._token = token
         self._timeout = _get_context().timeout if timeout is None else timeout
         self._context_var_token_stack: List[Token[_WebknossosContext]] = []


### PR DESCRIPTION
### Description:
URLs for the webknossos-context (e.g. in the `WK_URL` env var or via `webknossos_context(url=…)`) may now contain `/` in the end and are sanitized. Before, requests would fail if the URL contained a final `/`.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
