### PR TITLE
Add Contributing Guide & Code of Conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,35 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: bug
+assignees: ''
+
+---
+
+## Context
+- Affected library: e.g. webknossos or wkcuber
+<!--- In what context did your bug occur? -->
+<!--- Providing context helps us come up with a solution that is most useful. -->
+
+## Expected Behavior
+<!--- What should should happen instead of the bug / error message. -->
+
+## Current Behavior
+<!--- What happens instead of the expected behavior? -->
+
+## Steps to Reproduce the bug
+<!-- If the bug is hard to reproduce check the following: -->
+- [ ] Cannot reproduce the bug anymore / needs deeper investigation.
+<!--- If you can reproduce the bug, provide a list of actions to reproduce the bug. -->
+
+1.
+2.
+3.
+4.
+
+## Your Environment for bug
+<!--- In what environment did the bug occur? -->
+- Operating System and version: e.g. Windows 10
+- Version of webKnossos-libs (Release or Commit):
+  (can be found e.g. with `pip show webknossos` or `wkcuber --version`)

--- a/.github/ISSUE_TEMPLATE/feature_suggestion.md
+++ b/.github/ISSUE_TEMPLATE/feature_suggestion.md
@@ -1,0 +1,16 @@
+---
+name: Feature suggestion
+about: Suggest an idea for this project
+title: ''
+labels: enhancement
+assignees: ''
+
+---
+
+## Detailed Description
+- Affected library: e.g. webknossos or wkcuber
+<!--- Provide a detailed description of the change or new feature you would like to have. -->
+
+## Use Cases & Context
+<!--- Describe use cases where this feature is missing. -->
+<!--- Why is this change / new feature important ?  -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,3 +7,6 @@
 ### Todos:
 Make sure to delete unnecessary points or to check all before merging:
  - [ ] Updated Changelog
