### PR TITLE
fix the bbox inferral for volume annotation layers

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -26,6 +26,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 - If a token is requested from the user on the commandline, it is now stored in the current context. Before, it was discarded. [#761](https://github.com/scalableminds/webknossos-libs/pull/761)
 
 ### Fixed
+- Fixed the bounding box inferral for volume annotation layers that were not saved in Mag(1). [#765](https://github.com/scalableminds/webknossos-libs/pull/765)
 
 
 ## [0.10.6](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.6) - 2022-06-27

--- a/webknossos/webknossos/dataset/_array.py
+++ b/webknossos/webknossos/dataset/_array.py
@@ -116,6 +116,7 @@ class BaseArray(ABC):
 
     @abstractmethod
     def list_bounding_boxes(self) -> Iterator[BoundingBox]:
+        "The bounding boxes are measured in voxels of the current mag."
         pass
 
     @abstractmethod

--- a/webknossos/webknossos/dataset/_array.py
+++ b/webknossos/webknossos/dataset/_array.py
@@ -117,7 +117,6 @@ class BaseArray(ABC):
     @abstractmethod
     def list_bounding_boxes(self) -> Iterator[BoundingBox]:
         "The bounding boxes are measured in voxels of the current mag."
-        pass
 
     @abstractmethod
     def close(self) -> None:

--- a/webknossos/webknossos/dataset/_utils/infer_bounding_box_existing_files.py
+++ b/webknossos/webknossos/dataset/_utils/infer_bounding_box_existing_files.py
@@ -6,8 +6,9 @@ from webknossos.geometry import BoundingBox
 
 def infer_bounding_box_existing_files(mag_view: MagView) -> BoundingBox:
     """Since volume annotation layers are only a single layer, they do not contain a datasource-properties.json.
-    Therefore, the bounding box needs to be inferred when working with those."""
+    Therefore, the bounding box needs to be inferred when working with those.
+    The returned bounding box is measured in Mag(1) voxels."""
 
     return reduce(
-        lambda acc, bbox: acc.extended_by(bbox), mag_view._array.list_bounding_boxes()
+        lambda acc, bbox: acc.extended_by(bbox), mag_view.get_bounding_boxes_on_disk()
     )


### PR DESCRIPTION
### Description:
Fixes the bbox inferral for volume annotation layers, by correcting `infer_bounding_box_existing_files` (has 1 usage, for the volume annotation bbox inferral). `get_bounding_boxes_on_disk` also uses `._array.list_bounding_boxes()`, but corrects for the mag.

### Issues:
- fixes #750

### Todos:
 - [x] Updated Changelog
