### PR TITLE
docs: remove margin between logo and title

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -36,6 +36,12 @@
 		.pdoc .attr {
 			font-family: var(--md-code-font);
 		}
+		[dir=ltr] .md-header__title {
+			margin-left: 0rem;
+		}
+		[dir=ltr] .md-header__title {
+			margin-right: 0rem;
+		}
 	</style>
 {% endblock styles %}
 


### PR DESCRIPTION
Before:
![Screenshot from 2023-01-17 11-50-30](https://user-images.githubusercontent.com/7216331/212882405-251d7147-947a-4297-8dc8-474e5ef48353.png)

After:
![Screenshot from 2023-01-17 11-50-38](https://user-images.githubusercontent.com/7216331/212882408-e39a36dc-2b64-4b91-97e6-c2432f75c889.png)
