### PR TITLE
View: minor fix in destructor

### DIFF
--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -960,7 +960,8 @@ class View:
             self._cached_array = None
 
     def __del__(self) -> None:
-        del self._cached_array
+        if hasattr(self, "_cached_array"):
+            del self._cached_array
 
     def __getstate__(self) -> Dict[str, Any]:
         d = dict(self.__dict__)


### PR DESCRIPTION
### Description:
When an exception is raised in the constructor of `MagView`, the `View` destructor has another exception, as the `_cached_array` was not set yet. This fixes this problem.

### Issues:
- helps with #780 
