### PR TITLE
Fix slurm execution

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixed the execution of non-array jobs using slurm. [#864](https://github.com/scalableminds/webknossos-libs/pull/864)
 
 
 ## [0.11.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.11.3) - 2023-02-06

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -133,7 +133,7 @@ class SlurmExecutor(ClusterExecutor):
         # inner_submit function.
         job_id_string = (
             job_id
-            if job_array_index is None or job_array_id is None
+            if job_array_id is None or job_array_index is None
             else f"{job_array_id}_{job_array_index}"
         )
         return job_id_string

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -107,10 +107,11 @@ class SlurmExecutor(ClusterExecutor):
             return None
 
     @staticmethod
-    def get_job_array_id() -> str:
-        r = os.environ.get("SLURM_ARRAY_JOB_ID")
-        assert r is not None
-        return r
+    def get_job_array_id() -> Optional[str]:
+        try:
+            return os.environ.get("SLURM_ARRAY_JOB_ID")
+        except KeyError:
+            return None
 
     @staticmethod
     def get_current_job_id() -> str:
@@ -131,7 +132,9 @@ class SlurmExecutor(ClusterExecutor):
         # This variable needs to be kept in sync with the job_id_string variable in the
         # inner_submit function.
         job_id_string = (
-            job_id if job_array_index is None else f"{job_array_id}_{job_array_index}"
+            job_id
+            if job_array_index is None or job_array_id is None
+            else f"{job_array_id}_{job_array_index}"
         )
         return job_id_string
 


### PR DESCRIPTION
### Description:
- In https://github.com/scalableminds/webknossos-libs/pull/858 an assertion was added to the `get_job_array_id` method of the slurm executor, asserting that the `SLURM_ARRAY_JOB_ID` environment variable is always set. However, it is not set for non-array jobs which triggers the assertion.

### Issues:
- I successfully tested this PR using the workflow which I ran when discovering the bug.
- I'm not sure why this wasn't triggered in the slurm tests :thinking: 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Added / Updated Tests
