### PR TITLE
Revert "Release for v0.10.9"

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.9...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...HEAD)
 
 ### Breaking Changes
 
@@ -16,10 +16,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-
-
-## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...v0.10.9)
 
 
 ## [0.10.8](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.8) - 2022-07-15

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.9...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...HEAD)
 
 ### Breaking Changes
 
@@ -19,10 +19,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-
-
-## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...v0.10.9)
 
 
 ## [0.10.8](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.8) - 2022-07-15

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.9...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...HEAD)
 
 ### Breaking Changes
 
@@ -16,10 +16,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-
-
-## [0.10.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.9) - 2022-07-21
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.8...v0.10.9)
 
 
 ## [0.10.8](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.8) - 2022-07-15


### PR DESCRIPTION
This reverts commit 965a29f1309b0ac19d586c8f808ff44b3aa5924e.

Since the previous release never built correctly, I'd like to revert the changes and release the current master with this version. I already deleted the corresponding tag.