### PR TITLE
Add annotation.get_volume_layer_segments()

### DIFF
--- a/webknossos/tests/test_annotation.py
+++ b/webknossos/tests/test_annotation.py
@@ -157,11 +157,19 @@ def test_annotation_from_url() -> None:
         mag.read(absolute_offset=(128, 128, 128), size=(10, 10, 10))[0, 0, 0, 0]
         == 286021
     )
+    segment_info = annotation.get_volume_layer_segments("Volume")[2504698]
+    assert segment_info.anchor_position == (2785, 4423, 1792)
+    segment_info.name = "Test Segment"
+    segment_info.color = (1, 0, 0, 1)
 
     annotation.save(TESTOUTPUT_DIR / "test_dummy_downloaded.zip")
     annotation = wk.Annotation.load(TESTOUTPUT_DIR / "test_dummy_downloaded.zip")
     assert annotation.dataset_name == "l4dense_motta_et_al_demo_v2"
     assert len(list(annotation.skeleton.flattened_trees())) == 1
+    segment_info = annotation.get_volume_layer_segments("Volume")[2504698]
+    assert segment_info.anchor_position == (2785, 4423, 1792)
+    assert segment_info.name == "Test Segment"
+    assert segment_info.color == (1, 0, 0, 1)
 
 
 def test_reading_bounding_boxes() -> None:

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -240,6 +240,7 @@ def test_volume_dump_round_trip(tmp_path: Path, layer_name: Optional[str]) -> No
         location="data_Volume.zip",
         fallback_layer="my_very_important_layer",
         name=layer_name,
+        segments=[],
     )
     volume_out = None
 

--- a/webknossos/webknossos/_nml/__init__.py
+++ b/webknossos/webknossos/_nml/__init__.py
@@ -6,5 +6,6 @@ from .meta import Meta
 from .nml import Nml
 from .node import Node
 from .parameters import Parameters
+from .segment import Segment
 from .tree import Tree
 from .volume import Volume

--- a/webknossos/webknossos/_nml/nml.py
+++ b/webknossos/webknossos/_nml/nml.py
@@ -10,6 +10,7 @@ from .group import Group
 from .meta import Meta
 from .node import Node
 from .parameters import Parameters
+from .segment import Segment
 from .tree import Tree
 from .volume import Volume
 
@@ -135,6 +136,11 @@ class Nml(NamedTuple):
                     group = Group._parse(elem)
                     group_stack[-1].children.append(group)
                     group_stack.append(group)
+                elif elem.tag == "segment":
+                    segment = Segment._parse(elem)
+                    if volumes[-1].segments is None:
+                        volumes[-1].segments = []
+                    volumes[-1].segments.append(segment)
             elif event == "end":
                 if elem.tag == "parameters":
                     parameters = Parameters._parse(elem)

--- a/webknossos/webknossos/_nml/segment.py
+++ b/webknossos/webknossos/_nml/segment.py
@@ -1,0 +1,71 @@
+from typing import NamedTuple, Optional
+from xml.etree.ElementTree import Element
+
+from loxun import XmlWriter
+
+from webknossos.geometry import Vec3Int
+
+from .utils import Vector4, enforce_not_null, filter_none_values
+
+
+class Segment(NamedTuple):
+    id: int
+    name: Optional[str]
+    anchor_position: Optional[Vec3Int]
+    color: Optional[Vector4]
+
+    def _dump(self, xf: XmlWriter) -> None:
+        if self.anchor_position is None:
+            anchor_position_dict = {}
+        else:
+            anchor_position_dict = {
+                "anchorPositionX": str(self.anchor_position.x),
+                "anchorPositionY": str(self.anchor_position.y),
+                "anchorPositionZ": str(self.anchor_position.z),
+            }
+        if self.color is None:
+            color_dict = {}
+        else:
+            color_dict = {
+                "color.r": str(self.color[0]),
+                "color.g": str(self.color[1]),
+                "color.b": str(self.color[2]),
+                "color.a": str(self.color[3]),
+            }
+        xf.tag(
+            "segment",
+            filter_none_values(
+                {
+                    "id": str(self.id),
+                    "name": self.name,
+                    **anchor_position_dict,
+                    **color_dict,
+                }
+            ),
+        )
+
+    @classmethod
+    def _parse(cls, nml_segment: Element) -> "Segment":
+        if nml_segment.get("color.r") is None:
+            color = None
+        else:
+            color = (
+                float(enforce_not_null(nml_segment.get("color.r"))),
+                float(enforce_not_null(nml_segment.get("color.g"))),
+                float(enforce_not_null(nml_segment.get("color.b"))),
+                float(enforce_not_null(nml_segment.get("color.a"))),
+            )
+        if nml_segment.get("anchorPositionX") is None:
+            anchor_position = None
+        else:
+            anchor_position = Vec3Int(
+                int(enforce_not_null(nml_segment.get("anchorPositionX"))),
+                int(enforce_not_null(nml_segment.get("anchorPositionY"))),
+                int(enforce_not_null(nml_segment.get("anchorPositionZ"))),
+            )
+        return cls(
+            int(enforce_not_null(nml_segment.get("id"))),
+            name=nml_segment.get("name"),
+            anchor_position=anchor_position,
+            color=color,
+        )

