### PR TITLE
Always try pims.ImageSequence if pims.open did not succeed

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Fixed
 
+- Fixed a bug where some image sequences could not be read in layer_from_images. [#817](https://github.com/scalableminds/webknossos-libs/pull/817)
+
 
 ## [0.10.21](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.21) - 2022-10-26
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.20...v0.10.21)

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -267,7 +267,7 @@ class PimsImages:
                         original_images = str(original_images)
                     try:
                         images_context_manager = pims.open(original_images)
-                    except TypeError:
+                    except Exception:
                         images_context_manager = pims.ImageSequence(original_images)
 
             with images_context_manager as images:


### PR DESCRIPTION
- I got a `pims.UnknownFormatError` when trying `pims.open`. ImageSequence works, but wasn’t tried.

 - [x] Updated Changelog
