### PR TITLE
More RemoteDataset Usages, and keep token in current context

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,8 +18,12 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 - When self-hosting a webKnossos server, please note that a webknossos version >= `22.06.0` is required. [#760](https://github.com/scalableminds/webknossos-libs/pull/760)
 
 ### Added
+- `Dataset.upload()` accepts `Layer` objects from a `RemoteDataset` in the `layers_to_link` argument list. Also, `LayerToLink` can consume those via `LayerToLink.from_remote_layer()`. [#761](https://github.com/scalableminds/webknossos-libs/pull/761)
+- `Task.create()` accepts a `RemoteDataset` for the `dataset_name` argument. [#761](https://github.com/scalableminds/webknossos-libs/pull/761)
+- Added `annotation.get_remote_base_dataset()` returning a `RemoteDataset`. [#761](https://github.com/scalableminds/webknossos-libs/pull/761)
 
 ### Changed
+- If a token is requested from the user on the commandline, it is now stored in the current context. Before, it was discarded. [#761](https://github.com/scalableminds/webknossos-libs/pull/761)
 
 ### Fixed
 

--- a/webknossos/examples/learned_segmenter.py
+++ b/webknossos/examples/learned_segmenter.py
@@ -75,13 +75,7 @@ def main() -> None:
     segmentation_layer.add_mag(mag, compress=True).write(segmentation)
 
     remote_ds = dataset.upload(
-        layers_to_link=[
-            wk.LayerToLink(
-                organization_id="scalable_minds",
-                dataset_name=annotation.dataset_name,
-                layer_name="color",
-            )
-        ]
+        layers_to_link=[annotation.get_remote_base_dataset().get_layer("color")]
         if "PYTEST_CURRENT_TEST" not in os.environ
         else None
     )

--- a/webknossos/webknossos/administration/task.py
+++ b/webknossos/webknossos/administration/task.py
@@ -12,6 +12,7 @@ from webknossos.client._generated.api.default import (
     task_info,
 )
 from webknossos.client.context import _get_generated_client
+from webknossos.dataset.dataset import RemoteDataset
 from webknossos.geometry import BoundingBox, Vec3Int
 
 logger = logging.getLogger(__name__)
@@ -109,7 +110,7 @@ class Task:
         cls,
         task_type_id: str,
         project_name: str,
-        dataset_name: str,
+        dataset_name: Union[str, RemoteDataset],
         needed_experience_domain: str,
         needed_experience_value: int,
         starting_position: Vec3Int,
@@ -122,6 +123,8 @@ class Task:
 
         client = _get_generated_client(enforce_auth=True)
         url = f"{client.base_url}/api/tasks"
+        if isinstance(dataset_name, RemoteDataset):
+            dataset_name = dataset_name._dataset_name
         task_parameters = {
             "taskTypeId": task_type_id,
             "neededExperience": {

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -49,6 +49,7 @@ from zipp import Path as ZipPath
 import webknossos._nml as wknml
 from webknossos.annotation._nml_conversion import annotation_to_nml, nml_to_skeleton
 from webknossos.dataset import SEGMENTATION_CATEGORY, Dataset, Layer, SegmentationLayer
+from webknossos.dataset.dataset import RemoteDataset
 from webknossos.geometry import BoundingBox
 from webknossos.skeleton import Skeleton
 from webknossos.utils import time_since_epoch_in_ms, warn_deprecated
@@ -436,6 +437,9 @@ class Annotation:
                 volume_layer._default_zip_name(),
                 layer_content,
             )
+
+    def get_remote_base_dataset(self) -> RemoteDataset:
+        return Dataset.open_remote(self.dataset_name, self.organization_id)
 
     def get_volume_layer_names(self) -> Iterable[str]:
         return (i.name for i in self._volume_layers)

--- a/webknossos/webknossos/client/_upload_dataset.py
+++ b/webknossos/webknossos/client/_upload_dataset.py
@@ -19,7 +19,8 @@ from webknossos.client._generated.api.default import (
 )
 from webknossos.client._resumable import Resumable
 from webknossos.client.context import _get_context, _WebknossosContext
-from webknossos.dataset import Dataset
+from webknossos.dataset import Dataset, Layer
+from webknossos.dataset.dataset import RemoteDataset
 from webknossos.utils import get_rich_progress
 
 DEFAULT_SIMULTANEOUS_UPLOADS = 5
@@ -33,6 +34,19 @@ class LayerToLink(NamedTuple):
     organization_id: Optional[
         str
     ] = None  # defaults to the user's organization before uploading
+
+    @classmethod
+    def from_remote_layer(
+        cls,
+        layer: Layer,
+        new_layer_name: Optional[str] = None,
+        organization_id: Optional[str] = None,
+    ) -> "LayerToLink":
+        ds = layer.dataset
+        assert isinstance(
+            ds, RemoteDataset
+        ), f"The passed layer must belong to a RemoteDataset, but belongs to {ds}"
+        return cls(ds._dataset_name, layer.name, new_layer_name, organization_id)
 
     def as_json(self) -> Dict[str, Optional[str]]:
         context = _get_context()

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -132,7 +132,14 @@ class _WebknossosContext:
     @property
     def required_token(self) -> str:
         if self.token is None:
-            return _cached_ask_for_token(self.url)
+            token = _cached_ask_for_token(self.url)
+            # We replace the current context, but leave all previous ones as-is.
+            # Any opened contextmanagers will still close correctly, as the stored
+            # tokens still point to the correct predecessors.
+            _webknossos_context_var.set(
+                _WebknossosContext(self.url, token, self.timeout)
+            )
+            return token
         else:
             return self.token
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -494,7 +494,7 @@ class Dataset:
     def upload(
         self,
         new_dataset_name: Optional[str] = None,
-        layers_to_link: Optional[List["LayerToLink"]] = None,
+        layers_to_link: Optional[List[Union["LayerToLink", Layer]]] = None,
         jobs: Optional[int] = None,
     ) -> "RemoteDataset":
         """
@@ -510,10 +510,19 @@ class Dataset:
         Returns the `RemoteDataset` upon successful upload.
         """
 
-        from webknossos.client._upload_dataset import upload_dataset
+        from webknossos.client._upload_dataset import LayerToLink, upload_dataset
+
+        converted_layers_to_link = (
+            None
+            if layers_to_link is None
+            else [
+                i if isinstance(i, LayerToLink) else LayerToLink.from_remote_layer(i)
+                for i in layers_to_link
+            ]
+        )
 
         return self.open_remote(
-            upload_dataset(self, new_dataset_name, layers_to_link, jobs)
+            upload_dataset(self, new_dataset_name, converted_layers_to_link, jobs)
         )
 
     def get_layer(self, layer_name: str) -> Layer:


### PR DESCRIPTION
### Description:
* Use RemoteDataset for
  * `Dataset.upload(layers_to_link=…)` (a remote Layer can be part of the list directly, or used via `LayerToLink.from_remote_layer()`)
  * `Task.create(),` 
* A `RemoteDataset` is available on `Annotation`s via `get_remote_base_dataset`. Using `base` in the name here, to avoid confusion when we introduce direct streaming from the Annotation itself.
* If a token is requested from the user on the commandline, it is stored in the current context. An example where this is important is `learned_segmenter.py`: When not having a token in `.env`, the user is asked for one for the upload. Before this PR it was discarded afterwards and the RemoteDataset construction failed. Now this is fixed.

### Issues:
- fixes #724 

### Todos:
 - [x] Updated Changelog
 - [x] Added this to the Examples
