### PR TITLE
added executor argument to all methods in webknossos package that only took args before

### DIFF
--- a/cluster_tools/cluster_tools/__init__.py
+++ b/cluster_tools/cluster_tools/__init__.py
@@ -7,10 +7,11 @@ from concurrent.futures import ProcessPoolExecutor
 from functools import partial
 from pathlib import Path
 from shutil import rmtree
+from typing import Union
 
 from . import pickling
 from .multiprocessing_logging_handler import get_multiprocessing_logging_setup_fn
-from .schedulers.cluster_executor import RemoteOutOfMemoryException
+from .schedulers.cluster_executor import ClusterExecutor, RemoteOutOfMemoryException
 from .schedulers.kube import KubernetesExecutor
 from .schedulers.pbs import PBSExecutor
 from .schedulers.slurm import SlurmExecutor
@@ -353,3 +354,6 @@ def get_executor(environment, **kwargs):
     elif environment == "test_pickling":
         return PickleExecutor(**kwargs)
     raise Exception("Unknown executor: {}".format(environment))
+
+
+Executor = Union[ClusterExecutor, WrappedProcessPoolExecutor]

--- a/docs/poetry.lock
+++ b/docs/poetry.lock
@@ -260,6 +260,14 @@ doh = ["requests-toolbelt", "requests"]
 dnssec = ["cryptography (>=2.6)"]
 
 [[package]]
+name = "entrypoints"
+version = "0.4"
+description = "Discover and load entry points from installed packages."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "fasteners"
 version = "0.17.3"
 description = "A python package that provides useful locks"
@@ -699,14 +707,16 @@ test = ["nose (>=0.11)"]
 
 [[package]]
 name = "numcodecs"
-version = "0.9.1"
+version = "0.10.2"
 description = "A Python package providing buffer compression and transformation codecs for use in data storage and communication applications."
 category = "dev"
 optional = false
-python-versions = ">=3.6, <4"
+python-versions = ">=3.7, <4"
 
 [package.dependencies]
+entrypoints = "*"
 numpy = ">=1.7"
+typing-extensions = ">=3.7.4"
 
 [package.extras]
 msgpack = ["msgpack"]
@@ -1142,7 +1152,7 @@ fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"
 loxun = "^2.0"
 networkx = "^2.6.2"
-numcodecs = "^0.9.1"
+numcodecs = "^0.10"
 numpy = "^1.15.0"
 psutil = "^5.6.7"
 python-dateutil = "^2.8.0"
