### PR TITLE
make largest_segment_id optional

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- The largest_segment_id is optional now. [#786](https://github.com/scalableminds/webknossos-libs/pull/786)
 
 ### Fixed
 

--- a/webknossos/tests/test_from_images.py
+++ b/webknossos/tests/test_from_images.py
@@ -112,6 +112,7 @@ def test_repo_images(
         assert l.num_channels == num_channels
         assert l.bounding_box == wk.BoundingBox(topleft=(0, 0, 0), size=size)
         if isinstance(l, wk.SegmentationLayer):
+            assert l.largest_segment_id is not None
             assert l.largest_segment_id > 0
     return ds
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -636,7 +636,7 @@ class Dataset:
                     **(
                         attr.asdict(layer_properties, recurse=False)
                     ),  # use all attributes from LayerProperties
-                    largest_segment_id=kwargs["largest_segment_id"],
+                    largest_segment_id=kwargs.get("largest_segment_id"),
                 )
             )
             if "mappings" in kwargs:

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -1072,13 +1072,13 @@ class SegmentationLayer(Layer):
     _properties: SegmentationLayerProperties
 
     @property
-    def largest_segment_id(self) -> int:
+    def largest_segment_id(self) -> Optional[int]:
         return self._properties.largest_segment_id
 
     @largest_segment_id.setter
-    def largest_segment_id(self, largest_segment_id: int) -> None:
+    def largest_segment_id(self, largest_segment_id: Optional[int]) -> None:
         self.dataset._ensure_writable()
-        if type(largest_segment_id) != int:
+        if largest_segment_id is not None and type(largest_segment_id) != int:
             assert largest_segment_id == int(
                 largest_segment_id
             ), f"A non-integer value was passed for largest_segment_id ({largest_segment_id})."

--- a/webknossos/webknossos/dataset/properties.py
+++ b/webknossos/webknossos/dataset/properties.py
@@ -147,7 +147,7 @@ class LayerProperties:
 
 @attr.define
 class SegmentationLayerProperties(LayerProperties):
-    largest_segment_id: int = -1
+    largest_segment_id: Optional[int] = None
     mappings: List[str] = []
 
 


### PR DESCRIPTION
### Description:
Adapts the largestSegmentId to be optional for segmentation layers. This is a minimal change that allows compatibility with webknossos, but still computes the largest segment id when possible as before.

### Issues:
- compare #6414

### Todos:
 - [x] Updated Changelog
