### PR TITLE
Improve tests

### DIFF
--- a/webknossos/local_wk_setup.sh
+++ b/webknossos/local_wk_setup.sh
@@ -47,3 +47,10 @@ function ensure_local_test_wk {
         echo "The local webknossos version is $LOCAL_VERSION, differing from the webknossos.org version $WK_ORG_VERSION"
     fi
 }
+
+
+function stop_local_test_wk {
+    pushd $WK_DOCKER_DIR > /dev/null
+    docker-compose down || true
+    popd > /dev/null
+}

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -1210,6 +1210,19 @@ pytest = ">=3.5.0"
 vcrpy = ">=2.0.1"
 
 [[package]]
+name = "pytest-sugar"
+version = "0.9.4"
+description = "pytest-sugar is a plugin for pytest that changes the default look and feel of pytest (e.g. progressbar, show tests that fail instantly)."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+packaging = ">=14.1"
+pytest = ">=2.9"
+termcolor = ">=1.1.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.8.2"
 description = "Extensions to the standard Python datetime module"
@@ -1461,6 +1474,14 @@ python-versions = "*"
 widechars = ["wcwidth"]
 
 [[package]]
+name = "termcolor"
+version = "1.1.0"
+description = "ANSII Color formatting for output in terminal."
+category = "dev"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "tifffile"
 version = "2021.11.2"
 description = "Read and write TIFF files"
@@ -1657,7 +1678,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "4db2f8ff19c85ae897da262477738c778fab07395ab3758d7135734b8e6a24bb"
+content-hash = "24f681290554192814b135705904ed186b2200e11a6a37e359d5bebd0ddf8052"
 
 [metadata.files]
 aiobotocore = [
@@ -2682,6 +2703,9 @@ pytest-recording = [
     {file = "pytest-recording-0.12.0.tar.gz", hash = "sha256:9039bf488f80c016055ffd039a91e33b1e89f3ee2ee0005c0bbce298fd417ee1"},
     {file = "pytest_recording-0.12.0-py3-none-any.whl", hash = "sha256:a94b000640fe5d05b34fa9e25dca1671dd7f21195502c5f4d2f600c31dc14f7e"},
 ]
+pytest-sugar = [
+    {file = "pytest-sugar-0.9.4.tar.gz", hash = "sha256:b1b2186b0a72aada6859bea2a5764145e3aaa2c1cfbb23c3a19b5f7b697563d3"},
+]
 python-dateutil = [
     {file = "python-dateutil-2.8.2.tar.gz", hash = "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86"},
     {file = "python_dateutil-2.8.2-py2.py3-none-any.whl", hash = "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"},
@@ -2936,6 +2960,9 @@ sortedcontainers = [
 tabulate = [
     {file = "tabulate-0.8.9-py3-none-any.whl", hash = "sha256:d7c013fe7abbc5e491394e10fa845f8f32fe54f8dc60c6622c6cf482d25d47e4"},
     {file = "tabulate-0.8.9.tar.gz", hash = "sha256:eb1d13f25760052e8931f2ef80aaf6045a6cceb47514db8beab24cded16f13a7"},
+]
+termcolor = [
+    {file = "termcolor-1.1.0.tar.gz", hash = "sha256:1d6d69ce66211143803fbc56652b41d73b4a400a2891d7bf7a1cdf4c02de613b"},
 ]
 tifffile = [
     {file = "tifffile-2021.11.2-py3-none-any.whl", hash = "sha256:2e0066f90e2dbeb3e6a287cfd78bafbd2f142fabbca4a76a8ff809573baf5ad5"},

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -81,6 +81,7 @@ pylint = "^2.10.2"
 pytest = "^6.2.4"
 pytest-custom-exit-code = "^0.3.0"
 pytest-recording = "^0.12.0"
+pytest-sugar = "^0.9.4"
 types-python-dateutil = "^0.1.6"
 # packages for examples:
 fastremap = "^1.12.2"

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -6,7 +6,10 @@ source local_wk_setup.sh
 export_vars
 
 
-if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
+PYTEST="poetry run python -m pytest -vv --suppress-no-test-exit-code"
+
+
+if [ $# -gt 0 ] && [ "$1" = "--refresh-snapshots" ]; then
     ensure_local_test_wk
 
     rm -rf tests/cassettes
@@ -16,9 +19,10 @@ if [ $# -eq 1 ] && [ "$1" = "--refresh-snapshots" ]; then
     # this will ensure that the current directory is added to sys.path
     # (which is standard python behavior). This is necessary so that the imports
     # refer to the checked out (and potentially modified) code.
-    poetry run python -m pytest -vv --record-mode once -m "with_vcr"
     shift
+    $PYTEST --record-mode once -m "with_vcr" "$@"
+    stop_local_test_wk
 else
-    poetry run python -m pytest -vv --suppress-no-test-exit-code --block-network -m "with_vcr" "$@"
+    $PYTEST --block-network -m "with_vcr" "$@"
 fi
-poetry run python -m pytest -vv --disable-recording -m "not with_vcr" "$@"
+$PYTEST --disable-recording -m "not with_vcr" "$@"

--- a/webknossos/test.sh
+++ b/webknossos/test.sh
@@ -6,7 +6,7 @@ source local_wk_setup.sh
 export_vars
 
 
-PYTEST="poetry run python -m pytest -vv --suppress-no-test-exit-code"
+PYTEST="poetry run python -m pytest --suppress-no-test-exit-code"
 
 
 if [ $# -gt 0 ] && [ "$1" = "--refresh-snapshots" ]; then


### PR DESCRIPTION
### Description:
This adds some improvements to the `test.sh` of the webknossos package:
- Ensure args can by passed to pytest
- Do not use `-vv` by default, can now be passed manually
- Use pytest-sugar of nicer output
- Kill webknossos in docker as early as possible after the tests to save some memory (hopefully fixes #754)

### Issues:
- maybe fixes #754