@@ -1478,6 +1488,10 @@ czifile = [
 dnspython = [
     {file = "dnspython-2.1.0-py3-none-any.whl", hash = "sha256:95d12f6ef0317118d2a1a6fc49aac65ffec7eb8087474158f42f26a639135216"},
     {file = "dnspython-2.1.0.zip", hash = "sha256:e4a87f0b573201a0f3727fa18a516b055fd1107e0e5477cded4a2de497df1dd4"},
+]
+entrypoints = [
+    {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
+    {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
 ]
 fasteners = [
     {file = "fasteners-0.17.3-py3-none-any.whl", hash = "sha256:cae0772df265923e71435cc5057840138f4e8b6302f888a567d06ed8e1cbca03"},
@@ -1870,35 +1884,19 @@ nibabel = [
     {file = "nibabel-2.5.1.tar.gz", hash = "sha256:83ecac4773ece02c49c364d99b465644c17cc66f1719560117e74991d9eb566b"},
 ]
 numcodecs = [
-    {file = "numcodecs-0.9.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2cf6f57cced28ee4590e451b89d9b6c5b2ac2a8251dcc27b7448c11976732944"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:69b1247999a2057542d52532db8ad54bedeb4c9d9c764a68a6908d33dab96e47"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4dec71b95c99a4c5c6ead93741684652ac27723044daad9ee567c2e5569f5514"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:0d5f7bb538727baf6bd8ff142bdbee8babd0be1d7fecbdd9a9cda18614979c1b"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ec5e9eb6f3572c5f24674cc43716f7757b4502db6fb577798380930ecf54f83b"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-win32.whl", hash = "sha256:2e8dbe2da7f9578331d02cd9b010ea446dc45c225f79b6d12b11f17a1106c89a"},
-    {file = "numcodecs-0.9.1-cp36-cp36m-win_amd64.whl", hash = "sha256:96ae1068868762580dbf4596ab82731215524054e99ab0d6f135c49266dd2b40"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cc7b3c526e866404e7555588f61b358728701637f3d02af1e79b80af7fcd99b7"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:3e5b6690910e642e506b47838a3440680eb03291626c5b19b6295e985d4c144b"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f3e831385dd68bbca338b284631cb94076579150744d15f4ca1bfb40e7acb1b8"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:aa5445c236e5e2879be16f0c65dc9a0275f089ed4fc1cb23aae366dbbd7d06f8"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:13968843c19bf611c0091f158cc3f9e39a2eca7c2fb378a53703e7f2c4d57e49"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-win32.whl", hash = "sha256:2ac9ff3f77948226fa3943581a822fa4ad83a21ffe6cce203ee9fe1ee781ed6d"},
-    {file = "numcodecs-0.9.1-cp37-cp37m-win_amd64.whl", hash = "sha256:28e37d461a01176055dcc3fbba57feb78914b84462d5609a3bbfec547da7350a"},
-    {file = "numcodecs-0.9.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e2c57c7803b2d0ace06c3108a36fc6831bc55da8d3614a753ec3ec610c76b771"},
-    {file = "numcodecs-0.9.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:39ff239648cf3fa6aa815d8c46cd2e2eed389a438ea78e57cf13dddc64d575c0"},
-    {file = "numcodecs-0.9.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:20eb92fdc127e4aca6032bcc516ae96aff1e4f1d3ee8caec5989b66f9232cc43"},
-    {file = "numcodecs-0.9.1-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:b5d0f6d2bae464b65e138037ab971125eec7305ce6e43d88b35c62e8c12f8386"},
-    {file = "numcodecs-0.9.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:3fdb7b43984d77f7fa7e7fb0776ad552d1bd7c078bc08564b439202235f52cbe"},
-    {file = "numcodecs-0.9.1-cp38-cp38-win32.whl", hash = "sha256:40f486f8f2d37048ea626e69ec0a08a01c58086bd262d8c2c0f8957122d87af2"},
-    {file = "numcodecs-0.9.1-cp38-cp38-win_amd64.whl", hash = "sha256:b0071925a56d6a32c97ebfaf9ee1e6f2e0c9df3239ccdda1f69306d4f44f0f5a"},
-    {file = "numcodecs-0.9.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:041cf29232b72ef9e0de92b0b182d9eb35819d84c0144b261c911a8c83840596"},
-    {file = "numcodecs-0.9.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:368274b49c80c1fb99481d0afb3a660c069a165b34cc2d1878e9d43058648dcc"},
-    {file = "numcodecs-0.9.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:3978aabf5967d69802becd38508f865d057020a0fdbfa355d736090e6e983d3e"},
-    {file = "numcodecs-0.9.1-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:ad12f1af033b4c36587d923abfabe90a81043912a3f94df790172e1d837b6238"},
-    {file = "numcodecs-0.9.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:c16e28c7907f96e097c74be47490c88e0b5040f862a754892c96e78e7b8aea1b"},
-    {file = "numcodecs-0.9.1-cp39-cp39-win32.whl", hash = "sha256:0bb491c53718b9e7dce8719208c1b0021f31d2544add63014f65304efd140cb8"},
-    {file = "numcodecs-0.9.1-cp39-cp39-win_amd64.whl", hash = "sha256:334110d78cb56d2281cce570f8434a4ed1080b3fb288df9594d82e5bfa42d16f"},
-    {file = "numcodecs-0.9.1.tar.gz", hash = "sha256:35adbcc746b95e3ac92e949a161811f5aa2602b9eb1ef241b5ea6f09bb220997"},
+    {file = "numcodecs-0.10.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a813bdc8b7d1f488562c34b9c6ae65a418008cc05a095c9b04f5aec937646b6a"},
+    {file = "numcodecs-0.10.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cd0850692fddcbd4f4a2b3d690b3fbd5b3adf82dcc5e72c46f89ba77cffde29d"},
+    {file = "numcodecs-0.10.2-cp310-cp310-win_amd64.whl", hash = "sha256:a8a1db53f7cc892bf2af4017ca987e11aac5633c2b8bc3fb94bfc5b5f2e19cca"},
+    {file = "numcodecs-0.10.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:3a0fac8c6e0cdea85ec039e72ea19a0361e6db3f8b8c7b20a467e31e0c767128"},
+    {file = "numcodecs-0.10.2-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfb72d0dcf2e8c4ed274f231324e86ad1e95dc600e83ba67eea984a6d14560cd"},
+    {file = "numcodecs-0.10.2-cp37-cp37m-win_amd64.whl", hash = "sha256:bef5d5ec7bbc2242ae51b7813cdf9ccbf6323aefd7927a3b61e6e8c2902e32e8"},
+    {file = "numcodecs-0.10.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2ccd46e5781fdc0d40cb8317525c859bbf932f56e5815d57ce5f96d1939bdc29"},
+    {file = "numcodecs-0.10.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:cb42dbc2a5cbbbf11a9d61999cb91b9e76b96a69a1f70470a75698161f36abb6"},
+    {file = "numcodecs-0.10.2-cp38-cp38-win_amd64.whl", hash = "sha256:92263324aa756ed335e6809c6c42449023707d63a2980acb1cf51bd69db02160"},
+    {file = "numcodecs-0.10.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:2f63b8023d34735ae31cfcf6de13ffe9322ec3a3cf3500032745e3a6cdb0af09"},
+    {file = "numcodecs-0.10.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0529743371a0b09f81966dc857d2641e292d31bae66b9ed1b385fa49b94e3efc"},
+    {file = "numcodecs-0.10.2-cp39-cp39-win_amd64.whl", hash = "sha256:6cfe0de3990df088567b6f13baf3cb3328ec71c2c0d8885583a86ec9223c3ca1"},
+    {file = "numcodecs-0.10.2.tar.gz", hash = "sha256:22838c6b3fd986bd9c724039b88870057f790e22b20e6e1cbbaa0de142dd59c4"},
 ]
 numpy = [
     {file = "numpy-1.19.5-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cc6bd4fd593cb261332568485e20a0712883cf631f6f5e8e86a52caa8b2b50ff"},

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -13,6 +13,16 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.17...HEAD)
 
 ### Breaking Changes
+- The `executor` argument can now be passed to the following methods,
+  `args` is deprecated now for those [#805](https://github.com/scalableminds/webknossos-libs/pull/805):
+  * `dataset.copy_dataset(…)`
+  * `layer.upsample(…)`
+  * `layer.downsample(…)`
+  * `layer.downsample_mag(…)`
+  * `layer.downsample_mag_list(…)`
+  * `layer.redownsample(…)`
+  * `mag_view.compress(…)`
+  * `view.content_is_equal(…)`
 
 ### Added
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -27,8 +27,7 @@ from typing import (
 import attr
 import numpy as np
 from boltons.typeutils import make_sentinel
-from cluster_tools import WrappedProcessPoolExecutor
-from cluster_tools.schedulers.cluster_executor import ClusterExecutor
+from cluster_tools import Executor
 from upath import UPath
 
 from ..geometry.vec3_int import Vec3Int, Vec3IntLike
@@ -789,7 +788,7 @@ class Dataset:
         channel: Optional[int] = None,
         timepoint: Optional[int] = None,
         batch_size: Optional[int] = None,  # defaults to shard-size z
-        executor: Optional[Union[ClusterExecutor, WrappedProcessPoolExecutor]] = None,
+        executor: Optional[Executor] = None,
         *,
         chunk_size: Optional[Union[Vec3IntLike, int]] = None,  # deprecated
     ) -> Layer:
@@ -901,8 +900,6 @@ class Dataset:
                 category=RuntimeWarning,
                 module="webknossos",
             )
-            if executor is None:
-                executor = get_executor_for_args(None)
             # There are race-conditions about setting the bbox of the layer.
             # The bbox is set correctly afterwards, ignore errors here:
             warnings.filterwarnings(
@@ -911,10 +908,11 @@ class Dataset:
                 category=UserWarning,
                 module="webknossos",
             )
-            shapes_and_max_ids = wait_and_ensure_success(
-                executor.map_to_futures(func_per_chunk, args),
-                progress_desc="Creating layer from images",
-            )
+            with get_executor_for_args(None, executor) as executor:
+                shapes_and_max_ids = wait_and_ensure_success(
+                    executor.map_to_futures(func_per_chunk, args),
+                    progress_desc="Creating layer from images",
+                )
             shapes, max_ids = zip(*shapes_and_max_ids)
             if category == "segmentation":
                 max_id = max(max_ids)
@@ -1009,7 +1007,7 @@ class Dataset:
         chunks_per_shard: Optional[Union[Vec3IntLike, int]] = None,
         data_format: Optional[Union[str, DataFormat]] = None,
         compress: Optional[bool] = None,
-        executor: Optional[Union[ClusterExecutor, WrappedProcessPoolExecutor]] = None,
+        executor: Optional[Executor] = None,
     ) -> Layer:
         """
         Copies the data at `foreign_layer` which belongs to another dataset to the current dataset.
@@ -1142,7 +1140,8 @@ class Dataset:
         chunks_per_shard: Optional[Union[Vec3IntLike, int]] = None,
         data_format: Optional[Union[str, DataFormat]] = None,
         compress: Optional[bool] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
+        executor: Optional[Executor] = None,
         *,
         chunk_size: Optional[Union[Vec3IntLike, int]] = None,  # deprecated
         block_len: Optional[int] = None,  # deprecated
@@ -1180,7 +1179,7 @@ class Dataset:
             voxel_size = self.voxel_size
         new_ds = Dataset(new_dataset_path, voxel_size=voxel_size, exist_ok=False)
 
-        with get_executor_for_args(args) as executor:
+        with get_executor_for_args(args, executor) as executor:
             for layer in self.layers.values():
                 new_ds.add_copy_layer(
                     layer,

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1157,7 +1157,7 @@ class Dataset:
         if args is not None:
             warn_deprecated(
                 "args argument",
-                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+                "executor (e.g. via webknossos.utils.get_executor_for_args(args))",
             )
 
         chunk_shape, chunks_per_shard = _get_sharding_parameters(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1154,6 +1154,12 @@ class Dataset:
         WKW layers can only be copied to datasets on local file systems.
         """
 
+        if args is not None:
+            warn_deprecated(
+                "args argument",
+                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+            )
+
         chunk_shape, chunks_per_shard = _get_sharding_parameters(
             chunk_shape=chunk_shape,
             chunks_per_shard=chunks_per_shard,

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -809,6 +809,13 @@ class Layer:
         of multiple layers while avoiding parallel writes with outdated updates
         to the datasource-properties.json file.
         """
+
+        if args is not None:
+            warn_deprecated(
+                "args argument",
+                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+            )
+
         assert (
             from_mag in self.mags.keys()
         ), f"Failed to downsample data. The from_mag ({from_mag.to_layer_name()}) does not exist."
@@ -970,6 +977,13 @@ class Layer:
 
         `min_mag` is deprecated, please use `finest_mag` instead.
         """
+
+        if args is not None:
+            warn_deprecated(
+                "args argument",
+                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+            )
+
         assert (
             from_mag in self.mags.keys()
         ), f"Failed to upsample data. The from_mag ({from_mag.to_layer_name()}) does not exist."

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -801,13 +801,15 @@ class Layer:
          - "bilinear"
          - "bicubic"
 
-        The `args` can contain information to distribute the computation.
         If allow_overwrite is True, an existing Mag may be overwritten.
 
         If only_setup_mag is True, the magnification is created, but left
         empty. This parameter can be used to prepare for parallel downsampling
         of multiple layers while avoiding parallel writes with outdated updates
         to the datasource-properties.json file.
+
+        `executor` can be passed to allow distrubuted computation, parallelizing
+        across chunks. `args` is deprecated.
         """
 
         if args is not None:

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -1029,7 +1029,7 @@ class Layer:
             target_view = target_mag_view.get_view()
 
             # perform upsampling
-            with get_executor_for_args(args, executor) as executor:
+            with get_executor_for_args(args, executor) as actual_executor:
 
                 if buffer_shape is None:
                     buffer_shape = determine_buffer_shape(prev_mag_view.info)
@@ -1042,7 +1042,7 @@ class Layer:
                     # this view is restricted to the bounding box specified in the properties
                     func,
                     target_view=target_view,
-                    executor=executor,
+                    executor=actual_executor,
                     progress_desc=f"Upsampling from Mag {prev_mag} to Mag {target_mag}",
                 )
 

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -815,7 +815,7 @@ class Layer:
         if args is not None:
             warn_deprecated(
                 "args argument",
-                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+                "executor (e.g. via webknossos.utils.get_executor_for_args(args))",
             )
 
         assert (
@@ -983,7 +983,7 @@ class Layer:
         if args is not None:
             warn_deprecated(
                 "args argument",
-                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+                "executor (e.g. via webknossos.utils.get_executor_for_args(args))",
             )
 
         assert (

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -9,8 +9,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
-from cluster_tools import WrappedProcessPoolExecutor
-from cluster_tools.schedulers.cluster_executor import ClusterExecutor
+from cluster_tools import Executor
 from upath import UPath
 
 from webknossos.dataset.sampling_modes import SamplingModes
@@ -539,7 +538,7 @@ class Layer:
         chunk_shape: Optional[Union[Vec3IntLike, int]] = None,
         chunks_per_shard: Optional[Union[Vec3IntLike, int]] = None,
         compress: Optional[bool] = None,
-        executor: Optional[Union[ClusterExecutor, WrappedProcessPoolExecutor]] = None,
+        executor: Optional[Executor] = None,
     ) -> MagView:
         """
         Copies the data at `foreign_mag_view_or_path` which can belong to another dataset
@@ -677,9 +676,10 @@ class Layer:
         align_with_other_layers: Union[bool, "Dataset"] = True,
         buffer_shape: Optional[Vec3Int] = None,
         force_sampling_scheme: bool = False,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
         allow_overwrite: bool = False,
         only_setup_mags: bool = False,
+        executor: Optional[Executor] = None,
     ) -> None:
         """
         Downsamples the data starting from `from_mag` until a magnification is `>= max(coarsest_mag)`.
@@ -776,6 +776,7 @@ class Layer:
                 args=args,
                 allow_overwrite=allow_overwrite,
                 only_setup_mag=only_setup_mags,
+                executor=executor,
             )
 
     def downsample_mag(
@@ -785,9 +786,10 @@ class Layer:
         interpolation_mode: str = "default",
         compress: bool = True,
         buffer_shape: Optional[Vec3Int] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
         allow_overwrite: bool = False,
         only_setup_mag: bool = False,
+        executor: Optional[Executor] = None,
     ) -> None:
         """
         Performs a single downsampling step from `from_mag` to `target_mag`.
@@ -850,7 +852,7 @@ class Layer:
         )
 
         # perform downsampling
-        with get_executor_for_args(args) as executor:
+        with get_executor_for_args(args, executor) as executor:
             if buffer_shape is None:
                 buffer_shape = determine_buffer_shape(prev_mag_view.info)
             func = named_partial(
@@ -873,7 +875,8 @@ class Layer:
         interpolation_mode: str = "default",
         compress: bool = True,
         buffer_shape: Optional[Vec3Int] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
+        executor: Optional[Executor] = None,
     ) -> None:
         """
         Use this method to recompute downsampled magnifications after mutating data in the
@@ -894,6 +897,7 @@ class Layer:
             buffer_shape=buffer_shape,
             args=args,
             allow_overwrite=True,
+            executor=executor,
         )
 
     def downsample_mag_list(
@@ -903,9 +907,10 @@ class Layer:
         interpolation_mode: str = "default",
         compress: bool = True,
         buffer_shape: Optional[Vec3Int] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
         allow_overwrite: bool = False,
         only_setup_mags: bool = False,
+        executor: Optional[Executor] = None,
     ) -> None:
         """
         Downsamples the data starting at `from_mag` to each magnification in `target_mags` iteratively.
@@ -938,6 +943,7 @@ class Layer:
                 args=args,
                 allow_overwrite=allow_overwrite,
                 only_setup_mag=only_setup_mags,
+                executor=executor,
             )
             source_mag = target_mag
 
@@ -950,7 +956,8 @@ class Layer:
         align_with_other_layers: Union[bool, "Dataset"] = True,
         buffer_shape: Optional[Vec3Int] = None,
         buffer_edge_len: Optional[int] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
+        executor: Optional[Executor] = None,
         *,
         min_mag: Optional[Mag] = None,
     ) -> None:
@@ -1022,7 +1029,7 @@ class Layer:
             target_view = target_mag_view.get_view()
 
             # perform upsampling
-            with get_executor_for_args(args) as executor:
+            with get_executor_for_args(args, executor) as executor:
 
                 if buffer_shape is None:
                     buffer_shape = determine_buffer_shape(prev_mag_view.info)

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 import numpy as np
 import zarr
+from cluster_tools import Executor
 from upath import UPath
 
 from ..geometry import BoundingBox, Mag, Vec3Int, Vec3IntLike
@@ -268,7 +269,8 @@ class MagView(View):
     def compress(
         self,
         target_path: Optional[Union[str, Path]] = None,
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
+        executor: Optional[Executor] = None,
     ) -> None:
         """
         Compresses the files on disk. This has consequences for writing data (see `write`).
@@ -323,7 +325,7 @@ class MagView(View):
                 self.name, str(uncompressed_full_path)
             )
         )
-        with get_executor_for_args(args) as executor:
+        with get_executor_for_args(args, executor) as executor:
             job_args = []
             for bbox in self.get_bounding_boxes_on_disk():
                 bbox = bbox.intersected_with(self.layer.bounding_box, dont_assert=True)

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -292,7 +292,7 @@ class MagView(View):
         if args is not None:
             warn_deprecated(
                 "args argument",
-                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+                "executor (e.g. via webknossos.utils.get_executor_for_args(args))",
             )
 
         if target_path is None:

--- a/webknossos/webknossos/dataset/mag_view.py
+++ b/webknossos/webknossos/dataset/mag_view.py
@@ -12,7 +12,13 @@ from cluster_tools import Executor
 from upath import UPath
 
 from ..geometry import BoundingBox, Mag, Vec3Int, Vec3IntLike
-from ..utils import get_executor_for_args, is_fs_path, rmtree, wait_and_ensure_success
+from ..utils import (
+    get_executor_for_args,
+    is_fs_path,
+    rmtree,
+    wait_and_ensure_success,
+    warn_deprecated,
+)
 from ._array import ArrayInfo, BaseArray, ZarrArray
 from .properties import MagViewProperties
 
@@ -282,6 +288,12 @@ class MagView(View):
         """
 
         from webknossos.dataset.dataset import Dataset
+
+        if args is not None:
+            warn_deprecated(
+                "args argument",
+                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+            )
 
         if target_path is None:
             if self._is_compressed():

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -889,7 +889,7 @@ class View:
         if args is not None:
             warn_deprecated(
                 "args argument",
-                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+                "executor (e.g. via webknossos.utils.get_executor_for_args(args))",
             )
 
         if self.bounding_box.size != other.bounding_box.size:

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -2,22 +2,11 @@ import warnings
 from argparse import Namespace
 from pathlib import Path
 from types import TracebackType
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    Optional,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, Optional, Tuple, Type
 
-import cluster_tools
 import numpy as np
 import wkw
-from cluster_tools.schedulers.cluster_executor import ClusterExecutor
+from cluster_tools import Executor
 
 from ..geometry import BoundingBox, Mag, Vec3Int, Vec3IntLike
 from ..utils import (
@@ -706,9 +695,7 @@ class View:
         self,
         func_per_chunk: Callable[[Tuple["View", int]], None],
         chunk_shape: Optional[Vec3IntLike] = None,  # in Mag(1)
-        executor: Optional[
-            Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]
-        ] = None,
+        executor: Optional[Executor] = None,
         progress_desc: Optional[str] = None,
         *,
         chunk_size: Optional[Vec3IntLike] = None,  # deprecated
@@ -727,7 +714,7 @@ class View:
 
         Example:
         ```python
-        from webknossos.utils import get_executor_for_args, named_partial
+        from webknossos.utils import named_partial
 
         def some_work(args: Tuple[View, int], some_parameter: int) -> None:
             view_of_single_chunk, i = args
@@ -789,9 +776,7 @@ class View:
         target_view: "View",
         source_chunk_shape: Optional[Vec3IntLike] = None,  # in Mag(1)
         target_chunk_shape: Optional[Vec3IntLike] = None,  # in Mag(1)
-        executor: Optional[
-            Union[ClusterExecutor, cluster_tools.WrappedProcessPoolExecutor]
-        ] = None,
+        executor: Optional[Executor] = None,
         progress_desc: Optional[str] = None,
         *,
         source_chunk_size: Optional[Vec3IntLike] = None,  # deprecated
@@ -898,11 +883,12 @@ class View:
     def content_is_equal(
         self,
         other: "View",
-        args: Optional[Namespace] = None,
+        args: Optional[Namespace] = None,  # deprecated
+        executor: Optional[Executor] = None,
     ) -> bool:
         if self.bounding_box.size != other.bounding_box.size:
             return False
-        with get_executor_for_args(args) as executor:
+        with get_executor_for_args(args, executor) as executor:
             try:
                 self.for_zipped_chunks(
                     _assert_check_equality,

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -886,6 +886,12 @@ class View:
         args: Optional[Namespace] = None,  # deprecated
         executor: Optional[Executor] = None,
     ) -> bool:
+        if args is not None:
+            warn_deprecated(
+                "args argument",
+                "executor (e.g. via wk.utils.get_executor_for_args(args))",
+            )
+
         if self.bounding_box.size != other.bounding_box.size:
             return False
         with get_executor_for_args(args, executor) as executor:

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -14,6 +14,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Some methods now take and `executor` argument instead of `args` or `executor_args`.
+  This does not affect the CLI arguments. [#805](https://github.com/scalableminds/webknossos-libs/pull/805)
 
 ### Fixed
 

--- a/wkcuber/wkcuber/__main__.py
+++ b/wkcuber/wkcuber/__main__.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Dict, List
 
 from webknossos import Mag
+from webknossos.utils import get_executor_for_args
 
 from ._internal.utils import (
     add_distribution_flags,
@@ -87,19 +88,20 @@ def cube_with_args(args: Namespace) -> None:
             for mag in mags:
                 compress_mag_inplace(args.target_path, layer_name, mag, args)
 
-    for (layer_path, mags) in layer_path_to_mags.items():
-        layer_name = layer_path.name
-        mags.sort()
-        downsample_mags(
-            path=args.target_path,
-            layer_name=layer_name,
-            from_mag=mags[-1],
-            max_mag=None if args.max_mag is None else Mag(args.max_mag),
-            interpolation_mode="default",
-            compress=not args.no_compress,
-            sampling_mode=args.sampling_mode,
-            args=args,
-        )
+    with get_executor_for_args(args) as executor:
+        for (layer_path, mags) in layer_path_to_mags.items():
+            layer_name = layer_path.name
+            mags.sort()
+            downsample_mags(
+                path=args.target_path,
+                layer_name=layer_name,
+                from_mag=mags[-1],
+                max_mag=None if args.max_mag is None else Mag(args.max_mag),
+                interpolation_mode="default",
+                compress=not args.no_compress,
+                sampling_mode=args.sampling_mode,
+                executor=executor,
+            )
 
     refresh_metadata(args.target_path)
 

--- a/wkcuber/wkcuber/_internal/utils.py
+++ b/wkcuber/wkcuber/_internal/utils.py
@@ -3,7 +3,7 @@ from glob import iglob
 from logging import getLogger
 from math import ceil, floor
 from os import environ
-from typing import Generator, Sequence, Tuple
+from typing import Generator, Sequence, Tuple, Union
 
 import numpy as np
 import wkw

--- a/wkcuber/wkcuber/_internal/utils.py
+++ b/wkcuber/wkcuber/_internal/utils.py
@@ -360,11 +360,3 @@ def convert_mag1_offset(
     mag1_offset: Union[List, np.ndarray], target_mag: Mag
 ) -> np.ndarray:
     return np.array(mag1_offset) // target_mag.to_np()  # floor div
-
-
-def get_executor_args(global_args: argparse.Namespace) -> argparse.Namespace:
-    executor_args = argparse.Namespace()
-    executor_args.jobs = global_args.jobs
-    executor_args.distribution_strategy = global_args.distribution_strategy
-    executor_args.job_resources = global_args.job_resources
-    return executor_args

--- a/wkcuber/wkcuber/downsampling.py
+++ b/wkcuber/wkcuber/downsampling.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from webknossos import Dataset, Mag, Vec3Int, SamplingModes
+from webknossos.utils import get_executor_for_args
 
 from ._internal.utils import (
     add_distribution_flags,
@@ -10,7 +11,6 @@ from ._internal.utils import (
     add_isotropic_flag,
     add_sampling_mode_flag,
     add_verbose_flag,
-    get_executor_args,
     parse_path,
     setup_logging,
     setup_warnings,
@@ -104,7 +104,7 @@ def downsample_mags(
     interpolation_mode: str = "default",
     buffer_shape: Optional[Vec3Int] = None,
     compress: bool = True,
-    args: Optional[Namespace] = None,
+    executor: Optional[Namespace] = None,
     sampling_mode: Union[str, SamplingModes] = SamplingModes.ANISOTROPIC,
     force_sampling_scheme: bool = False,
 ) -> None:
@@ -139,7 +139,7 @@ def downsample_mags(
         sampling_mode=sampling_mode,
         buffer_shape=buffer_shape,
         force_sampling_scheme=force_sampling_scheme,
-        args=args,
+        executor=executor,
     )
 
 
@@ -166,15 +166,16 @@ if __name__ == "__main__":
         else None
     )
 
-    downsample_mags(
-        path=args.path,
-        layer_name=args.layer_name,
-        from_mag=from_mag,
-        max_mag=max_mag,
-        interpolation_mode=args.interpolation_mode,
-        compress=not args.no_compress,
-        sampling_mode=args.sampling_mode,
-        buffer_shape=buffer_shape,
-        force_sampling_scheme=args.force_sampling_scheme,
-        args=get_executor_args(args),
-    )
+    with get_executor_for_args(args) as executor:
+        downsample_mags(
+            path=args.path,
+            layer_name=args.layer_name,
+            from_mag=from_mag,
+            max_mag=max_mag,
+            interpolation_mode=args.interpolation_mode,
+            compress=not args.no_compress,
+            sampling_mode=args.sampling_mode,
+            buffer_shape=buffer_shape,
+            force_sampling_scheme=args.force_sampling_scheme,
+            executor=executor,
+        )

--- a/wkcuber/wkcuber/recubing.py
+++ b/wkcuber/wkcuber/recubing.py
@@ -7,7 +7,6 @@ from ._internal.utils import (
     add_data_format_flags,
     add_distribution_flags,
     add_verbose_flag,
-    get_executor_args,
     parse_path,
     setup_logging,
     setup_warnings,

--- a/wkcuber/wkcuber/recubing.py
+++ b/wkcuber/wkcuber/recubing.py
@@ -1,11 +1,13 @@
 from argparse import ArgumentParser
 
 from webknossos import Dataset
+from webknossos.utils import get_executor_for_args
 
 from ._internal.utils import (
     add_data_format_flags,
     add_distribution_flags,
     add_verbose_flag,
+    get_executor_args,
     parse_path,
     setup_logging,
     setup_warnings,
@@ -45,12 +47,12 @@ if __name__ == "__main__":
     setup_warnings()
     args = create_parser().parse_args()
     setup_logging(args)
-
-    Dataset.open(args.source_path).copy_dataset(
-        args.target_path,
-        data_format=args.data_format,
-        chunk_shape=args.chunk_shape,
-        chunks_per_shard=args.chunks_per_shard,
-        compress=not args.no_compression,
-        args=args,
-    )
+    with get_executor_for_args(args) as executor:
+        Dataset.open(args.source_path).copy_dataset(
+            args.target_path,
+            data_format=args.data_format,
+            chunk_shape=args.chunk_shape,
+            chunks_per_shard=args.chunks_per_shard,
+            compress=not args.no_compression,
+            executor=executor,
+        )


### PR DESCRIPTION
### Description:
- Allow to pass `executor` to relevant wk-libs methods, where previously only `args` was allowed. `args` is deprecated now.
- Cleaned up the `args` passing in wkcuber, mostly passing executors now.

### Issues:
- fixes #370

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
