### PR TITLE
ds.add_layer_from_images: added topleft and dtype kwargs

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 - `ds.add_layer_from_images`: Turned some arguments into keyword-only arguments, only affecting positional arguments after the first 8 arguments. [#818](https://github.com/scalableminds/webknossos-libs/pull/818)
 
 ### Added
-- `ds.add_layer_from_images`: added topleft and enforce_dtype kw-only arguments. [#818](https://github.com/scalableminds/webknossos-libs/pull/818)
+- `ds.add_layer_from_images`: added topleft and dtype kw-only arguments. [#818](https://github.com/scalableminds/webknossos-libs/pull/818)
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -13,8 +13,10 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.22...HEAD)
 
 ### Breaking Changes
+- `ds.add_layer_from_images`: Turned some arguments into keyword-only arguments, only affecting positional arguments after the first 8 arguments. [#818](https://github.com/scalableminds/webknossos-libs/pull/818)
 
 ### Added
+- `ds.add_layer_from_images`: added topleft and enforce_dtype kw-only arguments. [#818](https://github.com/scalableminds/webknossos-libs/pull/818)
 
 ### Changed
 
@@ -25,9 +27,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.21...v0.10.22)
 
 ### Fixed
-
 - Fixed a bug where some image sequences could not be read in layer_from_images. [#817](https://github.com/scalableminds/webknossos-libs/pull/817)
-
 
 
 ## [0.10.21](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.21) - 2022-10-26
@@ -42,8 +42,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Fixed
 - `annotation.temporary_volume_layer_copy()` works also with empty volume annotations. [#814](https://github.com/scalableminds/webknossos-libs/pull/814)
-
-
 
 
 ## [0.10.19](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.10.19) - 2022-10-18

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -22,7 +22,9 @@ def test_compare_tifffile(tmp_path: Path) -> None:
         layer_name="compare_tifffile",
         compress=True,
         category="segmentation",
+        topleft=(100, 100, 55),
     )
+    assert l.bounding_box.topleft == wk.Vec3Int(100, 100, 55)
     data = l.get_finest_mag().read()[0, :, :]
     for z_index in range(0, data.shape[-1]):
         with TiffFile("testdata/tiff/test.0000.tiff") as tif_file:
@@ -60,8 +62,8 @@ REPO_IMAGES_ARGS: List[
     ),
     (
         "testdata/rgb_tiff/test_rgb.tif",
-        {"mag": 2, "channel": 1},
-        "uint8",
+        {"mag": 2, "channel": 1, "enforce_dtype": "uint32"},
+        "uint32",
         1,
         (64, 64, 2),
     ),

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -62,7 +62,7 @@ REPO_IMAGES_ARGS: List[
     ),
     (
         "testdata/rgb_tiff/test_rgb.tif",
-        {"mag": 2, "channel": 1, "enforce_dtype": "uint32"},
+        {"mag": 2, "channel": 1, "dtype": "uint32"},
         "uint32",
         1,
         (64, 64, 2),

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -303,7 +303,7 @@ class PimsImages:
         args: Tuple[int, int],
         mag_view: MagView,
         is_segmentation: bool,
-        enforce_dtype: Optional[DTypeLike] = None,
+        dtype: Optional[DTypeLike] = None,
     ) -> Tuple[Tuple[int, int], Optional[int]]:
         """Copies the images according to the passed arguments to the given mag_view.
         args is expected to be the start and end of the z-range, meant for usage with an executor."""
@@ -348,8 +348,8 @@ class PimsImages:
                     if self._flip_y:
                         image_slice = np.flip(image_slice, -1)
 
-                    if enforce_dtype is not None:
-                        image_slice = image_slice.astype(enforce_dtype, order="F")
+                    if dtype is not None:
+                        image_slice = image_slice.astype(dtype, order="F")
 
                     if max_id is not None:
                         max_id = max(max_id, image_slice.max())

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -19,9 +19,9 @@ from typing import (
 from urllib.error import HTTPError
 
 import numpy as np
-from numpy.typing import DTypeLike
 
 from webknossos.dataset.mag_view import MagView
+from webknossos.dataset.layer import DTypeLike
 from webknossos.geometry.vec3_int import Vec3Int
 
 try:
@@ -33,6 +33,10 @@ except ImportError as e:
 
 
 class PimsImages:
+    dtype: DTypeLike
+    expected_shape: Vec3Int
+    num_channels: int
+
     def __init__(
         self,
         images: Union[str, Path, "pims.FramesSequence", List[Union[str, PathLike]]],

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -20,8 +20,8 @@ from urllib.error import HTTPError
 
 import numpy as np
 
-from webknossos.dataset.mag_view import MagView
 from webknossos.dataset.layer import DTypeLike
+from webknossos.dataset.mag_view import MagView
 from webknossos.geometry.vec3_int import Vec3Int
 
 try:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -58,6 +58,7 @@ from ..utils import (
 from ._utils.from_images import guess_if_segmentation_path
 from ._utils.infer_bounding_box_existing_files import infer_bounding_box_existing_files
 from .layer import (
+    DTypeLike,
     Layer,
     SegmentationLayer,
     _dtype_per_channel_to_element_class,
@@ -65,7 +66,6 @@ from .layer import (
     _get_sharding_parameters,
     _normalize_dtype_per_channel,
     _normalize_dtype_per_layer,
-    DTypeLike
 )
 from .layer_categories import COLOR_CATEGORY, SEGMENTATION_CATEGORY, LayerCategoryType
 from .properties import (

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -983,7 +983,7 @@ class Dataset:
         flip_x: bool = False,
         flip_y: bool = False,
         flip_z: bool = False,
-        enforce_dtype: Optional[DTypeLike] = None,
+        dtype: Optional[DTypeLike] = None,
         use_bioformats: bool = False,
         channel: Optional[int] = None,
         timepoint: Optional[int] = None,
@@ -1011,7 +1011,7 @@ class Dataset:
         * `topleft`: set an offset in Mag(1) to start writing the data, only affecting the output
         * `swap_xy`: set to `True` to interchange x and y axis before writing to disk
         * `flip_x`, `flip_y`, `flip_z`: set to `True` to reverse the respective axis before writing to disk
-        * `enforce_dtype`: the read image data will be convertoed to this dtype using `numpy.ndarray.astype`
+        * `dtype`: the read image data will be convertoed to this dtype using `numpy.ndarray.astype`
         * `use_bioformats`: set to `True` to use the [pims bioformats adapter](https://soft-matter.github.io/pims/v0.6.1/bioformats.html), needs a JVM
         * `channel`: may be used to select a single channel, if multiple are available,
         * `timepoint`: for timeseries, select a timepoint to use by specifying it as an int, starting from 0
@@ -1046,9 +1046,7 @@ class Dataset:
             layer_name=layer_name,
             category=category,
             data_format=data_format,
-            dtype_per_channel=pims_images.dtype
-            if enforce_dtype is None
-            else enforce_dtype,
+            dtype_per_channel=pims_images.dtype if dtype is None else dtype,
             num_channels=pims_images.num_channels,
             **add_layer_kwargs,  # type: ignore[arg-type]
         )
@@ -1083,7 +1081,7 @@ class Dataset:
             pims_images.copy_to_view,
             mag_view=mag_view,
             is_segmentation=category == "segmentation",
-            enforce_dtype=enforce_dtype,
+            dtype=dtype,
         )
 
         args = []

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1011,6 +1011,7 @@ class Dataset:
         * `topleft`: set an offset in Mag(1) to start writing the data, only affecting the output
         * `swap_xy`: set to `True` to interchange x and y axis before writing to disk
         * `flip_x`, `flip_y`, `flip_z`: set to `True` to reverse the respective axis before writing to disk
+        * `enforce_dtype`: the read image data will be convertoed to this dtype using `numpy.ndarray.astype`
         * `use_bioformats`: set to `True` to use the [pims bioformats adapter](https://soft-matter.github.io/pims/v0.6.1/bioformats.html), needs a JVM
         * `channel`: may be used to select a single channel, if multiple are available,
         * `timepoint`: for timeseries, select a timepoint to use by specifying it as an int, starting from 0

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -31,7 +31,6 @@ import numpy as np
 from boltons.typeutils import make_sentinel
 from cluster_tools import Executor
 from natsort import natsort_keygen
-from numpy.typing import DTypeLike
 from upath import UPath
 
 from ..geometry.vec3_int import Vec3Int, Vec3IntLike
@@ -66,6 +65,7 @@ from .layer import (
     _get_sharding_parameters,
     _normalize_dtype_per_channel,
     _normalize_dtype_per_layer,
+    DTypeLike
 )
 from .layer_categories import COLOR_CATEGORY, SEGMENTATION_CATEGORY, LayerCategoryType
 from .properties import (
@@ -739,8 +739,8 @@ class Dataset:
         self,
         layer_name: str,
         category: LayerCategoryType,
-        dtype_per_layer: Optional[Union[str, np.dtype, type]] = None,
-        dtype_per_channel: Optional[Union[str, np.dtype, type, DTypeLike]] = None,
+        dtype_per_layer: Optional[DTypeLike] = None,
+        dtype_per_channel: Optional[DTypeLike] = None,
         num_channels: Optional[int] = None,
         data_format: Union[str, DataFormat] = DEFAULT_DATA_FORMAT,
         **kwargs: Any,
@@ -847,8 +847,8 @@ class Dataset:
         self,
         layer_name: str,
         category: LayerCategoryType,
-        dtype_per_layer: Optional[Union[str, np.dtype, type]] = None,
-        dtype_per_channel: Optional[Union[str, np.dtype, type]] = None,
+        dtype_per_layer: Optional[DTypeLike] = None,
+        dtype_per_channel: Optional[DTypeLike] = None,
         num_channels: Optional[int] = None,
         data_format: Union[str, DataFormat] = DEFAULT_DATA_FORMAT,
         **kwargs: Any,

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -54,7 +54,6 @@ from .defaults import (
 )
 from .mag_view import MagView, _find_mag_path_on_disk
 
-
 try:
     from numpy.typing import DTypeLike
 except:
@@ -87,9 +86,7 @@ def _convert_dtypes(
     return "".join(converted_dtype_parts)
 
 
-def _normalize_dtype_per_channel(
-    dtype_per_channel: DTypeLike
-) -> np.dtype:
+def _normalize_dtype_per_channel(dtype_per_channel: DTypeLike) -> np.dtype:
     try:
         return np.dtype(dtype_per_channel)
     except TypeError as e:
@@ -98,9 +95,7 @@ def _normalize_dtype_per_channel(
         ) from e
 
 
-def _normalize_dtype_per_layer(
-    dtype_per_layer: DTypeLike
-) -> DTypeLike:
+def _normalize_dtype_per_layer(dtype_per_layer: DTypeLike) -> DTypeLike:
     try:
         dtype_per_layer = str(np.dtype(dtype_per_layer))
     except Exception:

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -55,6 +55,12 @@ from .defaults import (
 from .mag_view import MagView, _find_mag_path_on_disk
 
 
+try:
+    from numpy.typing import DTypeLike
+except:
+    DTypeLike = Union[str, np.dtype, type]  # type: ignore[misc]
+
+
 def _is_int(s: str) -> bool:
     try:
         int(s)
@@ -64,7 +70,7 @@ def _is_int(s: str) -> bool:
 
 
 def _convert_dtypes(
-    dtype: Union[str, np.dtype],
+    dtype: DTypeLike,
     num_channels: int,
     dtype_per_layer_to_dtype_per_channel: bool,
 ) -> str:
@@ -82,7 +88,7 @@ def _convert_dtypes(
 
 
 def _normalize_dtype_per_channel(
-    dtype_per_channel: Union[str, np.dtype, type]
+    dtype_per_channel: DTypeLike
 ) -> np.dtype:
     try:
         return np.dtype(dtype_per_channel)
@@ -93,8 +99,8 @@ def _normalize_dtype_per_channel(
 
 
 def _normalize_dtype_per_layer(
-    dtype_per_layer: Union[str, np.dtype, type]
-) -> Union[str, np.dtype]:
+    dtype_per_layer: DTypeLike
+) -> DTypeLike:
     try:
         dtype_per_layer = str(np.dtype(dtype_per_layer))
     except Exception:
@@ -103,7 +109,7 @@ def _normalize_dtype_per_layer(
 
 
 def _dtype_per_layer_to_dtype_per_channel(
-    dtype_per_layer: Union[str, np.dtype], num_channels: int
+    dtype_per_layer: DTypeLike, num_channels: int
 ) -> np.dtype:
     try:
         return np.dtype(
@@ -118,7 +124,7 @@ def _dtype_per_layer_to_dtype_per_channel(
 
 
 def _dtype_per_channel_to_dtype_per_layer(
-    dtype_per_channel: Union[str, np.dtype], num_channels: int
+    dtype_per_channel: DTypeLike, num_channels: int
 ) -> str:
     return _convert_dtypes(
         np.dtype(dtype_per_channel),
@@ -128,7 +134,7 @@ def _dtype_per_channel_to_dtype_per_layer(
 
 
 def _dtype_per_channel_to_element_class(
-    dtype_per_channel: Union[str, np.dtype], num_channels: int
+    dtype_per_channel: DTypeLike, num_channels: int
 ) -> str:
     dtype_per_layer = _dtype_per_channel_to_dtype_per_layer(
         dtype_per_channel, num_channels

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -56,7 +56,7 @@ from .mag_view import MagView, _find_mag_path_on_disk
 
 try:
     from numpy.typing import DTypeLike
-except:
+except ImportError:
     DTypeLike = Union[str, np.dtype, type]  # type: ignore[misc]
 
 


### PR DESCRIPTION
### Description:
- `ds.add_layer_from_images`:
  * Turned some arguments into keyword-only arguments, only affecting positional arguments after the first 8 arguments
  * added topleft and dtype kw-only arguments
- cleaned up the dtype type annotations, using `np.typing.DTypeLike` now if available.

### Issues:
- part of #748

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
