### PR TITLE
except ConnectionResetError in MultiProcessingHandler

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Suppress spurios ConnectionResetErrors when using multiprocessing, probably only relevant for Python 3.9.13 and higher. [#770](https://github.com/scalableminds/webknossos-libs/pull/770)
 
 
 ## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Suppress spurios ConnectionResetErrors when using multiprocessing, probably only relevant for Python 3.9.13 and higher. [#770](https://github.com/scalableminds/webknossos-libs/pull/770)
+- Suppress spurious ConnectionResetErrors when using multiprocessing, probably only relevant for Python 3.9.13 and higher. [#770](https://github.com/scalableminds/webknossos-libs/pull/770)
 
 
 ## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Suppress spurious ConnectionResetErrors when using multiprocessing, probably only relevant for Python 3.9.13 and higher. [#770](https://github.com/scalableminds/webknossos-libs/pull/770)
+- Suppress spurious ConnectionResetErrors when using multiprocessing. [#770](https://github.com/scalableminds/webknossos-libs/pull/770)
 
 
 ## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21

--- a/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
+++ b/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
@@ -54,7 +54,7 @@ class MultiProcessingHandler(logging.Handler):
                 raise
             # multiprocessing.managers.RemoteError pop up quite often.
             # It seems that they can be safely ignored, though.
-            except (BrokenPipeError, EOFError, multiprocessing.managers.RemoteError):
+            except (BrokenPipeError, EOFError, ConnectionResetError, multiprocessing.managers.RemoteError):
                 break
             except QueueEmpty:
                 # This case is reached when the timeout in queue.get is hit. Pass, to

--- a/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
+++ b/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
@@ -52,8 +52,9 @@ class MultiProcessingHandler(logging.Handler):
                     self.wrapped_handler.emit(record)
             except (KeyboardInterrupt, SystemExit):  # pylint: disable=try-except-raise
                 raise
-            # multiprocessing.managers.RemoteError pop up quite often.
+            # The following errors pop up quite often.
             # It seems that they can be safely ignored, though.
+            # The reason for those might be that the sending end was closed.
             except (
                 BrokenPipeError,
                 EOFError,

--- a/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
+++ b/cluster_tools/cluster_tools/multiprocessing_logging_handler.py
@@ -54,7 +54,12 @@ class MultiProcessingHandler(logging.Handler):
                 raise
             # multiprocessing.managers.RemoteError pop up quite often.
             # It seems that they can be safely ignored, though.
-            except (BrokenPipeError, EOFError, ConnectionResetError, multiprocessing.managers.RemoteError):
+            except (
+                BrokenPipeError,
+                EOFError,
+                ConnectionResetError,
+                multiprocessing.managers.RemoteError,
+            ):
                 break
             except QueueEmpty:
                 # This case is reached when the timeout in queue.get is hit. Pass, to


### PR DESCRIPTION
### Description:
Before, I got the following stacktrace at the end of successful tests:
```
Traceback (most recent call last):
  File "/…/cluster_tools/cluster_tools/multiprocessing_logging_handler.py", line 50, in _receive
    record = self.queue.get(timeout=0.2)
  File "<string>", line 2, in get
  File "/usr/lib/python3.7/multiprocessing/managers.py", line 796, in _callmethod
    kind, result = conn.recv()
  File "/usr/lib/python3.7/multiprocessing/connection.py", line 250, in recv
    buf = self._recv_bytes()
  File "/usr/lib/python3.7/multiprocessing/connection.py", line 407, in _recv_bytes
    buf = self._recv(4)
  File "/usr/lib/python3.7/multiprocessing/connection.py", line 379, in _recv
    chunk = read(handle, remaining)
ConnectionResetError: [Errno 104] Connection reset by peer
```

This is now handled properly. ~~I also suspect that this error might be the reason for the current CI failures, let's see.~~


### Todos:
 - [x] Updated Changelog
