### PR TITLE
Natsort images when Path passed to add_layer_from_images

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-
+- Fixed a bug, where the image order could be randomized when passing a directory path to `Dataset.add_layer_from_images`. [#854](https://github.com/scalableminds/webknossos-libs/pull/854)
 
 ## [0.11.1](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.11.1) - 2023-01-05
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.11.0...v0.11.1)

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -19,9 +19,9 @@ from typing import (
     cast,
 )
 from urllib.error import HTTPError
-from natsort import natsorted
 
 import numpy as np
+from natsort import natsorted
 
 # pylint: disable=unused-import
 try:

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -19,6 +19,7 @@ from typing import (
     cast,
 )
 from urllib.error import HTTPError
+from natsort import natsorted
 
 import numpy as np
 
@@ -294,11 +295,11 @@ class PimsImages:
             original_images_path = Path(original_images)
             if original_images_path.is_dir():
                 valid_suffixes = get_valid_pims_suffixes()
-                original_images = [
+                original_images = natsorted(
                     str(i)
                     for i in original_images_path.glob("**/*")
                     if i.is_file() and i.suffix.lstrip(".") in valid_suffixes
-                ]
+                )
                 if len(original_images) == 1:
                     original_images = original_images[0]
         if isinstance(original_images, str):


### PR DESCRIPTION
### Description:

When a directory path is passed to `Dataset.add_layer_from_images`, glob is used to determine which image files to consider. Glob’s output is not sorted but is equal to that of `ls -U`.

This PR natsorts the output of glob, fixing the order of the images.

### Todos:
 - [x] Updated Changelog
