### PR TITLE
split nightly tests, too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,7 +171,7 @@ jobs:
     - name: Python tests
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
-      run: ./test.sh --splits 5 --group ${{ matrix.group }}
+      run: ./test.sh --splits 3 --group ${{ matrix.group }}
 
     - name: Check if git is dirty
       run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,7 +41,7 @@ jobs:
     - name: Python tests, refreshing the network snapshots
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
-      run: ./test.sh --refresh-snapshots --splits 5 --group ${{ matrix.group }}
+      run: ./test.sh --refresh-snapshots --splits 3 --group ${{ matrix.group }}
 
     - name: Python tests, using the new snapshots
       env:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -46,4 +46,4 @@ jobs:
     - name: Python tests, using the new snapshots
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
-      run: ./test.sh --refresh-snapshots --splits 5 --group ${{ matrix.group }}
+      run: ./test.sh --refresh-snapshots --splits 3 --group ${{ matrix.group }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,7 +3,6 @@ name: nightly
 on:
   schedule:
     - cron:  '00 06 * * *'
-  pull_request: {}
   workflow_dispatch: ~
 
 jobs:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -3,6 +3,7 @@ name: nightly
 on:
   schedule:
     - cron:  '00 06 * * *'
+  pull_request: {}
   workflow_dispatch: ~
 
 jobs:
@@ -11,7 +12,8 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.7, 3.8, 3.9]
+        group: [1, 2, 3]
     defaults:
       run:
         working-directory: webknossos
@@ -40,15 +42,9 @@ jobs:
     - name: Python tests, refreshing the network snapshots
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
-      run: ./test.sh --refresh-snapshots
+      run: ./test.sh --refresh-snapshots --splits 5 --group ${{ matrix.group }}
 
     - name: Python tests, using the new snapshots
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
-      run: ./test.sh --refresh-snapshots
-
-    - name: Check if git is dirty
-      continue-on-error: true  # This is currently expected to fail, might change in the future
-      run: |
-        git diff --no-ext-diff --quiet --exit-code
-        [[ -z $(git status -s) ]]
+      run: ./test.sh --refresh-snapshots --splits 5 --group ${{ matrix.group }}


### PR DESCRIPTION
### Description:
- Split the nightly tests similar to the normal CI runs, to avoid being terminated due to unknown reasons
