### PR TITLE
Update cattrs to 22.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,7 +309,7 @@ jobs:
             --batch_size 8 \
             --layer_name color \
             --chunks_per_shard 32 \
-            --scale 1 \
+            --voxel_size 1,1,1 \
             testdata/tiff testoutput/tiff
 
     - name: Login to docker

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Updated cattrs dependency to 22.2.0. [#819](https://github.com/scalableminds/webknossos-libs/pull/819)
 
 ### Fixed
 

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -1815,7 +1815,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "1daacf205af44ee5ff95f3d44234ce4475f2071bb20207f4800b0fff22ee8fb0"
+content-hash = "ec4b0e2863b9361b46714ba9186b36ec6c64a5ec82727f3c582691253085d525"
 
 [metadata.files]
 aiobotocore = [

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -1815,7 +1815,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "da4770dd349bdd62bf959fe47e12ee38f683d3fa914225e3518230826c2caf6a"
+content-hash = "1daacf205af44ee5ff95f3d44234ce4475f2071bb20207f4800b0fff22ee8fb0"
 
 [metadata.files]
 aiobotocore = [

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -232,15 +232,16 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "cattrs"
-version = "1.9.0"
+version = "22.2.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=20"
-typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "certifi"
@@ -373,6 +374,17 @@ description = "Discover and load entry points from installed packages."
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "executing"
@@ -1803,7 +1815,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "a22669a0b8f8bcc22d26782a7cd4c5dbad4048e1ead22e3661901a4bcc9dd892"
+content-hash = "da4770dd349bdd62bf959fe47e12ee38f683d3fa914225e3518230826c2caf6a"
 
 [metadata.files]
 aiobotocore = [
@@ -1946,8 +1958,8 @@ cachetools = [
     {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 cattrs = [
-    {file = "cattrs-1.9.0-py3-none-any.whl", hash = "sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678"},
-    {file = "cattrs-1.9.0.tar.gz", hash = "sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80"},
+    {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
+    {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -2041,6 +2053,10 @@ dill = [
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.1-py3-none-any.whl", hash = "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a"},
+    {file = "exceptiongroup-1.0.1.tar.gz", hash = "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"},
 ]
 executing = [
     {file = "executing-0.8.3-py2.py3-none-any.whl", hash = "sha256:d1eef132db1b83649a3905ca6dd8897f71ac6f8cac79a7e58a1a09cf137546c9"},

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -232,14 +232,15 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "cattrs"
-version = "1.7.1"
+version = "1.9.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-attrs = ">=20.1.0"
+attrs = ">=20"
+typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
 
 [[package]]
 name = "certifi"
@@ -320,7 +321,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "cycler"
@@ -732,8 +733,8 @@ python-versions = "*"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
+docs = ["readthedocs-sphinx-ext", "sphinx", "sphinx-rtd-theme"]
 tests = ["pytest"]
-docs = ["sphinx-rtd-theme", "sphinx", "readthedocs-sphinx-ext"]
 
 [[package]]
 name = "jsonschema"
@@ -982,9 +983,9 @@ jsonschema = ">=3.0.0"
 six = "*"
 
 [package.extras]
-strict_rfc3339 = ["strict-rfc3339"]
-rfc3339_validator = ["rfc3339-validator"]
 isodate = ["isodate"]
+rfc3339_validator = ["rfc3339-validator"]
+strict_rfc3339 = ["strict-rfc3339"]
 
 [[package]]
 name = "openapi-spec-validator"
@@ -1001,8 +1002,8 @@ PyYAML = ">=5.1"
 six = "*"
 
 [package.extras]
-requests = ["requests"]
 dev = ["pre-commit"]
+requests = ["requests"]
 
 [[package]]
 name = "packaging"
@@ -1048,7 +1049,7 @@ locket = "*"
 toolz = "*"
 
 [package.extras]
-complete = ["blosc", "pyzmq", "pandas (>=0.19.0)", "numpy (>=1.9.0)"]
+complete = ["numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq", "blosc"]
 
 [[package]]
 name = "pathspec"
@@ -1107,8 +1108,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "pooch"
@@ -1124,9 +1125,9 @@ packaging = ">=20.0"
 requests = ">=2.19.0"
 
 [package.extras]
-xxhash = ["xxhash (>=1.4.3)"]
-sftp = ["paramiko (>=2.7.0)"]
 progress = ["tqdm (>=4.41.0,<5.0.0)"]
+sftp = ["paramiko (>=2.7.0)"]
+xxhash = ["xxhash (>=1.4.3)"]
 
 [[package]]
 name = "psutil"
@@ -1495,10 +1496,10 @@ scipy = ">=1.1.0"
 threadpoolctl = ">=2.0.0"
 
 [package.extras]
-tests = ["pyamg (>=4.0.0)", "mypy (>=0.770)", "black (>=21.6b0)", "flake8 (>=3.8.2)", "pytest-cov (>=2.9.0)", "pytest (>=5.0.1)", "pandas (>=0.25.0)", "scikit-image (>=0.14.5)", "matplotlib (>=2.2.3)"]
-examples = ["seaborn (>=0.9.0)", "pandas (>=0.25.0)", "scikit-image (>=0.14.5)", "matplotlib (>=2.2.3)"]
-docs = ["sphinxext-opengraph (>=0.4.2)", "sphinx-prompt (>=1.3.0)", "Pillow (>=7.1.2)", "numpydoc (>=1.0.0)", "sphinx-gallery (>=0.7.0)", "sphinx (>=4.0.1)", "memory-profiler (>=0.57.0)", "seaborn (>=0.9.0)", "pandas (>=0.25.0)", "scikit-image (>=0.14.5)", "matplotlib (>=2.2.3)"]
-benchmark = ["memory-profiler (>=0.57.0)", "pandas (>=0.25.0)", "matplotlib (>=2.2.3)"]
+benchmark = ["matplotlib (>=2.2.3)", "pandas (>=0.25.0)", "memory-profiler (>=0.57.0)"]
+docs = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=4.0.1)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.0.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
+examples = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)"]
+tests = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "black (>=21.6b0)", "mypy (>=0.770)", "pyamg (>=4.0.0)"]
 
 [[package]]
 name = "scipy"
@@ -1652,10 +1653,10 @@ python-versions = ">=3.6"
 click = ">=7.1.1,<7.2.0"
 
 [package.extras]
-test = ["isort (>=5.0.6,<6.0.0)", "black (>=19.10b0,<20.0b0)", "mypy (==0.782)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "coverage (>=5.2,<6.0)", "pytest-cov (>=2.10.0,<3.0.0)", "pytest (>=4.4.0,<5.4.0)", "shellingham (>=1.3.0,<2.0.0)"]
-doc = ["markdown-include (>=0.5.1,<0.6.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "mkdocs (>=1.1.2,<2.0.0)"]
-dev = ["flake8 (>=3.8.3,<4.0.0)", "autoflake (>=1.3.1,<2.0.0)"]
-all = ["shellingham (>=1.3.0,<2.0.0)", "colorama (>=0.4.3,<0.5.0)"]
+test = ["pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.782)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)", "shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)"]
+all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
+dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
+doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
 
 [[package]]
 name = "types-python-dateutil"
@@ -1802,7 +1803,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "e89dd01189a955c785911378891c456779e53c0781b1f8e70df2423f107bb69b"
+content-hash = "a22669a0b8f8bcc22d26782a7cd4c5dbad4048e1ead22e3661901a4bcc9dd892"
 
 [metadata.files]
 aiobotocore = [
@@ -1945,8 +1946,8 @@ cachetools = [
     {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 cattrs = [
-    {file = "cattrs-1.7.1-py3-none-any.whl", hash = "sha256:d69bd4a3239e189f0740c3c41178dd0f00e4eac3bcb806937e49942fa83adfee"},
-    {file = "cattrs-1.7.1.tar.gz", hash = "sha256:95265b8aaa45e6de75b5f52ae081e021a2a7a688babdb711e4174e6b18920d08"},
+    {file = "cattrs-1.9.0-py3-none-any.whl", hash = "sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678"},
+    {file = "cattrs-1.9.0.tar.gz", hash = "sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -3198,10 +3199,7 @@ typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
-universal-pathlib = [
-    {file = "universal_pathlib-0.0.19-py3-none-any.whl", hash = "sha256:72df949935a12b7e6614481bb406df82383db52c58acba1bb44246762c76b127"},
-    {file = "universal_pathlib-0.0.19.tar.gz", hash = "sha256:382a6de60565faf33c39d9791d8a5c453e39b88ed19e8982de9bbffd5930800c"},
-]
+universal-pathlib = []
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -33,7 +33,7 @@ python = ">=3.7.1,<3.10"
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "1.9.0"
+cattrs = "22.2.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -33,7 +33,7 @@ python = ">=3.7.1,<3.10"
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = ">=1.7.1,<=22.2.0"
+cattrs = ">=1.7.1"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -33,7 +33,7 @@ python = ">=3.7.1,<3.10"
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "22.2.0"
+cattrs = ">=1.7.1,<=22.2.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -33,7 +33,7 @@ python = ">=3.7.1,<3.10"
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "1.7.1"
+cattrs = "1.9.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"

--- a/wkcuber/Changelog.md
+++ b/wkcuber/Changelog.md
@@ -14,6 +14,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Updated cattrs dependency to 22.2.0. [#819](https://github.com/scalableminds/webknossos-libs/pull/819)
 
 ### Fixed
 

--- a/wkcuber/poetry.lock
+++ b/wkcuber/poetry.lock
@@ -198,15 +198,16 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "cattrs"
-version = "1.9.0"
+version = "22.2.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
-python-versions = ">=3.7,<4.0"
+python-versions = ">=3.7"
 
 [package.dependencies]
 attrs = ">=20"
-typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
+exceptiongroup = {version = "*", markers = "python_version < \"3.11\""}
+typing_extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [[package]]
 name = "certifi"
@@ -324,6 +325,17 @@ description = "Discover and load entry points from installed packages."
 category = "main"
 optional = false
 python-versions = ">=3.6"
+
+[[package]]
+name = "exceptiongroup"
+version = "1.0.1"
+description = "Backport of PEP 654 (exception groups)"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+test = ["pytest (>=6)"]
 
 [[package]]
 name = "fasteners"
@@ -1260,7 +1272,7 @@ develop = true
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "1.9.0"
+cattrs = "22.2.0"
 cluster_tools = {path = "../cluster_tools", develop = true}
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"
@@ -1373,7 +1385,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "8cf981e1e0c586067b4ee56d5a6df34769dd4ad72e7db50d14991545764bdaed"
+content-hash = "5dbf903b494fcd2cbe8b183766fb1dbb124ef14c350b85094624eabfdbf432f5"
 
 [metadata.files]
 aiobotocore = [
@@ -1526,8 +1538,8 @@ cachetools = [
     {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 cattrs = [
-    {file = "cattrs-1.9.0-py3-none-any.whl", hash = "sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678"},
-    {file = "cattrs-1.9.0.tar.gz", hash = "sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80"},
+    {file = "cattrs-22.2.0-py3-none-any.whl", hash = "sha256:bc12b1f0d000b9f9bee83335887d532a1d3e99a833d1bf0882151c97d3e68c21"},
+    {file = "cattrs-22.2.0.tar.gz", hash = "sha256:f0eed5642399423cf656e7b66ce92cdc5b963ecafd041d1b24d136fdde7acf6d"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -1617,6 +1629,10 @@ dill = [
 entrypoints = [
     {file = "entrypoints-0.4-py3-none-any.whl", hash = "sha256:f174b5ff827504fd3cd97cc3f8649f3693f51538c7e4bdf3ef002c8429d42f9f"},
     {file = "entrypoints-0.4.tar.gz", hash = "sha256:b706eddaa9218a19ebcd67b56818f05bb27589b1ca9e8d797b74affad4ccacd4"},
+]
+exceptiongroup = [
+    {file = "exceptiongroup-1.0.1-py3-none-any.whl", hash = "sha256:4d6c0aa6dd825810941c792f53d7b8d71da26f5e5f84f20f9508e8f2d33b140a"},
+    {file = "exceptiongroup-1.0.1.tar.gz", hash = "sha256:73866f7f842ede6cb1daa42c4af078e2035e5f7607f0e2c762cc51bb31bbe7b2"},
 ]
 fasteners = [
     {file = "fasteners-0.17.3-py3-none-any.whl", hash = "sha256:cae0772df265923e71435cc5057840138f4e8b6302f888a567d06ed8e1cbca03"},

--- a/wkcuber/poetry.lock
+++ b/wkcuber/poetry.lock
@@ -198,14 +198,15 @@ python-versions = "~=3.7"
 
 [[package]]
 name = "cattrs"
-version = "1.7.1"
+version = "1.9.0"
 description = "Composable complex class support for attrs and dataclasses."
 category = "main"
 optional = false
 python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
-attrs = ">=20.1.0"
+attrs = ">=20"
+typing_extensions = {version = "*", markers = "python_version >= \"3.7\" and python_version < \"3.8\""}
 
 [[package]]
 name = "certifi"
@@ -282,7 +283,7 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-test = ["hypothesis (==3.55.3)", "flake8 (==3.7.8)"]
+test = ["flake8 (==3.7.8)", "hypothesis (==3.55.3)"]
 
 [[package]]
 name = "cycler"
@@ -826,8 +827,8 @@ python-versions = ">=3.6"
 importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 
 [package.extras]
-testing = ["pytest-benchmark", "pytest"]
-dev = ["tox", "pre-commit"]
+dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "psutil"
@@ -1259,7 +1260,7 @@ develop = true
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "1.7.1"
+cattrs = "1.9.0"
 cluster_tools = {path = "../cluster_tools", develop = true}
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"
@@ -1372,7 +1373,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "d5d7ca1e3352b5cc52f2724e8e2221e839c81d774cd433d0d41f17e2733b7725"
+content-hash = "8cf981e1e0c586067b4ee56d5a6df34769dd4ad72e7db50d14991545764bdaed"
 
 [metadata.files]
 aiobotocore = [
@@ -1525,8 +1526,8 @@ cachetools = [
     {file = "cachetools-5.0.0.tar.gz", hash = "sha256:486471dfa8799eb7ec503a8059e263db000cdda20075ce5e48903087f79d5fd6"},
 ]
 cattrs = [
-    {file = "cattrs-1.7.1-py3-none-any.whl", hash = "sha256:d69bd4a3239e189f0740c3c41178dd0f00e4eac3bcb806937e49942fa83adfee"},
-    {file = "cattrs-1.7.1.tar.gz", hash = "sha256:95265b8aaa45e6de75b5f52ae081e021a2a7a688babdb711e4174e6b18920d08"},
+    {file = "cattrs-1.9.0-py3-none-any.whl", hash = "sha256:8eca49962b1bfc09c24d442aa55688be88efe5c24aeef89d3be135614b95c678"},
+    {file = "cattrs-1.9.0.tar.gz", hash = "sha256:1ef33f089e0a494e8d1b487508356f055c865b1955b125c00c991a4358543c80"},
 ]
 certifi = [
     {file = "certifi-2021.10.8-py2.py3-none-any.whl", hash = "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"},
@@ -2248,13 +2249,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
     {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
     {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d4b0ba9512519522b118090257be113b9468d804b19d63c71dbcf4a48fa32358"},
-    {file = "PyYAML-6.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:81957921f441d50af23654aa6c5e5eaf9b06aba7f0a19c18a538dc7ef291c5a1"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:afa17f5bc4d1b10afd4466fd3a44dc0e245382deca5b3c353d8b757f9e3ecb8d"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:dbad0e9d368bb989f4515da330b88a057617d16b6a8245084f1b05400f24609f"},
-    {file = "PyYAML-6.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:432557aa2c09802be39460360ddffd48156e30721f5e8d917f01d31694216782"},
-    {file = "PyYAML-6.0-cp311-cp311-win32.whl", hash = "sha256:bfaef573a63ba8923503d27530362590ff4f576c626d86a9fed95822a8255fd7"},
-    {file = "PyYAML-6.0-cp311-cp311-win_amd64.whl", hash = "sha256:01b45c0191e6d66c470b6cf1b9531a771a83c1c4208272ead47a3ae4f2f603bf"},
     {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
     {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
@@ -2461,10 +2455,7 @@ typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
-universal-pathlib = [
-    {file = "universal_pathlib-0.0.19-py3-none-any.whl", hash = "sha256:72df949935a12b7e6614481bb406df82383db52c58acba1bb44246762c76b127"},
-    {file = "universal_pathlib-0.0.19.tar.gz", hash = "sha256:382a6de60565faf33c39d9791d8a5c453e39b88ed19e8982de9bbffd5930800c"},
-]
+universal-pathlib = []
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},

--- a/wkcuber/poetry.lock
+++ b/wkcuber/poetry.lock
@@ -1272,7 +1272,7 @@ develop = true
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = ">=1.7.1,<=22.2.0"
+cattrs = ">=1.7.1"
 cluster_tools = {path = "../cluster_tools", develop = true}
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"
@@ -1385,7 +1385,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "0c6cd4800d1f34a2d288d3af6ca74a736b07491c3940011ae3e2242e115344c3"
+content-hash = "5b266e0c7315fa5a7f7aa9dae357b9a983be0f2d7d8c04ebe34a63b9170cacb8"
 
 [metadata.files]
 aiobotocore = [

--- a/wkcuber/poetry.lock
+++ b/wkcuber/poetry.lock
@@ -1272,7 +1272,7 @@ develop = true
 aiohttp = "^3.8.1"
 attrs = "^21.1.0"
 boltons = "~21.0.0"
-cattrs = "22.2.0"
+cattrs = ">=1.7.1,<=22.2.0"
 cluster_tools = {path = "../cluster_tools", develop = true}
 fsspec = "^2022.2.0"
 httpx = ">=0.15.4,<0.19.0"
@@ -1385,7 +1385,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "5dbf903b494fcd2cbe8b183766fb1dbb124ef14c350b85094624eabfdbf432f5"
+content-hash = "0c6cd4800d1f34a2d288d3af6ca74a736b07491c3940011ae3e2242e115344c3"
 
 [metadata.files]
 aiobotocore = [

--- a/wkcuber/pyproject.toml
+++ b/wkcuber/pyproject.toml
@@ -12,7 +12,7 @@ include = ["wkcuber/version.py"]  # included explicitly since it's in .gitignore
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 attrs = "^21.1.0"
-cattrs = "1.9.0"
+cattrs = "22.2.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 czifile = "^2019.7.2"
 GitPython = "^3.0.5"

--- a/wkcuber/pyproject.toml
+++ b/wkcuber/pyproject.toml
@@ -12,7 +12,7 @@ include = ["wkcuber/version.py"]  # included explicitly since it's in .gitignore
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 attrs = "^21.1.0"
-cattrs = "1.7.1"
+cattrs = "1.9.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 czifile = "^2019.7.2"
 GitPython = "^3.0.5"

--- a/wkcuber/pyproject.toml
+++ b/wkcuber/pyproject.toml
@@ -12,7 +12,7 @@ include = ["wkcuber/version.py"]  # included explicitly since it's in .gitignore
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 attrs = "^21.1.0"
-cattrs = ">=1.7.1,<=22.2.0"
+cattrs = ">=1.7.1"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 czifile = "^2019.7.2"
 GitPython = "^3.0.5"

--- a/wkcuber/pyproject.toml
+++ b/wkcuber/pyproject.toml
@@ -12,7 +12,7 @@ include = ["wkcuber/version.py"]  # included explicitly since it's in .gitignore
 [tool.poetry.dependencies]
 python = ">=3.7.1,<3.10"
 attrs = "^21.1.0"
-cattrs = "22.2.0"
+cattrs = ">=1.7.1,<=22.2.0"
 cluster_tools = { path = "../cluster_tools/", develop = true }
 czifile = "^2019.7.2"
 GitPython = "^3.0.5"


### PR DESCRIPTION
### Description:
- Update cattrs to 22.2.0 to enable and fix `Literal` structuring support in voxelytics. Also needed to make cattrs work for newer python versions, see [changelog](https://cattrs.readthedocs.io/en/stable/history.html).

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
