### PR TITLE
allow wkcuber.tile_cubing to use zero indexed tile locations when using the --input_path_pattern option

### DIFF
--- a/wkcuber/wkcuber/tile_cubing.py
+++ b/wkcuber/wkcuber/tile_cubing.py
@@ -145,7 +145,6 @@ def detect_interval_for_dimensions(
                             idx : idx + current_decimal_length[current_dimension]
                         ]
                         coordinate_value = int(coordinate_value_str)
-                        assert coordinate_value
                         min_dimensions[current_dimension] = min(
                             min_dimensions.get(current_dimension, coordinate_value),
                             coordinate_value,


### PR DESCRIPTION
### Description:

removes an assert that failed only when an index was zero

importing with zero indexed paths where eg. `{z}/{x}_{y}.tiff` is in the range of `[1..99]/[0..8]_[0..7].tiff` would fail as the assert would trigger

importing a zero indexed stack of images works fine with this assert removed, there is no reason to require this to not be zero

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
