### PR TITLE
update generated client, rm unneeded type check

### DIFF
--- a/webknossos/webknossos/administration/task.py
+++ b/webknossos/webknossos/administration/task.py
@@ -11,7 +11,6 @@ from webknossos.client._generated.api.default import (
     annotation_infos_by_task_id,
     task_info,
 )
-from webknossos.client._generated.types import Unset
 from webknossos.client.context import _get_generated_client
 from webknossos.dataset.dataset import RemoteDataset
 from webknossos.geometry import BoundingBox, Vec3Int
@@ -171,7 +170,6 @@ class Task:
         cls,
         response: Union["TaskInfoResponse200", "TaskInfosByProjectIdResponse200Item"],
     ) -> "Task":
-        assert not isinstance(response.status, Unset)
         return cls(
             response.id,
             response.project_name,

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.annotation_info_response_200_task_status import (
 from ..models.annotation_info_response_200_task_type import (
     AnnotationInfoResponse200TaskType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfoResponse200Task")
 
@@ -29,13 +28,13 @@ class AnnotationInfoResponse200Task:
     data_set: str
     needed_experience: AnnotationInfoResponse200TaskNeededExperience
     created: int
+    status: AnnotationInfoResponse200TaskStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, AnnotationInfoResponse200TaskStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class AnnotationInfoResponse200Task:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class AnnotationInfoResponse200Task:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class AnnotationInfoResponse200Task:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -112,6 +108,8 @@ class AnnotationInfoResponse200Task:
 
         created = d.pop("created")
 
+        status = AnnotationInfoResponse200TaskStatus.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -121,13 +119,6 @@ class AnnotationInfoResponse200Task:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, AnnotationInfoResponse200TaskStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = AnnotationInfoResponse200TaskStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -141,12 +132,12 @@ class AnnotationInfoResponse200Task:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.annotation_infos_by_task_id_response_200_item_task_status import (
 from ..models.annotation_infos_by_task_id_response_200_item_task_type import (
     AnnotationInfosByTaskIdResponse200ItemTaskType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTask")
 
@@ -29,13 +28,13 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
     data_set: str
     needed_experience: AnnotationInfosByTaskIdResponse200ItemTaskNeededExperience
     created: int
+    status: AnnotationInfosByTaskIdResponse200ItemTaskStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -114,6 +110,10 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
 
         created = d.pop("created")
 
+        status = AnnotationInfosByTaskIdResponse200ItemTaskStatus.from_dict(
+            d.pop("status")
+        )
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -123,13 +123,6 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = AnnotationInfosByTaskIdResponse200ItemTaskStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -143,12 +136,12 @@ class AnnotationInfosByTaskIdResponse200ItemTask:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -7,7 +7,6 @@ from ..models.task_info_response_200_needed_experience import (
 )
 from ..models.task_info_response_200_status import TaskInfoResponse200Status
 from ..models.task_info_response_200_type import TaskInfoResponse200Type
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TaskInfoResponse200")
 
@@ -25,13 +24,13 @@ class TaskInfoResponse200:
     data_set: str
     needed_experience: TaskInfoResponse200NeededExperience
     created: int
+    status: TaskInfoResponse200Status
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, TaskInfoResponse200Status] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -46,16 +45,14 @@ class TaskInfoResponse200:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -72,6 +69,7 @@ class TaskInfoResponse200:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -80,8 +78,6 @@ class TaskInfoResponse200:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -108,6 +104,8 @@ class TaskInfoResponse200:
 
         created = d.pop("created")
 
+        status = TaskInfoResponse200Status.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -117,13 +115,6 @@ class TaskInfoResponse200:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, TaskInfoResponse200Status]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = TaskInfoResponse200Status.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -137,12 +128,12 @@ class TaskInfoResponse200:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional, Type, TypeVar, Union, cast
+from typing import Any, Dict, List, Optional, Type, TypeVar, cast
 
 import attr
 
@@ -11,7 +11,6 @@ from ..models.task_infos_by_project_id_response_200_item_status import (
 from ..models.task_infos_by_project_id_response_200_item_type import (
     TaskInfosByProjectIdResponse200ItemType,
 )
-from ..types import UNSET, Unset
 
 T = TypeVar("T", bound="TaskInfosByProjectIdResponse200Item")
 
@@ -29,13 +28,13 @@ class TaskInfosByProjectIdResponse200Item:
     data_set: str
     needed_experience: TaskInfosByProjectIdResponse200ItemNeededExperience
     created: int
+    status: TaskInfosByProjectIdResponse200ItemStatus
     script: str
     creation_info: str
     bounding_box: str
     edit_position: List[int]
     edit_rotation: List[int]
     tracing_time: Optional[int]
-    status: Union[Unset, TaskInfosByProjectIdResponse200ItemStatus] = UNSET
     additional_properties: Dict[str, Any] = attr.ib(init=False, factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -50,16 +49,14 @@ class TaskInfosByProjectIdResponse200Item:
         needed_experience = self.needed_experience.to_dict()
 
         created = self.created
+        status = self.status.to_dict()
+
         script = self.script
         creation_info = self.creation_info
         bounding_box = self.bounding_box
         edit_position = self.edit_position
 
         edit_rotation = self.edit_rotation
-
-        status: Union[Unset, Dict[str, Any]] = UNSET
-        if not isinstance(self.status, Unset):
-            status = self.status.to_dict()
 
         tracing_time = self.tracing_time
 
@@ -76,6 +73,7 @@ class TaskInfosByProjectIdResponse200Item:
                 "dataSet": data_set,
                 "neededExperience": needed_experience,
                 "created": created,
+                "status": status,
                 "script": script,
                 "creationInfo": creation_info,
                 "boundingBox": bounding_box,
@@ -84,8 +82,6 @@ class TaskInfosByProjectIdResponse200Item:
                 "tracingTime": tracing_time,
             }
         )
-        if status is not UNSET:
-            field_dict["status"] = status
 
         return field_dict
 
@@ -114,6 +110,8 @@ class TaskInfosByProjectIdResponse200Item:
 
         created = d.pop("created")
 
+        status = TaskInfosByProjectIdResponse200ItemStatus.from_dict(d.pop("status"))
+
         script = d.pop("script")
 
         creation_info = d.pop("creationInfo")
@@ -123,13 +121,6 @@ class TaskInfosByProjectIdResponse200Item:
         edit_position = cast(List[int], d.pop("editPosition"))
 
         edit_rotation = cast(List[int], d.pop("editRotation"))
-
-        _status = d.pop("status", UNSET)
-        status: Union[Unset, TaskInfosByProjectIdResponse200ItemStatus]
-        if isinstance(_status, Unset):
-            status = UNSET
-        else:
-            status = TaskInfosByProjectIdResponse200ItemStatus.from_dict(_status)
 
         tracing_time = d.pop("tracingTime")
 
@@ -143,12 +134,12 @@ class TaskInfosByProjectIdResponse200Item:
             data_set=data_set,
             needed_experience=needed_experience,
             created=created,
+            status=status,
             script=script,
             creation_info=creation_info,
             bounding_box=bounding_box,
             edit_position=edit_position,
             edit_rotation=edit_rotation,
-            status=status,
             tracing_time=tracing_time,
         )
 


### PR DESCRIPTION
### Description:
Somehow some changes for the generated client were missing (probably due to branches on top of each other and the related merging). This lead to the nightly tests failing. This PR updates them, and removes an unnecessary type check.