+ - [ ] Updated Documentation
+ - [ ] Added / Updated Tests
+ - [ ] Considered adding this to the Examples

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -38,7 +38,7 @@ This Code of Conduct applies both within project spaces and in public spaces whe
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [norman@webknossos.org](mailto:norman@webknossos.org) or [tom@webknossos.org](mailto:tom@webknossos.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [hello@webknossos.org](mailto:hello@webknossos.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
 
 Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,48 @@
+# Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at [norman@webknossos.org](mailto:norman@webknossos.org) or [tom@webknossos.org](mailto:tom@webknossos.org). The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org), version 1.4, available at [http://contributor-covenant.org/version/1/4](http://contributor-covenant.org/version/1/4/)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,15 @@ Then, please [add an issue using the feature suggestion template](https://github
 
 ## Pull Requests: Docs and Code Contributions
 
+This project welcomes contributions and suggestions. Most contributions require you to
+agree to a Contributor License Agreement (CLA) declaring that you have the right to,
+and actually do, grant us the rights to use your contribution. For details, visit
+https://cla-assistant.io/scalableminds/webknossos-libs.
+
+When you submit a pull request, a CLA-bot will automatically determine whether you need
+to provide a CLA and decorate the PR appropriately (e.g., label, comment). Simply follow the
+instructions provided by the bot. You will only need to do this once using our CLA.
+
 If you want to fix a minor problem in the documentation, examples or other code, feel free to
 [open a pull requests for it on GitHub](https://github.com/scalableminds/webknossos-libs/compare)
 (read more about [pull requests here](https://docs.github.com/en/pull-requests).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,89 @@
-# Contributions & Development
+# Contributing Guide
 
-## How to contribute
+**Welcome to the webKnossos-libs contributing guide :sparkles: **
+
+Thank you for taking the time to contribute to this project! The following is a set of guidelines for contributing to the different webKnossos related Python libraries, which are part of the [webKnossos-libs repository on GitHub](https://github.com/scalableminds/webknossos-libs). These are mostly guidelines, not rules. Use your best judgment, and feel free to propose changes to this document in a pull request.
+
+## Code of Conduct
+
+webKnossos-libs and everyone contributing and collaborating on this project is expected to follow the [webKnossos-libs Code of Conduct](CODE_OF_CONDUCT.md). Please report unacceptable behavior to [hello@webknossos.org](mailto:hello@webknossos.org).
+
+
+## How can I help?
 
 We welcome community feedback and contributions! We are happy to have
 
-* general feedback and questions on the [image.sc forum](https://forum.image.sc/tag/webknossos),
-* feature requests and bug reports as [issues on GitHub](https://github.com/scalableminds/webknossos-libs/issues/new),
-* documentation, examples and code contributions as [pull requests on GitHub](https://github.com/scalableminds/webknossos-libs/compare).
+* [general feedback, observations and questions](#feedback-observations-and-questions) on the [image.sc forum](https://forum.image.sc/tag/webknossos),
+* [feature suggestions and bug reports](#issues-feature-suggestions-and-bug-reports) as [issues on GitHub](https://github.com/scalableminds/webknossos-libs/issues/new),
+* [documentation, examples and code contributions](#pull-requests-docs-and-code-contributions) as [pull requests on GitHub](https://github.com/scalableminds/webknossos-libs/compare).
 
 
-## Development
+## Feedback, Observations and Questions
+
+We'd love to hear your feedback on the webKnossos Python libraries!
+We're also interested in hearing if these tools don't work for your usecase,
+or if you have questions regarding their usage.
+
+Please leave a message on the [image.sc forum](https://forum.image.sc/tag/webknossos)
+using the `webknossos` tag to enable public communication on those topics.
+If you prefer to share information only with the webKnossos team, please write an email
+to [hello@webknossos.org](mailto:hello@webknossos.org). For commercial support please
+reach out to [scalable minds](https://scalableminds.com).
+
+
+## Issues: Feature Suggestions and Bug Reports
+
+We track feature requests and bug reports in the [webKnossos-libs repository issues](https://github.com/scalableminds/webknossos-libs/issues).
+Before opening a new issue, please do a quick search of existing issues to make sure your suggestion hasn’t already been added.
+If your issue doesn’t already exist, and you’re ready to create a new one, make sure to state what you would like to implement, improve or bugfix.
+Please use one of the provided templates to make this process easier for you.
+
+You can submit an issue [here](https://github.com/scalableminds/webknossos-libs/issues/new)
+(read more about [issues here](https://docs.github.com/en/issues)).
+
+
+### Report a Bug :lady_beetle:
+
+When you find a bug, please double-check if an issue for the same bug exists already.
+If that's not the case, please verify in the [documentation](https://docs.webknossos.org/api/webknossos.html)
+that you use the API as intended. If that's the case, please
+[add an issue using the bug report template](https://github.com/scalableminds/webknossos/issues/new?template=bug_report.md).
+
+
+### Suggest a New Feature
+
+If you are missing a feature to support your use-case, please consider the following points:
+
+1. Please verify if this feature is directly related to webKnossos.
+   Does it belong into the webKnossos Python libraries?
+2. Double-check if an issue for this feature exists already. If there is one with a very similar scope,
+   please considering commenting there.
+3. If possible, consider how the implementation might look like (e.g. how would the public API change),
+   as well as how this could be tested and presented in the examples.
+
+Then, please [add an issue using the feature suggestion template](https://github.com/scalableminds/webknossos/issues/new?template=feature_suggestion.md).
+
+
+## Pull Requests: Docs and Code Contributions
+
+If you want to fix a minor problem in the documentation, examples or other code, feel free to
+[open a pull requests for it on GitHub](https://github.com/scalableminds/webknossos-libs/compare)
+(read more about [pull requests here](https://docs.github.com/en/pull-requests).
+
+For larger features and changes, we prefer that you open a new issue before creating a pull request.
+Please include the following in your pull request:
+
+* The pull request description should explain what you've done.
+* Add tests for the new features.
+* Comply with the coding styles.
+* Adapt or add the documentation.
+* Consider enhancing the examples.
+
+The specific coding styles, test frameworks and documentation setup of webKnossos-libs are described
+in the following sections:
+
+
+### Development
 
 The [webknossos-libs repository](https://github.com/scalableminds/webknossos-libs) is structured as a mono-repo, containing multiple packages:
 
@@ -30,7 +104,7 @@ See below for specifics of the different packages. Let's have a look at the comm
   [`pip install -f requirements.txt`](https://github.com/scalableminds/webknossos-libs/blob/master/requirements.txt)
 
   To install the dependencies for all sub-projects, run `make install`.
-* **Tooling** we use across the sub-projects:
+* **Tooling** we use across the sub-projects to enforce coding styles and tests:
     * `format.sh`: black and isort
     * `lint.sh`: pylint
     * `typecheck.sh`: mypy
@@ -49,7 +123,7 @@ Internal workflows for scalable minds:
   This updates the changelog and pushes a new tag, which triggers another CI run building and publishing the package.
 
 
-### `webknossos` package
+#### `webknossos` package
 
 The `webknossos` folder contains examples, which are not part of the package, but are tested via `tests/test_examples.py` and added to the documentation (see `docs/src/webknossos-py/examples`).
 
@@ -69,7 +143,7 @@ To re-generate the code, run
 ```
 
 
-### `wkcuber` package
+#### `wkcuber` package
 
 Currently the test setup consists of different scripts as well as pytest tests. The following commands are run in CI:
 ```bash
@@ -81,14 +155,14 @@ poetry run tests/scripts/all_tests.sh
 There is also a `test.sh` which is currently outdated, see [issue #580](https://github.com/scalableminds/webknossos-libs/issues/580).
 
 
-### `cluster_tools` package
+#### `cluster_tools` package
 
 For testing the `slurm` setup a docker-compose setup is available. Please see the [respective Readme](https://github.com/scalableminds/webknossos-libs/blob/master/cluster_tools/README.md) for details.
 
 For testing the `kubernetes` setup, we recommend a [Kubernetes-in-Docker setup](https://kind.sigs.k8s.io/).
 
 
-## Documentation
+### Documentation
 
 We render a common documentation for webKnossos itself and webknossos-libs from this repository using [mkdocs](https://www.mkdocs.org/). Source-files for the documentation are stored at `docs/src`:
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -105,11 +105,13 @@ nav:
       - User: api/webknossos/administration/user.md
       - Project: api/webknossos/administration/project.md
       - Task: api/webknossos/administration/task.md
-  - Other:
-    - webknossos-py/changelog.md
+  - Version Changelog:
     - webknossos-py/stability_policy.md
+    - webknossos-py/changelog.md
+  - Community:
+    - webknossos-py/CONTRIBUTING.md
+    - webknossos-py/CODE_OF_CONDUCT.md
     - Getting Help:
-      - webknossos-py/development.md
       - Community Support: https://forum.image.sc/tag/webknossos" target="_blank
       - Email Support: mailto:hello@webknossos.org
       - Commercial Support: https://scalableminds.com" target="_blank

--- a/docs/src/webknossos-py/CODE_OF_CONDUCT.md
+++ b/docs/src/webknossos-py/CODE_OF_CONDUCT.md
@@ -1,0 +1,1 @@
+../../../CODE_OF_CONDUCT.md

--- a/docs/src/webknossos-py/CONTRIBUTING.md
+++ b/docs/src/webknossos-py/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+../../../CONTRIBUTING.md


### PR DESCRIPTION
### Description:
- Changes the current `Contributions & Development` docs to the Contributing Guide. I took inspiration from the Atom & Rasa guides, the main part is adapted for our workflows.
- Added a Code of Conduct, the same one that [Numfocus proposes](https://github.com/numfocus/getting-started-with-open-source/blob/master/code_of_conduct.md) and [Rasa uses](https://github.com/RasaHQ/rasa/blob/main/CODE_OF_CONDUCT.md).
- Added issue templates and adapted the PR template slightly.

Links to docs:
https://static.webknossos.org/docs/coc_and_contrib_guide/webknossos-py/CONTRIBUTING.html
https://static.webknossos.org/docs/coc_and_contrib_guide/webknossos-py/CODE_OF_CONDUCT.html