### PR TITLE
Fix error when trying to call existing sigint handler which might be signal.SIG_IGN

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixed `TypeError` when aborting a run that occurred under certain circumstances. [#851](https://github.com/scalableminds/webknossos-libs/pull/851)
 
 
 ## [0.11.1](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.11.1) - 2023-01-05

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -128,6 +128,7 @@ class ClusterExecutor(futures.Executor):
         if (
             existing_sigint_handler  # pylint: disable=comparison-with-callable
             != signal.default_int_handler
+            and callable(existing_sigint_handler)  # Could also be signal.SIG_IGN
         ):
             existing_sigint_handler(signum, frame)
 


### PR DESCRIPTION
### Description:
- See title, I stumbled upon this during some tests I made and decided to fix it right away. I confirmed that the error no longer happens and the original functionality still works as intended.

Stack trace was:

```
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/u/danielwe/code/voxelytics/environments/miniconda/envs/vx-py39/lib/python3.9/multiprocessing/spawn.py", line 116, in spawn_main
    exitcode = _main(fd, parent_sentinel)
  File "/u/danielwe/code/voxelytics/environments/miniconda/envs/vx-py39/lib/python3.9/multiprocessing/spawn.py", line 129, in _main
    return self._bootstrap(parent_sentinel)
  File "/u/danielwe/code/voxelytics/environments/miniconda/envs/vx-py39/lib/python3.9/multiprocessing/process.py", line 333, in _bootstrap
    threading._shutdown()
  File "/u/danielwe/code/voxelytics/environments/miniconda/envs/vx-py39/lib/python3.9/threading.py", line 1477, in _shutdown
    lock.acquire()
  File "/u/danielwe/code/voxelytics/environments/miniconda/envs/vx-py39/lib/python3.9/site-packages/cluster_tools/schedulers/cluster_executor.py", line 132, in handle_kill
    existing_sigint_handler(signum, frame)
TypeError: 'Handlers' object is not callable
```

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
