### PR TITLE
update client, allow annotation urls without type

### DIFF
--- a/webknossos/examples/calculate_segment_sizes.py
+++ b/webknossos/examples/calculate_segment_sizes.py
@@ -2,9 +2,7 @@ import numpy as np
 
 import webknossos as wk
 
-ANNOTATION_URL = (
-    "https://webknossos.org/annotations/Explorational/622b130a010000220122ebd1"
-)
+ANNOTATION_URL = "https://webknossos.org/annotations/622b130a010000220122ebd1"
 
 
 def main() -> None:

--- a/webknossos/local_wk_setup.sh
+++ b/webknossos/local_wk_setup.sh
@@ -1,7 +1,7 @@
 function export_vars {
     export WK_TOKEN=1b88db86331a38c21a0b235794b9e459856490d70408bcffb767f64ade0f83d2bdb4c4e181b9a9a30cdece7cb7c65208cc43b6c1bb5987f5ece00d348b1a905502a266f8fc64f0371cd6559393d72e031d0c2d0cabad58cccf957bb258bc86f05b5dc3d4fff3d5e3d9c0389a6027d861a21e78e3222fb6c5b7944520ef21761e
     export WK_URL=http://localhost:9000
-    export DOCKER_TAG=master__18448
+    export DOCKER_TAG=master__18491
 }
 
 function ensure_local_test_wk {

--- a/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
+++ b/webknossos/tests/cassettes/test_annotation/test_annotation_from_url.yaml
@@ -13,7 +13,7 @@ interactions:
       user-agent:
       - python-httpx/0.18.2
     method: GET
-    uri: https://webknossos.org/api/annotations/Explorational/61c20205010000cc004a6356/download
+    uri: https://webknossos.org/api/annotations/61c20205010000cc004a6356/download
   response:
     content:
       zip:
@@ -26756,7 +26756,7 @@ interactions:
               DwgADFAAA/0BAA==
         l4dense_motta_et_al_demo_v2__explorational__potto__4a6356.nml: "<things>\n
           \ <meta name=\"writer\" content=\"NmlWriter.scala\" />\n  <meta name=\"writerGitCommit\"
-          content=\"ed9031614bd34db65bbd473852081fdd397e0759\" />\n  <meta name=\"timestamp\"
+          content=\"2198e87ee0c05495d4dfa2a3d5d3fbc3c753ae60\" />\n  <meta name=\"timestamp\"
           content=\"1643210000000\" />\n  <meta name=\"annotationId\" content=\"61c20205010000cc004a6356\"
           />\n  <meta name=\"username\" content=\"Philipp Otto\" />\n  <parameters>\n
           \   <experiment name=\"l4dense_motta_et_al_demo_v2\" organization=\"scalable_minds\"

--- a/webknossos/tests/test_annotation.py
+++ b/webknossos/tests/test_annotation.py
@@ -137,7 +137,7 @@ def test_annotation_from_file_with_multi_volume() -> None:
 def test_annotation_from_url() -> None:
 
     annotation = wk.Annotation.download(
-        "https://webknossos.org/annotations/Explorational/61c20205010000cc004a6356"
+        "https://webknossos.org/annotations/61c20205010000cc004a6356"
     )
     assert annotation.dataset_name == "l4dense_motta_et_al_demo_v2"
     assert len(list(annotation.skeleton.flattened_trees())) == 1

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -229,8 +229,8 @@ class Annotation:
     ) -> "Annotation":
         """
         * `annotation_id_or_url` may be an annotation id or a full URL to an annotation, e.g.
-          `https://webknossos.org/annotations/Explorational/6114d9410100009f0096c640`
-        * `annotation_type` must be supplied if and only if an annotation id was used in the previous argument
+          `https://webknossos.org/annotations/6114d9410100009f0096c640`
+        * `annotation_type` is not used anymore
         * `webknossos_url` may be supplied if an annotation id was used
           and allows to specifiy in which webknossos instance to search for the annotation.
           It defaults to the url from your current `webknossos_context`, using https://webknossos.org as a fallback.
@@ -246,20 +246,17 @@ class Annotation:
         if match is not None:
             assert webknossos_url is None and annotation_type is None, (
                 "When Annotation.download() is be called with an annotation url, "
-                + "e.g. Annotation.download('https://webknossos.org/annotations/Explorational/6114d9410100009f0096c640'), "
+                + "e.g. Annotation.download('https://webknossos.org/annotations/6114d9410100009f0096c640'), "
                 + "annotation_type and webknossos_url must not be set."
             )
             annotation_id = match.group("annotation_id")
             annotation_type = match.group("annotation_type")
             webknossos_url = match.group("webknossos_url")
         else:
-            assert annotation_type is not None, (
-                "When calling Annotation.download() with an id you must supply the argument annotation_type, "
-                + "e.g. 'Task' or 'Explorational'. Alternatively, you can use the full annotation url, "
-                + "e.g. Annotation.download('https://webknossos.org/annotations/Explorational/6114d9410100009f0096c640')."
-            )
             annotation_id = annotation_id_or_url
-        annotation_type = AnnotationType(annotation_type)
+        annotation_type = (
+            None if annotation_type is None else AnnotationType(annotation_type)
+        )
         assert (
             annotation_type not in _COMPOUND_ANNOTATION_TYPES
         ), f"Currently compound annotation types are not supported, got {annotation_type}"
@@ -279,7 +276,7 @@ class Annotation:
         with context:
             client = _get_generated_client()
             response = annotation_download.sync_detailed(
-                typ=annotation_type.value, id=annotation_id, client=client
+                id=annotation_id, client=client
             )
         assert response.status_code == 200, response
         content_disposition_header = response.headers.get("content-disposition", "")
@@ -691,7 +688,7 @@ _COMPOUND_ANNOTATION_TYPES = [
 
 _ANNOTATION_URL_REGEX = re.compile(
     r"^(?P<webknossos_url>https?://.*)/annotations/"
-    + rf"(?P<annotation_type>{'|'.join(i.value for i in AnnotationType.__members__.values())})/"
+    + rf"((?P<annotation_type>{'|'.join(i.value for i in AnnotationType.__members__.values())})/)?"
     + r"(?P<annotation_id>[0-9A-Fa-f]*)"
 )
 

--- a/webknossos/webknossos/client/_generated/api/default/annotation_download_by_type.py
+++ b/webknossos/webknossos/client/_generated/api/default/annotation_download_by_type.py
@@ -7,6 +7,7 @@ from ...types import UNSET, Response, Unset
 
 
 def _get_kwargs(
+    typ: str,
     id: str,
     *,
     client: Client,
@@ -14,7 +15,9 @@ def _get_kwargs(
     volume_version: Union[Unset, None, int] = UNSET,
     skip_volume_data: Union[Unset, None, bool] = UNSET,
 ) -> Dict[str, Any]:
-    url = "{}/api/annotations/{id}/download".format(client.base_url, id=id)
+    url = "{}/api/annotations/{typ}/{id}/download".format(
+        client.base_url, typ=typ, id=id
+    )
 
     headers: Dict[str, Any] = client.get_headers()
     cookies: Dict[str, Any] = client.get_cookies()
@@ -45,6 +48,7 @@ def _build_response(*, response: httpx.Response) -> Response[Any]:
 
 
 def sync_detailed(
+    typ: str,
     id: str,
     *,
     client: Client,
@@ -53,6 +57,7 @@ def sync_detailed(
     skip_volume_data: Union[Unset, None, bool] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
+        typ=typ,
         id=id,
         client=client,
         skeleton_version=skeleton_version,
@@ -68,6 +73,7 @@ def sync_detailed(
 
 
 async def asyncio_detailed(
+    typ: str,
     id: str,
     *,
     client: Client,
@@ -76,6 +82,7 @@ async def asyncio_detailed(
     skip_volume_data: Union[Unset, None, bool] = UNSET,
 ) -> Response[Any]:
     kwargs = _get_kwargs(
+        typ=typ,
         id=id,
         client=client,
         skeleton_version=skeleton_version,

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200.py
@@ -51,6 +51,7 @@ class AnnotationInfoResponse200:
     task: Optional[AnnotationInfoResponse200Task]
     tracing_time: Optional[int]
     view_configuration: Union[Unset, str] = UNSET
+    teams: Union[Unset, List[Any]] = UNSET
     user: Union[Unset, AnnotationInfoResponse200User] = UNSET
     owner: Union[Unset, AnnotationInfoResponse200Owner] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
@@ -94,6 +95,14 @@ class AnnotationInfoResponse200:
         task = self.task.to_dict() if self.task else None
 
         tracing_time = self.tracing_time
+        teams: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.teams, Unset):
+            teams = []
+            for teams_item_data in self.teams:
+                teams_item = teams_item_data
+
+                teams.append(teams_item)
+
         user: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.user, Unset):
             user = self.user.to_dict()
@@ -130,6 +139,8 @@ class AnnotationInfoResponse200:
         )
         if view_configuration is not UNSET:
             field_dict["viewConfiguration"] = view_configuration
+        if teams is not UNSET:
+            field_dict["teams"] = teams
         if user is not UNSET:
             field_dict["user"] = user
         if owner is not UNSET:
@@ -205,6 +216,13 @@ class AnnotationInfoResponse200:
 
         tracing_time = d.pop("tracingTime")
 
+        teams = []
+        _teams = d.pop("teams", UNSET)
+        for teams_item_data in _teams or []:
+            teams_item = teams_item_data
+
+            teams.append(teams_item)
+
         _user = d.pop("user", UNSET)
         user: Union[Unset, AnnotationInfoResponse200User]
         if isinstance(_user, Unset):
@@ -241,6 +259,7 @@ class AnnotationInfoResponse200:
             view_configuration=view_configuration,
             task=task,
             tracing_time=tracing_time,
+            teams=teams,
             user=user,
             owner=owner,
         )

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_annotation_layers_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_annotation_layers_item.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfoResponse200AnnotationLayersItem")
 
@@ -11,11 +13,13 @@ class AnnotationInfoResponse200AnnotationLayersItem:
 
     tracing_id: str
     typ: str
+    name: Union[Unset, str] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         tracing_id = self.tracing_id
         typ = self.typ
+        name = self.name
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -25,6 +29,8 @@ class AnnotationInfoResponse200AnnotationLayersItem:
                 "typ": typ,
             }
         )
+        if name is not UNSET:
+            field_dict["name"] = name
 
         return field_dict
 
@@ -35,9 +41,12 @@ class AnnotationInfoResponse200AnnotationLayersItem:
 
         typ = d.pop("typ")
 
+        name = d.pop("name", UNSET)
+
         annotation_info_response_200_annotation_layers_item = cls(
             tracing_id=tracing_id,
             typ=typ,
+            name=name,
         )
 
         annotation_info_response_200_annotation_layers_item.additional_properties = d

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.annotation_info_response_200_task_status import (
 from ..models.annotation_info_response_200_task_type import (
     AnnotationInfoResponse200TaskType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfoResponse200Task")
 
@@ -29,13 +28,13 @@ class AnnotationInfoResponse200Task:
     data_set: str
     needed_experience: AnnotationInfoResponse200TaskNeededExperience
     created: int
+    status: AnnotationInfoResponse200TaskStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, AnnotationInfoResponse200TaskStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class AnnotationInfoResponse200Task:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class AnnotationInfoResponse200Task:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class AnnotationInfoResponse200Task:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -112,6 +108,8 @@ class AnnotationInfoResponse200Task:
 
         created = d.pop("created")
 
+        status = AnnotationInfoResponse200TaskStatus.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -121,13 +119,6 @@ class AnnotationInfoResponse200Task:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, AnnotationInfoResponse200TaskStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = AnnotationInfoResponse200TaskStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -141,12 +132,12 @@ class AnnotationInfoResponse200Task:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item.py
@@ -59,6 +59,7 @@ class AnnotationInfosByTaskIdResponse200Item:
     task: Optional[AnnotationInfosByTaskIdResponse200ItemTask]
     tracing_time: Optional[int]
     view_configuration: Union[Unset, str] = UNSET
+    teams: Union[Unset, List[Any]] = UNSET
     user: Union[Unset, AnnotationInfosByTaskIdResponse200ItemUser] = UNSET
     owner: Union[Unset, AnnotationInfosByTaskIdResponse200ItemOwner] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
@@ -102,6 +103,14 @@ class AnnotationInfosByTaskIdResponse200Item:
         task = self.task.to_dict() if self.task else None
 
         tracing_time = self.tracing_time
+        teams: Union[Unset, List[Any]] = UNSET
+        if not isinstance(self.teams, Unset):
+            teams = []
+            for teams_item_data in self.teams:
+                teams_item = teams_item_data
+
+                teams.append(teams_item)
+
         user: Union[Unset, Dict[str, Any]] = UNSET
         if not isinstance(self.user, Unset):
             user = self.user.to_dict()
@@ -138,6 +147,8 @@ class AnnotationInfosByTaskIdResponse200Item:
         )
         if view_configuration is not UNSET:
             field_dict["viewConfiguration"] = view_configuration
+        if teams is not UNSET:
+            field_dict["teams"] = teams
         if user is not UNSET:
             field_dict["user"] = user
         if owner is not UNSET:
@@ -217,6 +228,13 @@ class AnnotationInfosByTaskIdResponse200Item:
 
         tracing_time = d.pop("tracingTime")
 
+        teams = []
+        _teams = d.pop("teams", UNSET)
+        for teams_item_data in _teams or []:
+            teams_item = teams_item_data
+
+            teams.append(teams_item)
+
         _user = d.pop("user", UNSET)
         user: Union[Unset, AnnotationInfosByTaskIdResponse200ItemUser]
         if isinstance(_user, Unset):
@@ -253,6 +271,7 @@ class AnnotationInfosByTaskIdResponse200Item:
             view_configuration=view_configuration,
             task=task,
             tracing_time=tracing_time,
+            teams=teams,
             user=user,
             owner=owner,
         )

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_annotation_layers_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_annotation_layers_item.py
@@ -1,6 +1,8 @@
-from typing import Any, Dict, List, Type, TypeVar
+from typing import Any, Dict, List, Type, TypeVar, Union
 
 import attr
+
+from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem")
 
@@ -11,11 +13,13 @@ class AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem:
 
     tracing_id: str
     typ: str
+    name: Union[Unset, str] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
         tracing_id = self.tracing_id
         typ = self.typ
+        name = self.name
 
         field_dict: Dict[str, Any] = {}
         field_dict.update(self.additional_properties)
@@ -25,6 +29,8 @@ class AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem:
                 "typ": typ,
             }
         )
+        if name is not UNSET:
+            field_dict["name"] = name
 
         return field_dict
 
@@ -35,9 +41,12 @@ class AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem:
 
         typ = d.pop("typ")
 
+        name = d.pop("name", UNSET)
+
         annotation_infos_by_task_id_response_200_item_annotation_layers_item = cls(
             tracing_id=tracing_id,
             typ=typ,
+            name=name,
         )
 
         annotation_infos_by_task_id_response_200_item_annotation_layers_item.additional_properties = (

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.annotation_infos_by_task_id_response_200_item_task_status import (
 from ..models.annotation_infos_by_task_id_response_200_item_task_type import (
     AnnotationInfosByTaskIdResponse200ItemTaskType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTask")
 
@@ -29,13 +28,13 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
     data_set: str
     needed_experience: AnnotationInfosByTaskIdResponse200ItemTaskNeededExperience
     created: int
+    status: AnnotationInfosByTaskIdResponse200ItemTaskStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -114,6 +110,10 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
 
         created = d.pop("created")
 
+        status = AnnotationInfosByTaskIdResponse200ItemTaskStatus.from_dict(
+            d.pop("status")
+        )
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -123,13 +123,6 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = AnnotationInfosByTaskIdResponse200ItemTaskStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -143,12 +136,12 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -7,7 +7,6 @@ from ..models.task_info_response_200_needed_experience import (
 )
 from ..models.task_info_response_200_status import TaskInfoResponse200Status
 from ..models.task_info_response_200_type import TaskInfoResponse200Type
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TaskInfoResponse200")
 
@@ -25,13 +24,13 @@ class TaskInfoResponse200:
     data_set: str
     needed_experience: TaskInfoResponse200NeededExperience
     created: int
+    status: TaskInfoResponse200Status
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, TaskInfoResponse200Status] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -46,16 +45,14 @@ class TaskInfoResponse200:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -72,6 +69,7 @@ class TaskInfoResponse200:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -80,8 +78,6 @@ class TaskInfoResponse200:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -108,6 +104,8 @@ class TaskInfoResponse200:
 
         created = d.pop("created")
 
+        status = TaskInfoResponse200Status.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -117,13 +115,6 @@ class TaskInfoResponse200:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, TaskInfoResponse200Status]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = TaskInfoResponse200Status.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -137,12 +128,12 @@ class TaskInfoResponse200:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.task_infos_by_project_id_response_200_item_status import (
 from ..models.task_infos_by_project_id_response_200_item_type import (
     TaskInfosByProjectIdResponse200ItemType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TaskInfosByProjectIdResponse200Item")
 
@@ -29,13 +28,13 @@ class TaskInfosByProjectIdResponse200Item:
     data_set: str
     needed_experience: TaskInfosByProjectIdResponse200ItemNeededExperience
     created: int
+    status: TaskInfosByProjectIdResponse200ItemStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, TaskInfosByProjectIdResponse200ItemStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class TaskInfosByProjectIdResponse200Item:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class TaskInfosByProjectIdResponse200Item:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class TaskInfosByProjectIdResponse200Item:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -114,6 +110,8 @@ class TaskInfosByProjectIdResponse200Item:
 
         created = d.pop("created")
 
+        status = TaskInfosByProjectIdResponse200ItemStatus.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -123,13 +121,6 @@ class TaskInfosByProjectIdResponse200Item:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, TaskInfosByProjectIdResponse200ItemStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = TaskInfosByProjectIdResponse200ItemStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -143,12 +134,12 @@ class TaskInfosByProjectIdResponse200Item:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 


### PR DESCRIPTION
### Description:
- updates the generated client, allows better definition of optional fields
- allows to download annotations without specifying the type (either via URL or parameter)

### Issues:
- fixes #749
- depends on #763, since I branched from there due to changes in the generated client

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
 - [x] Considered adding this to the Examples