--- a/webknossos/webknossos/annotation/_nml_conversion.py
+++ b/webknossos/webknossos/annotation/_nml_conversion.py
@@ -175,6 +175,15 @@ def annotation_to_nml(  # pylint: disable=dangerous-default-value
                 location=volume._default_zip_name(),
                 fallback_layer=volume.fallback_layer_name,
                 name=volume.name,
+                segments=[
+                    wknml.Segment(
+                        id=segment_id,
+                        name=segment_info.name,
+                        anchor_position=segment_info.anchor_position,
+                        color=segment_info.color,
+                    )
+                    for segment_id, segment_info in volume.segments.items()
+                ],
             )
         )
 

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -52,11 +52,12 @@ from webknossos.annotation._nml_conversion import annotation_to_nml, nml_to_skel
 from webknossos.client._generated.api.default import dataset_info
 from webknossos.dataset import SEGMENTATION_CATEGORY, Dataset, Layer, SegmentationLayer
 from webknossos.dataset.dataset import RemoteDataset
-from webknossos.geometry import BoundingBox
+from webknossos.geometry import BoundingBox, Vec3Int
 from webknossos.skeleton import Skeleton
 from webknossos.utils import time_since_epoch_in_ms, warn_deprecated
 
 Vector3 = Tuple[float, float, float]
+Vector4 = Tuple[float, float, float, float]
 
 
 MAG_RE = r"((\d+-\d+-)?\d+)"
@@ -66,11 +67,19 @@ ANNOTATION_WKW_PATH_RE = re.compile(rf"{MAG_RE}{SEP_RE}(header\.wkw|{CUBE_RE})")
 
 
 @attr.define
+class SegmentInformation:
+    name: Optional[str]
+    anchor_position: Optional[Vec3Int]
+    color: Optional[Vector4]
+
+
+@attr.define
 class _VolumeLayer:
     id: int
     name: str
     fallback_layer_name: Optional[str]
     zip: Optional[ZipPath]
+    segments: Dict[int, SegmentInformation]
 
     def _default_zip_name(self) -> str:
         return f"data_{self.id}_{self.name}.zip"
@@ -353,12 +362,21 @@ class Annotation:
                         volume_path = None
                     else:
                         volume_path = fitting_volume_paths[0]
+            segments = {}
+            if volume.segments is not None:
+                for segment in volume.segments:
+                    segments[segment.id] = SegmentInformation(
+                        name=segment.name,
+                        anchor_position=segment.anchor_position,
+                        color=segment.color,
+                    )
             volume_layers.append(
                 _VolumeLayer(
                     id=volume.id,
                     name="Volume" if volume.name is None else volume.name,
                     fallback_layer_name=volume.fallback_layer,
                     zip=volume_path,
+                    segments=segments,
                 )
             )
         assert len(set(i.id for i in volume_layers)) == len(
@@ -544,6 +562,7 @@ class Annotation:
                 name=name,
                 fallback_layer_name=fallback_layer_name,
                 zip=None,
+                segments={},
             )
         )
 
@@ -708,6 +727,19 @@ class Annotation:
             input_annotation_dataset._read_only = True
 
             yield input_annotation_layer
+
+    def get_volume_layer_segments(
+        self,
+        volume_layer_name: Optional[str] = None,
+        volume_layer_id: Optional[int] = None,
+    ) -> Dict[int, SegmentInformation]:
+        """Returns a dict mapping from segment ids to `SegmentInformation`.
+        The dict is mutable, changes to the returned instance are saved in the annotation."""
+        layer = self._get_volume_layer(
+            volume_layer_name=volume_layer_name,
+            volume_layer_id=volume_layer_id,
+        )
+        return layer.segments
 
 
 Annotation._set_init_docstring()


### PR DESCRIPTION
### Description:
This PR
* adds parsing and serialization of segment information in NMLs
* represents those in an annotation
* adds `annotation.get_volume_layer_segments()` to interact with those

### Issues:
- fixes #772

### Todos:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
