### PR TITLE
coherent fs-copy and data-streaming in dataset copy methods

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+* `dataset.add_copy_layer()` and `layer.add_copy_mag()` now read and write the image data, not copying files. This allows to stream data from remote datasets. To continue using the filesystem copy mechanism, please use `dataset.add_fs_copy_layer()` or `layer.add_fs_copy_mag()`. [#790](https://github.com/scalableminds/webknossos-libs/pull/790)
 
 ### Fixed
 

--- a/webknossos/tests/test_dataset.py
+++ b/webknossos/tests/test_dataset.py
@@ -1562,7 +1562,56 @@ def test_add_copy_mag(data_format: DataFormat, output_path: Path) -> None:
     assert tuple(layer.bounding_box.topleft) == (6, 6, 6)
     assert tuple(layer.bounding_box.size) == (10, 20, 30)
 
-    copy_mag = layer.add_copy_mag(original_mag_2)
+    copy_mag = layer.add_copy_mag(original_mag_2, extend_layer_bounding_box=False)
+
+    assert (symlink_path / "color" / "1").exists()
+    assert len(layer._properties.mags) == 2
+
+    assert tuple(layer.bounding_box.topleft) == (6, 6, 6)
+    assert tuple(layer.bounding_box.size) == (10, 20, 30)
+
+    # Write data in copied layer
+    write_data = (np.random.rand(5, 5, 5) * 255).astype(np.uint8)
+    copy_mag.write(absolute_offset=(0, 0, 0), data=write_data)
+
+    assert np.array_equal(
+        copy_mag.read(absolute_offset=(0, 0, 0), size=(10, 10, 10))[0], write_data
+    )
+    assert np.array_equal(original_layer.get_mag(2).read()[0], original_data)
+
+    assure_exported_properties(ds)
+    assure_exported_properties(original_ds)
+
+
+@pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
+def test_add_fs_copy_mag(data_format: DataFormat, output_path: Path) -> None:
+    ds_path = prepare_dataset_path(data_format, output_path, "original")
+    symlink_path = prepare_dataset_path(data_format, output_path, "with_symlink")
+
+    original_ds = Dataset(ds_path, voxel_size=(1, 1, 1))
+    original_layer = original_ds.add_layer(
+        "color", COLOR_CATEGORY, dtype_per_channel="uint8", data_format=data_format
+    )
+    original_layer.add_mag(1).write(
+        data=(np.random.rand(10, 20, 30) * 255).astype(np.uint8)
+    )
+    original_data = (np.random.rand(5, 10, 15) * 255).astype(np.uint8)
+    original_mag_2 = original_layer.add_mag(2)
+    original_mag_2.write(data=original_data)
+
+    ds = Dataset(symlink_path, voxel_size=(1, 1, 1))
+    layer = ds.add_layer(
+        "color", COLOR_CATEGORY, dtype_per_channel="uint8", data_format=data_format
+    )
+    layer.add_mag(1).write(
+        absolute_offset=(6, 6, 6),
+        data=(np.random.rand(10, 20, 30) * 255).astype(np.uint8),
+    )
+
+    assert tuple(layer.bounding_box.topleft) == (6, 6, 6)
+    assert tuple(layer.bounding_box.size) == (10, 20, 30)
+
+    copy_mag = layer.add_fs_copy_mag(original_mag_2)
 
     assert (symlink_path / "color" / "1").exists()
     assert len(layer._properties.mags) == 2

--- a/webknossos/tests/test_dataset_deprecated.py
+++ b/webknossos/tests/test_dataset_deprecated.py
@@ -1218,7 +1218,7 @@ def test_add_symlink_mag(tmp_path: Path) -> None:
     assure_exported_properties(original_ds)
 
 
-def test_add_copy_mag(tmp_path: Path) -> None:
+def test_add_fs_copy_mag(tmp_path: Path) -> None:
     original_ds = Dataset(tmp_path / "original", scale=(1, 1, 1))
     original_layer = original_ds.add_layer(
         "color", COLOR_CATEGORY, dtype_per_channel="uint8"
@@ -1239,7 +1239,7 @@ def test_add_copy_mag(tmp_path: Path) -> None:
     assert tuple(layer.bounding_box.topleft) == (6, 6, 6)
     assert tuple(layer.bounding_box.size) == (10, 20, 30)
 
-    copy_mag = layer.add_copy_mag(original_mag_2)
+    copy_mag = layer.add_fs_copy_mag(original_mag_2)
 
     assert (tmp_path / "link" / "color" / "1").exists()
     assert len(layer._properties.resolutions) == 2

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -72,7 +72,7 @@ from .properties import (
     _properties_floating_type_to_python_type,
     dataset_converter,
 )
-from .view import _BLOCK_ALIGNMENT_WARNING, _copy_job
+from .view import _BLOCK_ALIGNMENT_WARNING
 
 logger = logging.getLogger(__name__)
 
@@ -1205,6 +1205,12 @@ class Dataset:
         This method becomes useful when exposing a dataset to webknossos.
         Only datasets on local filesystems can be shallow copied.
         """
+        assert is_fs_path(
+            self.path
+        ), f"Cannot create symlinks to remote dataset {self.path}"
+        assert is_fs_path(
+            new_dataset_path
+        ), f"Cannot create symlink in remote path {new_dataset_path}"
         new_dataset = Dataset(
             new_dataset_path,
             voxel_size=self.voxel_size,

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1106,9 +1106,11 @@ class Dataset:
         new_layer_name: Optional[str] = None,
     ) -> Layer:
         """
-        Copies the files at `foreign_layer` which belongs to another dataset to the current dataset.
-        Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied too.
-        If new_layer_name is None, the name of the foreign layer is used.
+        Copies the files at `foreign_layer` which belongs to another dataset
+        to the current dataset via the filesystem. Additionally, the relevant
+        information from the `datasource-properties.json` of the other dataset
+        are copied too. If new_layer_name is None, the name of the foreign
+        layer is used.
         """
         self._ensure_writable()
         foreign_layer = Layer._ensure_layer(foreign_layer)

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1208,6 +1208,7 @@ class Dataset:
         assert is_fs_path(
             self.path
         ), f"Cannot create symlinks to remote dataset {self.path}"
+        new_dataset_path = UPath(new_dataset_path)
         assert is_fs_path(
             new_dataset_path
         ), f"Cannot create symlink in remote path {new_dataset_path}"

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -542,8 +542,9 @@ class Layer:
         executor: Optional[Union[ClusterExecutor, WrappedProcessPoolExecutor]] = None,
     ) -> MagView:
         """
-        Copies the data at `foreign_mag_view_or_path` which belongs to another dataset to the current dataset.
-        Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied, too.
+        Copies the data at `foreign_mag_view_or_path` which can belong to another dataset
+        to the current dataset. Additionally, the relevant information from the
+        `datasource-properties.json` of the other dataset are copied, too.
         """
         self.dataset._ensure_writable()
         foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
@@ -564,13 +565,12 @@ class Layer:
                 foreign_mag_view.layer.bounding_box
             )
 
-        if not foreign_mag_view.bounding_box.is_empty():
-            foreign_mag_view.for_zipped_chunks(
-                func_per_chunk=_copy_job,
-                target_view=mag_view,
-                executor=executor,
-                progress_desc=f"Copying mag {mag_view.mag.to_layer_name()} from {foreign_mag_view.layer} to {mag_view.layer}",
-            )
+        foreign_mag_view.for_zipped_chunks(
+            func_per_chunk=_copy_job,
+            target_view=mag_view,
+            executor=executor,
+            progress_desc=f"Copying mag {mag_view.mag.to_layer_name()} from {foreign_mag_view.layer} to {mag_view.layer}",
+        )
 
         return mag_view
 

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -9,9 +9,12 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+from cluster_tools import WrappedProcessPoolExecutor
+from cluster_tools.schedulers.cluster_executor import ClusterExecutor
 from upath import UPath
 
 from webknossos.dataset.sampling_modes import SamplingModes
+from webknossos.dataset.view import _copy_job
 from webknossos.geometry import BoundingBox, Mag, Vec3Int, Vec3IntLike
 
 from ._array import ArrayException, BaseArray, DataFormat
@@ -529,67 +532,47 @@ class Layer:
         )
         rmtree(full_path)
 
-    def _add_foreign_mag(
+    def add_copy_mag(
         self,
         foreign_mag_view_or_path: Union[PathLike, str, MagView],
-        symlink: bool,
-        make_relative: bool,
         extend_layer_bounding_box: bool = True,
+        chunk_shape: Optional[Union[Vec3IntLike, int]] = None,
+        chunks_per_shard: Optional[Union[Vec3IntLike, int]] = None,
+        compress: Optional[bool] = None,
+        executor: Optional[Union[ClusterExecutor, WrappedProcessPoolExecutor]] = None,
     ) -> MagView:
         """
-        The foreign mag is (shallow) copied and the existing mag is added to the datasource-properties.json.
-        If extend_layer_bounding_box is true, the self.bounding_box will be extended
-        by the bounding box of the layer the foreign mag belongs to.
-        Symlinked mags can only be added to layers on local file systems.
+        Copies the data at `foreign_mag_view_or_path` which belongs to another dataset to the current dataset.
+        Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied, too.
         """
         self.dataset._ensure_writable()
-
-        if isinstance(foreign_mag_view_or_path, MagView):
-            foreign_mag_view = foreign_mag_view_or_path
-        else:
-            # local import to prevent circular dependency
-            from .dataset import Dataset
-
-            foreign_mag_view_path = UPath(foreign_mag_view_or_path)
-            foreign_mag_view = (
-                Dataset.open(foreign_mag_view_path.parent.parent)
-                .get_layer(foreign_mag_view_path.parent.name)
-                .get_mag(foreign_mag_view_path.name)
-            )
-
+        foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
         self._assert_mag_does_not_exist_yet(foreign_mag_view.mag)
 
-        if symlink:
-            assert is_fs_path(
-                self.path
-            ), f"Cannot create symlinks in remote layer {self.path}"
-            assert is_fs_path(
-                foreign_mag_view.path
-            ), f"Cannot create symlink to remote mag {foreign_mag_view.path}"
+        mag_view = self.add_mag(
+            mag=foreign_mag_view.mag,
+            chunk_shape=chunk_shape or foreign_mag_view._array_info.chunk_shape,
+            chunks_per_shard=chunks_per_shard
+            or foreign_mag_view._array_info.chunks_per_shard,
+            compress=compress
+            if compress is not None
+            else foreign_mag_view._array_info.compression_mode,
+        )
 
-            foreign_normalized_mag_path = (
-                Path(relpath(foreign_mag_view.path, self.path))
-                if make_relative
-                else foreign_mag_view.path.resolve()
-            )
-
-            (self.path / str(foreign_mag_view.mag)).symlink_to(
-                foreign_normalized_mag_path
-            )
-        else:
-            copytree(
-                foreign_mag_view.path,
-                self.path / str(foreign_mag_view.mag),
-            )
-
-        self.add_mag_for_existing_files(foreign_mag_view.mag)
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
                 foreign_mag_view.layer.bounding_box
             )
-        self.dataset._export_as_json()
 
-        return self._mags[foreign_mag_view.mag]
+        if not foreign_mag_view.bounding_box.is_empty():
+            foreign_mag_view.for_zipped_chunks(
+                func_per_chunk=_copy_job,
+                target_view=mag_view,
+                executor=executor,
+                progress_desc=f"Copying mag {mag_view.mag.to_layer_name()} from {foreign_mag_view.layer} to {mag_view.layer}",
+            )
+
+        return mag_view
 
     def add_symlink_mag(
         self,
@@ -605,28 +588,59 @@ class Layer:
         If make_relative is True, the symlink is made relative to the current dataset path.
         Symlinked mags can only be added to layers on local file systems.
         """
-        return self._add_foreign_mag(
-            foreign_mag_view_or_path,
-            symlink=True,
-            make_relative=make_relative,
-            extend_layer_bounding_box=extend_layer_bounding_box,
+        self.dataset._ensure_writable()
+        foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
+        self._assert_mag_does_not_exist_yet(foreign_mag_view.mag)
+
+        assert is_fs_path(
+            self.path
+        ), f"Cannot create symlinks in remote layer {self.path}"
+        assert is_fs_path(
+            foreign_mag_view.path
+        ), f"Cannot create symlink to remote mag {foreign_mag_view.path}"
+
+        foreign_normalized_mag_path = (
+            Path(relpath(foreign_mag_view.path, self.path))
+            if make_relative
+            else foreign_mag_view.path.resolve()
         )
 
-    def add_copy_mag(
+        (self.path / str(foreign_mag_view.mag)).symlink_to(foreign_normalized_mag_path)
+
+        mag = self.add_mag_for_existing_files(foreign_mag_view.mag)
+
+        if extend_layer_bounding_box:
+            self.bounding_box = self.bounding_box.extended_by(
+                foreign_mag_view.layer.bounding_box
+            )
+        return mag
+
+    def add_fs_copy_mag(
         self,
         foreign_mag_view_or_path: Union[PathLike, str, MagView],
         extend_layer_bounding_box: bool = True,
     ) -> MagView:
         """
-        Copies the data at `foreign_mag_view_or_path` which belongs to another dataset to the current dataset.
-        Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied too.
+        Copies the data at `foreign_mag_view_or_path` which belongs to another dataset to the current dataset via the filesystem.
+        Additionally, the relevant information from the `datasource-properties.json` of the other dataset are copied, too.
         """
-        return self._add_foreign_mag(
-            foreign_mag_view_or_path,
-            symlink=False,
-            make_relative=False,
-            extend_layer_bounding_box=extend_layer_bounding_box,
+        self.dataset._ensure_writable()
+        foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
+        self._assert_mag_does_not_exist_yet(foreign_mag_view.mag)
+
+        copytree(
+            foreign_mag_view.path,
+            self.path / str(foreign_mag_view.mag),
         )
+
+        mag = self.add_mag_for_existing_files(foreign_mag_view.mag)
+
+        if extend_layer_bounding_box:
+            self.bounding_box = self.bounding_box.extended_by(
+                foreign_mag_view.layer.bounding_box
+            )
+
+        return mag
 
     def _create_dir_for_mag(
         self, mag: Union[int, str, list, tuple, np.ndarray, Mag]
@@ -1065,6 +1079,17 @@ class Layer:
 
     def _get_largest_segment_id_maybe(self) -> Optional[int]:
         return None
+
+    @classmethod
+    def _ensure_layer(cls, layer: Union[str, PathLike, "Layer"]) -> "Layer":
+        if isinstance(layer, Layer):
+            return layer
+        else:
+            # local import to prevent circular dependency
+            from .dataset import Dataset
+
+            layer_path = UPath(layer)
+            return Dataset.open(layer_path.parent).get_layer(layer_path.name)
 
 
 class SegmentationLayer(Layer):

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -1,6 +1,7 @@
 import logging
 import warnings
 from argparse import Namespace
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional, Tuple, Union
 from uuid import uuid4
@@ -355,3 +356,18 @@ class MagView(View):
 
     def __repr__(self) -> str:
         return f"MagView(name={repr(self.name)}, bounding_box={self.bounding_box})"
+
+    @classmethod
+    def _ensure_mag_view(cls, mag_view: Union[str, PathLike, "MagView"]) -> "MagView":
+        if isinstance(mag_view, MagView):
+            return mag_view
+        else:
+            # local import to prevent circular dependency
+            from .dataset import Dataset
+
+            mag_view_path = UPath(mag_view)
+            return (
+                Dataset.open(mag_view_path.parent.parent)
+                .get_layer(mag_view_path.parent.name)
+                .get_mag(mag_view_path.name)
+            )

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -993,3 +993,9 @@ class View:
 
 def _count_defined_values(values: Iterable[Optional[Any]]) -> int:
     return sum(i is not None for i in values)
+
+
+def _copy_job(args: Tuple[View, View, int]) -> None:
+    (source_view, target_view, _) = args
+    # Copy the data form one view to the other in a buffered fashion
+    target_view.write(source_view.read())

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -843,12 +843,9 @@ class View:
                 target_chunk_shape, read_only=target_view.read_only
             )
 
-        assert (
-            not self.bounding_box.is_empty()
-        ), "Calling 'for_zipped_chunks' failed because the size of the source view contains a 0."
-        assert (
-            not target_view.bounding_box.is_empty()
-        ), "Calling 'for_zipped_chunks' failed because the size of the target view contains a 0."
+        if self.bounding_box.is_empty() or target_view.bounding_box.is_empty():
+            return
+
         assert np.array_equal(
             self.bounding_box.size.to_np() / target_view.bounding_box.size.to_np(),
             source_chunk_shape.to_np() / target_chunk_shape.to_np(),


### PR DESCRIPTION
### Description:
* renamed `dataset.add_copy_layer()` to `dataset.add_fs_copy_layer()`
* renamed `layer.add_copy_mag()` to `layer.add_fs_copy_mag()`
* `dataset.add_copy_layer()` and `layer.add_copy_mag()` now read and write the image data
* `dataset.copy_dataset` uses `dataset.add_copy_layer()` internally, continuing to read/write the data

An overview of the different copy and symlink methods after this PR:
```
dataset.copy_dataset(to): data r/w
dataset.shallow_copy_dataset(to): fs symlinking of first-level files & folders (e.g. layers)

dataset.add_copy_layer(from): data r/w
dataset.add_symlink_layer(from): fs symlinking
dataset.add_fs_copy_layer(from): fs copy

layer.add_copy_mag(from): data r/w
layer.add_symlink_mag(from): fs symlinking
layer.add_fs_copy_mag(from): fs copy
```

Should I also add `dataset.fs_copy_dataset()`? Probably not for now, since we've never needed it.

### Issues:
- fixes #784

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
