### PR TITLE
Allow --pad arg in auto conversion entry point

### DIFF
--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -12,6 +12,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Breaking Changes
 
 ### Added
+- The modules `wkcuber` and `wkcuber.converter' also accept `--pad` as a CLI argument to allow converting image data with differing image extents. [#796](https://github.com/scalableminds/webknossos-libs/pull/796)
 
 ### Changed
 

--- a/wkcuber/wkcuber/converter.py
+++ b/wkcuber/wkcuber/converter.py
@@ -48,6 +48,15 @@ def create_parser() -> ArgumentParser:
         type=parse_path,
     )
 
+    parser.add_argument(
+        "--pad",
+        help="Automatically pad image files at the bottom and right borders. "
+        "Use this, when the input images don't have a common size, but have "
+        "their origin at (0, 0).",
+        default=False,
+        action="store_true",
+    )
+
     add_voxel_size_flag(parser)
     add_verbose_flag(parser)
     add_data_format_flags(parser)


### PR DESCRIPTION
### Description:
- Allow --pad arg in auto conversion entry point

I tested it by running `python -m wkcuber --voxel_size 1,1,1 --name test-pad-out --max_mag 1 --pad test-pad test-pad-out` with a `test-pad` folder as input.

### Issues:
- fixes #729 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
