### PR TITLE
from_images: python-native czi support and timepoint and channel multiplexing

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -13,8 +13,11 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.24...HEAD)
 
 ### Breaking Changes
+- `Dataset.from_images` now adds a layer per timepoint and per channel (if the data doesn't have 1 or 3 channels).
 
 ### Added
+- Added python-native CZI support for `Dataset.from_images` or `dataset.add_layer_from_images`, without using bioformats.
+- `dataset.add_layer_from_images` can add a layer per timepoint and per channel when passing `allow_multiple_layers=True`.
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -13,11 +13,11 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.10.24...HEAD)
 
 ### Breaking Changes
-- `Dataset.from_images` now adds a layer per timepoint and per channel (if the data doesn't have 1 or 3 channels).
+- `Dataset.from_images` now adds a layer per timepoint and per channel (if the data doesn't have 1 or 3 channels). [#822](https://github.com/scalableminds/webknossos-libs/pull/822)
 
 ### Added
-- Added python-native CZI support for `Dataset.from_images` or `dataset.add_layer_from_images`, without using bioformats.
-- `dataset.add_layer_from_images` can add a layer per timepoint and per channel when passing `allow_multiple_layers=True`.
+- Added python-native CZI support for `Dataset.from_images` or `dataset.add_layer_from_images`, without using bioformats. [#822](https://github.com/scalableminds/webknossos-libs/pull/822)
+- `dataset.add_layer_from_images` can add a layer per timepoint and per channel when passing `allow_multiple_layers=True`. [#822](https://github.com/scalableminds/webknossos-libs/pull/822)
 
 ### Changed
 

--- a/webknossos/poetry.lock
+++ b/webknossos/poetry.lock
@@ -36,7 +36,7 @@ typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
 yarl = ">=1.0,<2.0"
 
 [package.extras]
-speedups = ["aiodns", "brotli", "cchardet"]
+speedups = ["Brotli", "aiodns", "cchardet"]
 
 [[package]]
 name = "aioitertools"
@@ -74,8 +74,8 @@ sniffio = ">=1.1"
 typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
-doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
-test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+doc = ["packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
+test = ["contextlib2", "coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "mock (>=4)", "pytest (>=6.0)", "pytest-mock (>=3.6.1)", "trustme", "uvloop (<0.15)", "uvloop (>=0.15)"]
 trio = ["trio (>=0.16)"]
 
 [[package]]
@@ -104,6 +104,7 @@ python-versions = ">=3.6.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0"
+setuptools = ">=20.0"
 typed-ast = {version = ">=1.4.0,<2.0", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
 typing-extensions = {version = ">=3.10", markers = "python_version < \"3.10\""}
 wrapt = ">=1.11,<2"
@@ -158,10 +159,10 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
-docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
-tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
-tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "mypy", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["cloudpickle", "coverage[toml] (>=5.0.2)", "furo", "hypothesis", "mypy", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "sphinx", "sphinx-notfound-page", "zope.interface"]
+docs = ["furo", "sphinx", "sphinx-notfound-page", "zope.interface"]
+tests = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six", "zope.interface"]
+tests-no-zope = ["cloudpickle", "coverage[toml] (>=5.0.2)", "hypothesis", "mypy", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "six"]
 
 [[package]]
 name = "autoflake"
@@ -271,7 +272,7 @@ optional = false
 python-versions = ">=3.5.0"
 
 [package.extras]
-unicode_backport = ["unicodedata2"]
+unicode-backport = ["unicodedata2"]
 
 [[package]]
 name = "click"
@@ -304,6 +305,17 @@ kubernetes = "^23.3.0"
 [package.source]
 type = "directory"
 url = "../cluster_tools"
+
+[[package]]
+name = "cmake"
+version = "3.24.3"
+description = "CMake is an open-source, cross-platform family of tools designed to build, test and package software"
+category = "main"
+optional = true
+python-versions = "*"
+
+[package.extras]
+test = ["codecov (>=2.0.5)", "coverage (>=4.2)", "flake8 (>=3.0.4)", "path.py (>=11.5.0)", "pytest (>=3.0.3)", "pytest-cov (>=2.4.0)", "pytest-runner (>=2.9)", "pytest-virtualenv (>=1.7.0)", "scikit-build (>=0.10.0)", "setuptools (>=28.0.0)", "virtualenv (>=15.0.3)", "wheel"]
 
 [[package]]
 name = "colorama"
@@ -354,7 +366,7 @@ complete = ["bokeh (>=2.1.1)", "distributed (==2022.02.0)", "jinja2", "numpy (>=
 dataframe = ["numpy (>=1.18)", "pandas (>=1.0)"]
 diagnostics = ["bokeh (>=2.1.1)", "jinja2"]
 distributed = ["distributed (==2022.02.0)"]
-test = ["pytest", "pytest-rerunfailures", "pytest-xdist", "pre-commit"]
+test = ["pre-commit", "pytest", "pytest-rerunfailures", "pytest-xdist"]
 
 [[package]]
 name = "dill"
@@ -422,9 +434,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-all = ["fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "zopfli (>=0.1.4)", "lz4 (>=1.7.4.2)", "matplotlib", "sympy", "skia-pathops (>=0.5.0)", "uharfbuzz (>=0.23.0)", "brotlicffi (>=0.8.0)", "scipy", "brotli (>=1.0.1)", "munkres", "unicodedata2 (>=14.0.0)", "xattr"]
+all = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "fs (>=2.2.0,<3)", "lxml (>=4.0,<5)", "lz4 (>=1.7.4.2)", "matplotlib", "munkres", "scipy", "skia-pathops (>=0.5.0)", "sympy", "uharfbuzz (>=0.23.0)", "unicodedata2 (>=14.0.0)", "xattr", "zopfli (>=0.1.4)"]
 graphite = ["lz4 (>=1.7.4.2)"]
-interpolatable = ["scipy", "munkres"]
+interpolatable = ["munkres", "scipy"]
 lxml = ["lxml (>=4.0,<5)"]
 pathops = ["skia-pathops (>=0.5.0)"]
 plot = ["matplotlib"]
@@ -433,7 +445,7 @@ symfont = ["sympy"]
 type1 = ["xattr"]
 ufo = ["fs (>=2.2.0,<3)"]
 unicode = ["unicodedata2 (>=14.0.0)"]
-woff = ["zopfli (>=0.1.4)", "brotlicffi (>=0.8.0)", "brotli (>=1.0.1)"]
+woff = ["brotli (>=1.0.1)", "brotlicffi (>=0.8.0)", "zopfli (>=0.1.4)"]
 
 [[package]]
 name = "frozenlist"
@@ -456,7 +468,7 @@ abfs = ["adlfs"]
 adl = ["adlfs"]
 arrow = ["pyarrow (>=1)"]
 dask = ["dask", "distributed"]
-dropbox = ["dropboxdrivefs", "requests", "dropbox"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
 entrypoints = ["importlib-metadata"]
 fuse = ["fusepy"]
 gcs = ["gcsfs"]
@@ -465,7 +477,7 @@ github = ["requests"]
 gs = ["gcsfs"]
 gui = ["panel"]
 hdfs = ["pyarrow (>=1)"]
-http = ["requests", "aiohttp"]
+http = ["aiohttp", "requests"]
 libarchive = ["libarchive-c"]
 oci = ["ocifs"]
 s3 = ["s3fs"]
@@ -489,7 +501,7 @@ rsa = {version = ">=3.1.4,<5", markers = "python_version >= \"3.6\""}
 six = ">=1.9.0"
 
 [package.extras]
-aiohttp = ["requests (>=2.20.0,<3.0.0dev)", "aiohttp (>=3.6.2,<4.0.0dev)"]
+aiohttp = ["aiohttp (>=3.6.2,<4.0.0dev)", "requests (>=2.20.0,<3.0.0dev)"]
 pyopenssl = ["pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
 
@@ -548,8 +560,8 @@ attrs = ">=19.2.0"
 sortedcontainers = ">=2.1.0,<3.0.0"
 
 [package.extras]
-all = ["black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "importlib-metadata (>=3.6)", "backports.zoneinfo (>=0.2.1)", "tzdata (>=2022.1)"]
-cli = ["click (>=7.0)", "black (>=19.10b0)", "rich (>=9.0.0)"]
+all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "django (>=2.2)", "dpcontracts (>=0.4)", "importlib-metadata (>=3.6)", "lark-parser (>=0.6.5)", "libcst (>=0.3.16)", "numpy (>=1.9.0)", "pandas (>=0.25)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2022.1)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
 codemods = ["libcst (>=0.3.16)"]
 dateutil = ["python-dateutil (>=1.4)"]
 django = ["django (>=2.2)"]
@@ -597,7 +609,7 @@ python-versions = ">=3.7"
 numpy = ">=1.16.5"
 
 [package.extras]
-all = ["matplotlib (>=3.2)", "tifffile (>=2021.1.11)", "numcodecs"]
+all = ["matplotlib (>=3.2)", "numcodecs", "tifffile (>=2021.1.11)"]
 
 [[package]]
 name = "imageio"
@@ -615,17 +627,17 @@ pillow = ">=8.3.2"
 all-plugins = ["astropy", "av", "imageio-ffmpeg", "opencv-python", "psutil", "tifffile"]
 all-plugins-pypy = ["av", "imageio-ffmpeg", "psutil", "tifffile"]
 build = ["wheel"]
-dev = ["invoke", "pytest", "pytest-cov", "fsspec", "black", "flake8"]
-docs = ["sphinx", "numpydoc", "pydata-sphinx-theme"]
+dev = ["black", "flake8", "fsspec[github]", "invoke", "pytest", "pytest-cov"]
+docs = ["numpydoc", "pydata-sphinx-theme", "sphinx"]
 ffmpeg = ["imageio-ffmpeg", "psutil"]
 fits = ["astropy"]
-full = ["astropy", "av", "black", "flake8", "fsspec", "gdal", "imageio-ffmpeg", "invoke", "itk", "numpydoc", "opencv-python", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx", "tifffile", "wheel"]
+full = ["astropy", "av", "black", "flake8", "fsspec[github]", "gdal", "imageio-ffmpeg", "invoke", "itk", "numpydoc", "opencv-python", "psutil", "pydata-sphinx-theme", "pytest", "pytest-cov", "sphinx", "tifffile", "wheel"]
 gdal = ["gdal"]
 itk = ["itk"]
 linting = ["black", "flake8"]
 opencv = ["opencv-python"]
 pyav = ["av"]
-test = ["invoke", "pytest", "pytest-cov", "fsspec"]
+test = ["fsspec[github]", "invoke", "pytest", "pytest-cov"]
 tifffile = ["tifffile"]
 
 [[package]]
@@ -640,8 +652,8 @@ python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "unittest2", "importlib-resources (>=1.3)"]
+docs = ["rst.linker", "sphinx"]
+testing = ["importlib-resources (>=1.3)", "packaging", "pep517", "unittest2"]
 
 [[package]]
 name = "importlib-resources"
@@ -655,8 +667,8 @@ python-versions = ">=3.7"
 zipp = {version = ">=3.1.0", markers = "python_version < \"3.10\""}
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [[package]]
 name = "inducoapi"
@@ -698,10 +710,10 @@ optional = false
 python-versions = ">=3.6.1,<4.0"
 
 [package.extras]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
-requirements_deprecated_finder = ["pipreqs", "pip-api"]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
+pipfile-deprecated-finder = ["pipreqs", "requirementslib"]
 plugins = ["setuptools"]
+requirements-deprecated-finder = ["pip-api", "pipreqs"]
 
 [[package]]
 name = "jinja2"
@@ -793,6 +805,7 @@ python-dateutil = ">=2.5.3"
 pyyaml = ">=5.4.1"
 requests = "*"
 requests-oauthlib = "*"
+setuptools = ">=21.0.0"
 six = ">=1.9.0"
 urllib3 = ">=1.24.2"
 websocket-client = ">=0.32.0,<0.40.0 || >0.40.0,<0.41.0 || >=0.43.0"
@@ -914,11 +927,11 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-default = ["numpy (>=1.19)", "scipy (>=1.5,!=1.6.1)", "matplotlib (>=3.3)", "pandas (>=1.1)"]
+default = ["matplotlib (>=3.3)", "numpy (>=1.19)", "pandas (>=1.1)", "scipy (>=1.5,!=1.6.1)"]
 developer = ["black (==21.5b1)", "pre-commit (>=2.12)"]
-doc = ["sphinx (>=4.0,<5.0)", "pydata-sphinx-theme (>=0.6,<1.0)", "sphinx-gallery (>=0.9,<1.0)", "numpydoc (>=1.1)", "pillow (>=8.2)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
-extra = ["lxml (>=4.5)", "pygraphviz (>=1.7)", "pydot (>=1.4.1)"]
-test = ["pytest (>=6.2)", "pytest-cov (>=2.12)", "codecov (>=2.1)"]
+doc = ["nb2plots (>=0.6)", "numpydoc (>=1.1)", "pillow (>=8.2)", "pydata-sphinx-theme (>=0.6,<1.0)", "sphinx (>=4.0,<5.0)", "sphinx-gallery (>=0.9,<1.0)", "texext (>=0.6.6)"]
+extra = ["lxml (>=4.5)", "pydot (>=1.4.1)", "pygraphviz (>=1.7)"]
+test = ["codecov (>=2.1)", "pytest (>=6.2)", "pytest-cov (>=2.12)"]
 
 [[package]]
 name = "numcodecs"
@@ -996,8 +1009,8 @@ six = "*"
 
 [package.extras]
 isodate = ["isodate"]
-rfc3339_validator = ["rfc3339-validator"]
-strict_rfc3339 = ["strict-rfc3339"]
+rfc3339-validator = ["rfc3339-validator"]
+strict-rfc3339 = ["strict-rfc3339"]
 
 [[package]]
 name = "openapi-spec-validator"
@@ -1061,7 +1074,7 @@ locket = "*"
 toolz = "*"
 
 [package.extras]
-complete = ["numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq", "blosc"]
+complete = ["blosc", "numpy (>=1.9.0)", "pandas (>=0.19.0)", "pyzmq"]
 
 [[package]]
 name = "pathspec"
@@ -1105,8 +1118,8 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx-autodoc-typehints (>=1.12)", "sphinx (>=4)"]
-test = ["appdirs (==1.4.4)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)", "pytest (>=6)"]
+docs = ["furo (>=2021.7.5b38)", "proselint (>=0.10.2)", "sphinx (>=4)", "sphinx-autodoc-typehints (>=1.12)"]
+test = ["appdirs (==1.4.4)", "pytest (>=6)", "pytest-cov (>=2.7)", "pytest-mock (>=3.6)"]
 
 [[package]]
 name = "pluggy"
@@ -1150,7 +1163,7 @@ optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-test = ["ipaddress", "mock", "unittest2", "enum34", "pywin32", "wmi"]
+test = ["enum34", "ipaddress", "mock", "pywin32", "unittest2", "wmi"]
 
 [[package]]
 name = "py"
@@ -1219,6 +1232,24 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
+name = "pylibczirw"
+version = "3.2.0"
+description = "A python wrapper around the libCZIrw C++ library with reading and writing functionality."
+category = "main"
+optional = true
+python-versions = ">=3.7,<4"
+
+[package.dependencies]
+cmake = "*"
+numpy = "*"
+xmltodict = "*"
+
+[package.extras]
+all = ["bandit", "black", "cmake", "flake8", "flake8-bugbear", "flake8-docstrings", "ipython", "mypy", "numpy", "pylint-runner", "pytest", "pytest-cov", "pytest-timeout", "types-all", "xmltodict"]
+dev = ["bandit", "black", "flake8", "flake8-bugbear", "flake8-docstrings", "ipython", "mypy", "pylint-runner", "pytest", "pytest-cov", "pytest-timeout", "types-all"]
+test = ["bandit", "black", "flake8", "flake8-bugbear", "flake8-docstrings", "mypy", "pylint-runner", "pytest", "pytest-cov", "pytest-timeout", "types-all"]
+
+[[package]]
 name = "pylint"
 version = "2.13.8"
 description = "python code static checker"
@@ -1248,7 +1279,7 @@ optional = false
 python-versions = ">=3.6.8"
 
 [package.extras]
-diagrams = ["railroad-diagrams", "jinja2"]
+diagrams = ["jinja2", "railroad-diagrams"]
 
 [[package]]
 name = "pyrsistent"
@@ -1393,7 +1424,7 @@ urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)", "win-inet-pton"]
-use_chardet_on_py3 = ["chardet (>=3.0.2,<5)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<5)"]
 
 [[package]]
 name = "requests-oauthlib"
@@ -1489,9 +1520,9 @@ tifffile = ">=2019.7.26"
 
 [package.extras]
 data = ["pooch (>=1.3.0)"]
-docs = ["sphinx (>=1.8,<=2.4.4)", "sphinx-gallery (>=0.7.0,!=0.8.0)", "numpydoc (>=1.0)", "sphinx-copybutton", "pytest-runner", "scikit-learn", "matplotlib (>=3.0.1)", "dask[array] (>=0.15.0,!=2.17.0)", "cloudpickle (>=0.2.1)", "pandas (>=0.23.0)", "seaborn (>=0.7.1)", "pooch (>=1.3.0)", "tifffile (>=2020.5.30)", "myst-parser", "ipywidgets", "plotly (>=4.10.0)"]
-optional = ["simpleitk", "astropy (>=3.1.2)", "qtpy", "pyamg", "dask[array] (>=1.0.0,!=2.17.0)", "cloudpickle (>=0.2.1)", "pooch (>=1.3.0)"]
-test = ["pytest (>=5.2.0)", "pytest-cov (>=2.7.0)", "pytest-localserver", "pytest-faulthandler", "flake8", "codecov", "pooch (>=1.3.0)"]
+docs = ["cloudpickle (>=0.2.1)", "dask[array] (>=0.15.0,!=2.17.0)", "ipywidgets", "matplotlib (>=3.0.1)", "myst-parser", "numpydoc (>=1.0)", "pandas (>=0.23.0)", "plotly (>=4.10.0)", "pooch (>=1.3.0)", "pytest-runner", "scikit-learn", "seaborn (>=0.7.1)", "sphinx (>=1.8,<=2.4.4)", "sphinx-copybutton", "sphinx-gallery (>=0.7.0,!=0.8.0)", "tifffile (>=2020.5.30)"]
+optional = ["SimpleITK", "astropy (>=3.1.2)", "cloudpickle (>=0.2.1)", "dask[array] (>=1.0.0,!=2.17.0)", "pooch (>=1.3.0)", "pyamg", "qtpy"]
+test = ["codecov", "flake8", "pooch (>=1.3.0)", "pytest (>=5.2.0)", "pytest-cov (>=2.7.0)", "pytest-faulthandler", "pytest-localserver"]
 
 [[package]]
 name = "scikit-learn"
@@ -1508,10 +1539,10 @@ scipy = ">=1.1.0"
 threadpoolctl = ">=2.0.0"
 
 [package.extras]
-benchmark = ["matplotlib (>=2.2.3)", "pandas (>=0.25.0)", "memory-profiler (>=0.57.0)"]
-docs = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)", "memory-profiler (>=0.57.0)", "sphinx (>=4.0.1)", "sphinx-gallery (>=0.7.0)", "numpydoc (>=1.0.0)", "Pillow (>=7.1.2)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
-examples = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "seaborn (>=0.9.0)"]
-tests = ["matplotlib (>=2.2.3)", "scikit-image (>=0.14.5)", "pandas (>=0.25.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "flake8 (>=3.8.2)", "black (>=21.6b0)", "mypy (>=0.770)", "pyamg (>=4.0.0)"]
+benchmark = ["matplotlib (>=2.2.3)", "memory-profiler (>=0.57.0)", "pandas (>=0.25.0)"]
+docs = ["Pillow (>=7.1.2)", "matplotlib (>=2.2.3)", "memory-profiler (>=0.57.0)", "numpydoc (>=1.0.0)", "pandas (>=0.25.0)", "scikit-image (>=0.14.5)", "seaborn (>=0.9.0)", "sphinx (>=4.0.1)", "sphinx-gallery (>=0.7.0)", "sphinx-prompt (>=1.3.0)", "sphinxext-opengraph (>=0.4.2)"]
+examples = ["matplotlib (>=2.2.3)", "pandas (>=0.25.0)", "scikit-image (>=0.14.5)", "seaborn (>=0.9.0)"]
+tests = ["black (>=21.6b0)", "flake8 (>=3.8.2)", "matplotlib (>=2.2.3)", "mypy (>=0.770)", "pandas (>=0.25.0)", "pyamg (>=4.0.0)", "pytest (>=5.0.1)", "pytest-cov (>=2.9.0)", "scikit-image (>=0.14.5)"]
 
 [[package]]
 name = "scipy"
@@ -1525,6 +1556,19 @@ python-versions = ">=3.7,<3.11"
 numpy = ">=1.16.5,<1.23.0"
 
 [[package]]
+name = "setuptools"
+version = "65.5.1"
+description = "Easily download, build, install, upgrade, and uninstall Python packages"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "pygments-github-lexers (==0.0.5)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-favicon", "sphinx-hoverxref (<2)", "sphinx-inline-tabs", "sphinx-notfound-page (==0.8.3)", "sphinx-reredirects", "sphinxcontrib-towncrier"]
+testing = ["build[virtualenv]", "filelock (>=3.4.0)", "flake8 (<5)", "flake8-2020", "ini2toml[lite] (>=0.9)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pip (>=19.1)", "pip-run (>=8.8)", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf", "pytest-timeout", "pytest-xdist", "tomli-w (>=1.0.0)", "virtualenv (>=13.0.0)", "wheel"]
+testing-integration = ["build[virtualenv]", "filelock (>=3.4.0)", "jaraco.envs (>=2.2)", "jaraco.path (>=3.2.0)", "pytest", "pytest-enabler", "pytest-xdist", "tomli", "virtualenv (>=13.0.0)", "wheel"]
+
+[[package]]
 name = "setuptools-scm"
 version = "6.4.2"
 description = "the blessed package to manage your versions by scm tags"
@@ -1534,6 +1578,7 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 packaging = ">=20.0"
+setuptools = "*"
 tomli = ">=1.0.0"
 
 [package.extras]
@@ -1619,7 +1664,7 @@ python-versions = ">=3.7"
 numpy = ">=1.15.1"
 
 [package.extras]
-all = ["imagecodecs (>=2021.7.30)", "matplotlib (>=3.2)", "lxml"]
+all = ["imagecodecs (>=2021.7.30)", "lxml", "matplotlib (>=3.2)"]
 
 [[package]]
 name = "toml"
@@ -1665,10 +1710,10 @@ python-versions = ">=3.6"
 click = ">=7.1.1,<7.2.0"
 
 [package.extras]
-test = ["pytest-xdist (>=1.32.0,<2.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "mypy (==0.782)", "black (>=19.10b0,<20.0b0)", "isort (>=5.0.6,<6.0.0)", "shellingham (>=1.3.0,<2.0.0)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "coverage (>=5.2,<6.0)"]
 all = ["colorama (>=0.4.3,<0.5.0)", "shellingham (>=1.3.0,<2.0.0)"]
 dev = ["autoflake (>=1.3.1,<2.0.0)", "flake8 (>=3.8.3,<4.0.0)"]
-doc = ["mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)", "markdown-include (>=0.5.1,<0.6.0)"]
+doc = ["markdown-include (>=0.5.1,<0.6.0)", "mkdocs (>=1.1.2,<2.0.0)", "mkdocs-material (>=5.4.0,<6.0.0)"]
+test = ["black (>=19.10b0,<20.0b0)", "coverage (>=5.2,<6.0)", "isort (>=5.0.6,<6.0.0)", "mypy (==0.782)", "pytest (>=4.4.0,<5.4.0)", "pytest-cov (>=2.10.0,<3.0.0)", "pytest-sugar (>=0.9.4,<0.10.0)", "pytest-xdist (>=1.32.0,<2.0.0)", "shellingham (>=1.3.0,<2.0.0)"]
 
 [[package]]
 name = "types-python-dateutil"
@@ -1698,7 +1743,7 @@ python-versions = ">=3.7"
 fsspec = "*"
 
 [package.extras]
-test = ["aiohttp", "adlfs", "flake8", "gcsfs", "hadoop-test-cluster", "ipython", "jupyter", "moto", "pyarrow", "pylint", "pytest", "requests", "s3fs", "webdav4"]
+test = ["adlfs", "aiohttp", "flake8", "gcsfs", "hadoop-test-cluster", "ipython", "jupyter", "moto", "pyarrow", "pylint", "pytest", "requests", "s3fs", "webdav4[fsspec]"]
 
 [[package]]
 name = "urllib3"
@@ -1709,8 +1754,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
-brotli = ["brotlicffi (>=0.8.0)", "brotli (>=1.0.9)", "brotlipy (>=0.6.0)"]
-secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "certifi", "ipaddress"]
+brotli = ["brotli (>=1.0.9)", "brotlicffi (>=0.8.0)", "brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "ipaddress", "pyOpenSSL (>=0.14)"]
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
@@ -1752,7 +1797,7 @@ python-versions = "*"
 cffi = "*"
 numpy = [
     {version = ">=1.15,<2.0.0", markers = "python_version >= \"3.8\""},
-    {version = "<1.22", markers = "python_version < \"3.8\""},
+    {version = ">=1.15,<1.22", markers = "python_version < \"3.8\""},
 ]
 
 [[package]]
@@ -1762,6 +1807,14 @@ description = "Module for decorators, wrappers and monkey patching."
 category = "dev"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+
+[[package]]
+name = "xmltodict"
+version = "0.13.0"
+description = "Makes working with XML feel like you are working with JSON"
+category = "main"
+optional = true
+python-versions = ">=3.4"
 
 [[package]]
 name = "yarl"
@@ -1791,7 +1844,7 @@ numcodecs = ">=0.6.4"
 numpy = ">=1.7"
 
 [package.extras]
-jupyter = ["notebook", "ipytree"]
+jupyter = ["ipytree", "notebook"]
 
 [[package]]
 name = "zipp"
@@ -1802,12 +1855,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.0.1)", "jaraco.itertools", "func-timeout", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)"]
+docs = ["jaraco.packaging (>=9)", "rst.linker (>=1.9)", "sphinx"]
+testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.0.1)", "pytest-flake8", "pytest-mypy (>=0.9.1)"]
 
 [extras]
-all = ["pims", "tifffile", "imagecodecs", "JPype1"]
+all = ["pims", "tifffile", "imagecodecs", "JPype1", "pylibCZIrw"]
 bioformats = ["pims", "JPype1"]
+czi = ["pims", "pylibCZIrw"]
 imagecodecs = ["pims", "imagecodecs"]
 pims = ["pims"]
 tifffile = ["pims", "tifffile"]
@@ -1815,7 +1869,7 @@ tifffile = ["pims", "tifffile"]
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.7.1,<3.10"
-content-hash = "ec4b0e2863b9361b46714ba9186b36ec6c64a5ec82727f3c582691253085d525"
+content-hash = "a84553d832b54aed6fbfc3273a7cd1224e96596c6cac280e9811631d99aa7d21"
 
 [metadata.files]
 aiobotocore = [
@@ -2030,6 +2084,24 @@ cloudpickle = [
     {file = "cloudpickle-2.2.0.tar.gz", hash = "sha256:3f4219469c55453cfe4737e564b67c2a149109dabf7f242478948b895f61106f"},
 ]
 cluster-tools = []
+cmake = [
+    {file = "cmake-3.24.3-py2.py3-none-macosx_10_10_universal2.macosx_10_10_x86_64.macosx_11_0_arm64.macosx_11_0_universal2.whl", hash = "sha256:7f44502c52d02ac7526133b9080cfe91e4ccbb2a3abf36139697d6e6161ff89b"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:3a28abd32284935d54f1fcc33140ccde293fb529a6cb0418ca0eea7ff0ac7b26"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:0402c38e34e0cec1a099a40e147f47e509640db01d5ced7313327555185b8d1e"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2da8c93e1adcf8df307487e852d6f1f63b03aea7cbf22050c081d9f369d142b"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7ba1a0e3fdc7a9512c30a7b75024f67e65b96a15f7e8174fb1b58356ecc44aa4"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:717938fc5ee4c7538b27aac29a6e3b75c5eb223cb523e06cf8139f12ea73f708"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:737580fd3f7435f80bd9bc91af7e819b1a2def131712fcc4d9133fdb78138a51"},
+    {file = "cmake-3.24.3-py2.py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:38348b9f0e4094fcf375bb84bc04cdf0fd57ba640dffa11a899ec12a7eb100b9"},
+    {file = "cmake-3.24.3-py2.py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:a8cebc2ca35b6e945f5f432159c95e0012ea26bc977421ab3fd1c01cc0818fd0"},
+    {file = "cmake-3.24.3-py2.py3-none-musllinux_1_1_i686.whl", hash = "sha256:ca3a7bcfbdf4981091a72693dccb35192bcd6a3342579eb46f1c6d6bd6d7779d"},
+    {file = "cmake-3.24.3-py2.py3-none-musllinux_1_1_ppc64le.whl", hash = "sha256:fa69e7bb50abe1408e6b2f8ae311ad268347e6db865b14f50e8c8f677203175d"},
+    {file = "cmake-3.24.3-py2.py3-none-musllinux_1_1_s390x.whl", hash = "sha256:90b5486fc4e0526745dd3dc028dd2a5a0d2933290dc0887a9c0748f02e6295d7"},
+    {file = "cmake-3.24.3-py2.py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:ea7bf708da65b6f0de8565c020e68048681cf79cc8c9967aec8f5293b4108115"},
+    {file = "cmake-3.24.3-py2.py3-none-win32.whl", hash = "sha256:4ea7e1d0e6f011c727954db2cdcaac2c6320ebf856d1952de4eeb8c157ea8265"},
+    {file = "cmake-3.24.3-py2.py3-none-win_amd64.whl", hash = "sha256:c9cf37bb3839cdfba915dcceabe2d2cf0550612b6b5a747cefa32dea854c5d1a"},
+    {file = "cmake-3.24.3.tar.gz", hash = "sha256:73fa252b21fce1db988beace3e1a2b21f926dd870322d9f37ff04e773b13a12a"},
+]
 colorama = [
     {file = "colorama-0.4.4-py2.py3-none-any.whl", hash = "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"},
     {file = "colorama-0.4.4.tar.gz", hash = "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b"},
@@ -2755,34 +2827,12 @@ py = [
     {file = "py-1.11.0.tar.gz", hash = "sha256:51c75c4126074b472f746a24399ad32f6053d1b34b68d2fa41e558e6f4a98719"},
 ]
 pyasn1 = [
-    {file = "pyasn1-0.4.8-py2.4.egg", hash = "sha256:fec3e9d8e36808a28efb59b489e4528c10ad0f480e57dcc32b4de5c9d8c9fdf3"},
-    {file = "pyasn1-0.4.8-py2.5.egg", hash = "sha256:0458773cfe65b153891ac249bcf1b5f8f320b7c2ce462151f8fa74de8934becf"},
-    {file = "pyasn1-0.4.8-py2.6.egg", hash = "sha256:5c9414dcfede6e441f7e8f81b43b34e834731003427e5b09e4e00e3172a10f00"},
-    {file = "pyasn1-0.4.8-py2.7.egg", hash = "sha256:6e7545f1a61025a4e58bb336952c5061697da694db1cae97b116e9c46abcf7c8"},
     {file = "pyasn1-0.4.8-py2.py3-none-any.whl", hash = "sha256:39c7e2ec30515947ff4e87fb6f456dfc6e84857d34be479c9d4a4ba4bf46aa5d"},
-    {file = "pyasn1-0.4.8-py3.1.egg", hash = "sha256:78fa6da68ed2727915c4767bb386ab32cdba863caa7dbe473eaae45f9959da86"},
-    {file = "pyasn1-0.4.8-py3.2.egg", hash = "sha256:08c3c53b75eaa48d71cf8c710312316392ed40899cb34710d092e96745a358b7"},
-    {file = "pyasn1-0.4.8-py3.3.egg", hash = "sha256:03840c999ba71680a131cfaee6fab142e1ed9bbd9c693e285cc6aca0d555e576"},
-    {file = "pyasn1-0.4.8-py3.4.egg", hash = "sha256:7ab8a544af125fb704feadb008c99a88805126fb525280b2270bb25cc1d78a12"},
-    {file = "pyasn1-0.4.8-py3.5.egg", hash = "sha256:e89bf84b5437b532b0803ba5c9a5e054d21fec423a89952a74f87fa2c9b7bce2"},
-    {file = "pyasn1-0.4.8-py3.6.egg", hash = "sha256:014c0e9976956a08139dc0712ae195324a75e142284d5f87f1a87ee1b068a359"},
-    {file = "pyasn1-0.4.8-py3.7.egg", hash = "sha256:99fcc3c8d804d1bc6d9a099921e39d827026409a58f2a720dcdb89374ea0c776"},
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 pyasn1-modules = [
     {file = "pyasn1-modules-0.2.8.tar.gz", hash = "sha256:905f84c712230b2c592c19470d3ca8d552de726050d1d1716282a1f6146be65e"},
-    {file = "pyasn1_modules-0.2.8-py2.4.egg", hash = "sha256:0fe1b68d1e486a1ed5473f1302bd991c1611d319bba158e98b106ff86e1d7199"},
-    {file = "pyasn1_modules-0.2.8-py2.5.egg", hash = "sha256:fe0644d9ab041506b62782e92b06b8c68cca799e1a9636ec398675459e031405"},
-    {file = "pyasn1_modules-0.2.8-py2.6.egg", hash = "sha256:a99324196732f53093a84c4369c996713eb8c89d360a496b599fb1a9c47fc3eb"},
-    {file = "pyasn1_modules-0.2.8-py2.7.egg", hash = "sha256:0845a5582f6a02bb3e1bde9ecfc4bfcae6ec3210dd270522fee602365430c3f8"},
     {file = "pyasn1_modules-0.2.8-py2.py3-none-any.whl", hash = "sha256:a50b808ffeb97cb3601dd25981f6b016cbb3d31fbf57a8b8a87428e6158d0c74"},
-    {file = "pyasn1_modules-0.2.8-py3.1.egg", hash = "sha256:f39edd8c4ecaa4556e989147ebf219227e2cd2e8a43c7e7fcb1f1c18c5fd6a3d"},
-    {file = "pyasn1_modules-0.2.8-py3.2.egg", hash = "sha256:b80486a6c77252ea3a3e9b1e360bc9cf28eaac41263d173c032581ad2f20fe45"},
-    {file = "pyasn1_modules-0.2.8-py3.3.egg", hash = "sha256:65cebbaffc913f4fe9e4808735c95ea22d7a7775646ab690518c056784bc21b4"},
-    {file = "pyasn1_modules-0.2.8-py3.4.egg", hash = "sha256:15b7c67fabc7fc240d87fb9aabf999cf82311a6d6fb2c70d00d3d0604878c811"},
-    {file = "pyasn1_modules-0.2.8-py3.5.egg", hash = "sha256:426edb7a5e8879f1ec54a1864f16b882c2837bfd06eee62f2c982315ee2473ed"},
-    {file = "pyasn1_modules-0.2.8-py3.6.egg", hash = "sha256:cbac4bc38d117f2a49aeedec4407d23e8866ea4ac27ff2cf7fb3e5b570df19e0"},
-    {file = "pyasn1_modules-0.2.8-py3.7.egg", hash = "sha256:c29a5e5cc7a3f05926aff34e097e84f8589cd790ce0ed41b67aed6857b26aafd"},
 ]
 pycparser = [
     {file = "pycparser-2.21-py2.py3-none-any.whl", hash = "sha256:8ee45429555515e1f6b185e78100aea234072576aa43ab53aefcae078162fca9"},
@@ -2832,6 +2882,17 @@ pyflakes = [
 pygments = [
     {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
     {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
+]
+pylibczirw = [
+    {file = "pylibCZIrw-3.2.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:685f36703170f1815144d64809d0b383fd7b14c38eb6ddddbc51def616b8a60d"},
+    {file = "pylibCZIrw-3.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:d3c8c3e408c5f453076ee2525b434d658b63e2102bebde7d560281d6b2125408"},
+    {file = "pylibCZIrw-3.2.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:75be27a0aaa17295ed00fa83571b192efee0ec129620b2c723edae2188faf5e5"},
+    {file = "pylibCZIrw-3.2.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0a178669f08356b606ce1e71a8116cd275f4e76216963f0362bbef3bf19e5cf1"},
+    {file = "pylibCZIrw-3.2.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e52aac0b1bfec5742097467a51ae966b5c81738aa4ad02610f0be91dc4ae04b"},
+    {file = "pylibCZIrw-3.2.0-cp38-cp38-win_amd64.whl", hash = "sha256:e7aaf2009a6115a3aa283756163e455dd2df261023a4dd533fb62046281c110d"},
+    {file = "pylibCZIrw-3.2.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1b2815145c22b46ec0966da1d01d03cc921038d5883bdf36cdf66a35994e30e"},
+    {file = "pylibCZIrw-3.2.0-cp39-cp39-win_amd64.whl", hash = "sha256:0e42a959282a66bc931115d6632beb2587242bd2c2bcf17b2cc2b6e294df6da0"},
+    {file = "pylibCZIrw-3.2.0.tar.gz", hash = "sha256:de4dd9aae0fa06cf5d6e615648642a85cf687a862428f200e041ecce94241913"},
 ]
 pylint = [
     {file = "pylint-2.13.8-py3-none-any.whl", hash = "sha256:f87e863a0b08f64b5230e7e779bcb75276346995737b2c0dc2793070487b1ff6"},
@@ -3120,6 +3181,10 @@ scipy = [
     {file = "scipy-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:3f78181a153fa21c018d346f595edd648344751d7f03ab94b398be2ad083ed3e"},
     {file = "scipy-1.7.3.tar.gz", hash = "sha256:ab5875facfdef77e0a47d5fd39ea178b58e60e454a4c85aa1e52fcb80db7babf"},
 ]
+setuptools = [
+    {file = "setuptools-65.5.1-py3-none-any.whl", hash = "sha256:d0b9a8433464d5800cbe05094acf5c6d52a91bfac9b52bcfc4d41382be5d5d31"},
+    {file = "setuptools-65.5.1.tar.gz", hash = "sha256:e197a19aa8ec9722928f2206f8de752def0e4c9fc6953527360d1c36d94ddb2f"},
+]
 setuptools-scm = [
     {file = "setuptools_scm-6.4.2-py3-none-any.whl", hash = "sha256:acea13255093849de7ccb11af9e1fb8bde7067783450cee9ef7a93139bddf6d4"},
     {file = "setuptools_scm-6.4.2.tar.gz", hash = "sha256:6833ac65c6ed9711a4d5d2266f8024cfa07c533a0e55f4c12f6eff280a5a9e30"},
@@ -3215,7 +3280,10 @@ typing-extensions = [
     {file = "typing_extensions-4.2.0-py3-none-any.whl", hash = "sha256:6657594ee297170d19f67d55c05852a874e7eb634f4f753dbd667855e07c1708"},
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
-universal-pathlib = []
+universal-pathlib = [
+    {file = "universal_pathlib-0.0.19-py3-none-any.whl", hash = "sha256:72df949935a12b7e6614481bb406df82383db52c58acba1bb44246762c76b127"},
+    {file = "universal_pathlib-0.0.19.tar.gz", hash = "sha256:382a6de60565faf33c39d9791d8a5c453e39b88ed19e8982de9bbffd5930800c"},
+]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},
     {file = "urllib3-1.26.9.tar.gz", hash = "sha256:aabaf16477806a5e1dd19aa41f8c2b7950dd3c746362d7e3223dbe6de6ac448e"},
@@ -3304,6 +3372,10 @@ wrapt = [
     {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
     {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
     {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]
+xmltodict = [
+    {file = "xmltodict-0.13.0-py2.py3-none-any.whl", hash = "sha256:aa89e8fd76320154a40d19a0df04a4695fb9dc5ba977cbb68ab3e4eb225e7852"},
+    {file = "xmltodict-0.13.0.tar.gz", hash = "sha256:341595a488e3e01a85a9d8911d8912fd922ede5fecc4dce437eb4b6c8d037e56"},
 ]
 yarl = [
     {file = "yarl-1.7.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f2a8508f7350512434e41065684076f640ecce176d262a7d54f0da41d99c5a95"},

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -60,13 +60,15 @@ imagecodecs = { version = ">=2021.11.20", optional = true }
 JPype1 = { version = "^1.3.0", optional = true }
 pims = { version = "^0.6.0", optional = true }
 tifffile = { version = ">=2021.11.2", optional = true }
+pylibCZIrw = { version = "^3.2", optional = true }
 
 [tool.poetry.extras]
 pims = ["pims"]
 tifffile = ["pims", "tifffile"]
 imagecodecs = ["pims", "imagecodecs"]
 bioformats = ["pims","JPype1"]
-all = ["pims","tifffile","imagecodecs","JPype1",]
+czi = ["pims","pylibCZIrw"]
+all = ["pims","tifffile","imagecodecs","JPype1","pylibCZIrw",]
 
 [tool.poetry.dev-dependencies]
 # autoflake

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -251,7 +251,7 @@ TEST_IMAGES_ARGS = [
     (
         "https://samples.scif.io/test-jpeg2000.zip",
         "scifio-test.jp2",
-        {},  # {"channel": 499},
+        {},
         "uint8",
         3,
         (500, 500, 1),

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -1,0 +1,112 @@
+from contextlib import contextmanager
+from os import PathLike
+from pathlib import Path
+from typing import Iterator, List, Set
+
+import numpy as np
+
+try:
+    from pims import FramesSequenceND
+except ImportError as e:
+    raise RuntimeError(
+        "Cannot import pims, please install it e.g. using 'webknossos[all]'"
+    ) from e
+
+try:
+    from pylibCZIrw import czi as pyczi
+except ImportError as e:
+    raise RuntimeError(
+        "Cannot import pylibCZIrw, please install it e.g. using 'webknossos[czi]'"
+    ) from e
+
+PIXEL_TYPE_TO_DTYPE = {
+    "Gray8": "<u1",
+    "Gray16": "<u2",
+    "Gray32Float": "<f4",
+    "Bgr24": "<u1",
+    "Bgr48": "<u2",
+    "Bgr96Float": "<f4",
+    "Bgra32": "<4u1",
+    "Gray64ComplexFloat": "<F8",
+    "Bgr192ComplexFloat": "<F8",
+    "Gray32": "<i4",
+    "Gray64": "<i8",
+}
+
+
+class PimsCziReader(FramesSequenceND):
+    @classmethod
+    def class_exts(cls) -> Set[str]:
+        return {".czi"}
+
+    class_priority = 20
+
+    def __init__(self, path: PathLike, czi_channel: int = 0) -> None:
+        self.path = Path(path)
+        self.czi_channel = czi_channel
+        super().__init__()
+        with self.czi_file() as czi_file:
+            for axis, (
+                start,
+                length,
+            ) in czi_file.total_bounding_box.items():
+                axis = axis.lower()
+                if axis == "c":
+                    continue
+                assert start == 0
+                if axis not in "xy" and length == 1:
+                    # not propagating axes of length one
+                    continue
+                self._init_axis(axis, length)
+            czi_pixel_type = czi_file.get_channel_pixel_type(self.czi_channel)
+            if czi_pixel_type.startswith("Bgra"):
+                self._init_axis("c", 4)
+            elif czi_pixel_type.startswith("Bgr"):
+                self._init_axis("c", 3)
+            elif czi_pixel_type.startswith("Gray"):
+                self._init_axis("c", 1)
+            elif czi_pixel_type == "Invalid":
+                raise ValueError(
+                    f"czi_channel {self.czi_channel} does not exist in {self.path}"
+                )
+            else:
+                raise ValueError(
+                    f"Got unsupported czi pixel-type {czi_pixel_type} in {self.path}"
+                )
+
+        self._register_get_frame(self.get_frame_2D, "yxc")
+
+    @contextmanager
+    def czi_file(self) -> Iterator[pyczi.CziReader]:
+        with pyczi.open_czi(str(self.path)) as czi_file:
+            yield czi_file
+
+    def available_czi_channels(self) -> List[int]:
+        with self.czi_file() as czi_file:
+            return sorted(czi_file.pixel_types.keys())
+
+    @property  # potential @cached_property for py3.8+
+    def pixel_type(self) -> np.dtype:
+        with self.czi_file() as czi_file:
+            return np.dtype(
+                PIXEL_TYPE_TO_DTYPE[czi_file.get_channel_pixel_type(self.czi_channel)]
+            )
+
+    def get_frame_2D(self, **ind: int) -> np.ndarray:
+        plane = {k.upper(): v for k, v in ind.items()}
+        plane.pop("X", None)
+        plane.pop("Y", None)
+        plane["C"] = self.czi_channel
+        print(plane)
+        with self.czi_file() as czi_file:
+            a = czi_file.read(plane=plane)
+            num_channels = a.shape[-1]
+            if num_channels == 3:
+                # convert from bgr to rgb
+                a = np.flip(a, axis=-1)
+            elif num_channels == 4:
+                # convert from bgra to rgba
+                a_red = a[:, :, 2].copy(order="K")
+                a[:, :, 2] = a[:, :, 0]
+                a[:, :, 0] = a_red
+            return a

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -97,7 +97,6 @@ class PimsCziReader(FramesSequenceND):
         plane.pop("X", None)
         plane.pop("Y", None)
         plane["C"] = self.czi_channel
-        print(plane)
         with self.czi_file() as czi_file:
             a = czi_file.read(plane=plane)
             num_channels = a.shape[-1]

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -39,6 +39,9 @@ class PimsCziReader(FramesSequenceND):
     def class_exts(cls) -> Set[str]:
         return {".czi"}
 
+    # class_priority is used in pims to pick the reader with the highest priority.
+    # Default is 10, and bioformats priority (which is the only other reader supporting czi) is 2.
+    # See http://soft-matter.github.io/pims/v0.6.1/custom_readers.html#plugging-into-pims-s-open-function
     class_priority = 20
 
     def __init__(self, path: PathLike, czi_channel: int = 0) -> None:
@@ -94,8 +97,12 @@ class PimsCziReader(FramesSequenceND):
 
     def get_frame_2D(self, **ind: int) -> np.ndarray:
         plane = {k.upper(): v for k, v in ind.items()}
+
+        # safe-guard against x/y in ind argument,
+        # we always read the whole slice here:
         plane.pop("X", None)
         plane.pop("Y", None)
+
         plane["C"] = self.czi_channel
         with self.czi_file() as czi_file:
             a = czi_file.read(plane=plane)

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -216,8 +216,8 @@ class PimsImages:
                     # 5th dimension would be something else)
                     if timepoint is not None:
                         raise RuntimeError(
-                            f"Got {len(images.shape)} axes for the images, "
-                            + "cannot map to 3D+channels+timepoints."
+                            f"Got {len(images.shape)} axes for the images after "
+                            + "removing time dimension, can only map to 3D+channels."
                         )
 
                     if _assume_color_channel(images.shape[2], images.dtype):

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1060,11 +1060,24 @@ class Dataset:
             # and automatically truncate to 3 channels
             # (pims_images takes care of this:)
             del possible_layers["channel"]
-        # Below, we iterate over suffix_with_pims_open_kwargs_per_layer in the for-loop
+        # Further below, we iterate over suffix_with_pims_open_kwargs_per_layer in the for-loop
         # to add one layer per possible_layer if allow_multiple_layers is True.
         # If just a single layer is added, we still add a default value in the dict.
         if possible_layers is not None and len(possible_layers) > 0:
             if allow_multiple_layers:
+                # Get all combinations of possible layers. E.g.
+                # possible_layers = {
+                #    "channel": [0, 1, 3, 4, 5],
+                #    "timepoint": [0, 1],
+                # }
+                # suffix_with_pims_open_kwargs_per_layer = {
+                #    "__channel=0_timepoint=0", {"channel": 0, "timepoint": 0},
+                #    "__channel=0_timepoint=1", {"channel": 0, "timepoint": 1},
+                #    "__channel=0_timepoint=2", {"channel": 0, "timepoint": 2},
+                #    …,
+                #    "__channel=1_timepoint=0", {"channel": 1, "timepoint": 0},
+                #    …,
+                # }
                 suffix_with_pims_open_kwargs_per_layer = {
                     "__" + "_".join(f"{k}={v}" for k, v in sorted(pairs)): dict(pairs)
                     for pairs in product(
@@ -1075,6 +1088,7 @@ class Dataset:
                     )
                 }
             else:
+                # initialize PimsImages as above, with normal layer name
                 suffix_with_pims_open_kwargs_per_layer = {"": {}}
                 warnings.warn(
                     f"There are dimensions beyond channels and xyz which cannot be read: {possible_layers}. "
@@ -1084,6 +1098,7 @@ class Dataset:
                     RuntimeWarning,
                 )
         else:
+            # initialize PimsImages as above, with normal layer name
             suffix_with_pims_open_kwargs_per_layer = {"": {}}
         first_layer = None
         add_layer_kwargs = {}

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1018,8 +1018,9 @@ class Dataset:
         * `flip_x`, `flip_y`, `flip_z`: set to `True` to reverse the respective axis before writing to disk
         * `dtype`: the read image data will be convertoed to this dtype using `numpy.ndarray.astype`
         * `use_bioformats`: set to `True` to use the [pims bioformats adapter](https://soft-matter.github.io/pims/v0.6.1/bioformats.html), needs a JVM
-        * `channel`: may be used to select a single channel, if multiple are available,
+        * `channel`: may be used to select a single channel, if multiple are available
         * `timepoint`: for timeseries, select a timepoint to use by specifying it as an int, starting from 0
+        * `czi_channel`: may be used to select a channel for .czi images, which differs from normal color-channels
         * `batch_size`: size to process the images, must be a multiple of the chunk-size z-axis for uncompressed and the shard-size z-axis for compressed layers, default is the chunk-size or shard-size respectively
         * `allow_multiple_layers`: set to `True` if timepoints or channels may result in multiple layers being added (only the first is returned)
         * `truncate_rgba_to_rgb`: only applies if `allow_multiple_layers=True`, set to `False` to write four channels into layers instead of an RGB channel

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1081,6 +1081,9 @@ class Dataset:
         else:
             suffix_with_kwargs = {"": {}}
         first_layer = None
+        add_layer_kwargs = {}
+        if category == "segmentation":
+            add_layer_kwargs["largest_segment_id"] = 0
         for suffix, pims_kwargs in suffix_with_kwargs.items():
             if len(pims_kwargs) > 0:
                 pims_kwargs.setdefault("timepoint", timepoint)
@@ -1102,6 +1105,7 @@ class Dataset:
                 data_format=data_format,
                 dtype_per_channel=pims_images.dtype if dtype is None else dtype,
                 num_channels=pims_images.num_channels,
+                **add_layer_kwargs,  # type: ignore[arg-type]
             )
             mag_view = layer.add_mag(
                 mag=mag,


### PR DESCRIPTION
### Description:
- `Dataset.from_images` now adds a layer per timepoint and per channel (if the data doesn't have 1 or 3 channels).
- Added python-native CZI support for `Dataset.from_images` or `dataset.add_layer_from_images`, without using bioformats.
- `dataset.add_layer_from_images` can add a layer per timepoint and per channel when passing `allow_multiple_layers=True`.
- Fixes for the pims ImageIO reader are improved.

### Issues:
- part of #748

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
