### PR TITLE
Pims normalize extensions for assertion

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 
 ### Fixed
 
+- Fixed a bug where some czi, dm3, dm4 images could not be converted to wkw due to a too-strict check. [#865](https://github.com/scalableminds/webknossos-libs/pull/865)
+
 
 ## [0.12.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.12.0) - 2023-02-10
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.11.4...v0.12.0)

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -37,7 +37,7 @@ PIXEL_TYPE_TO_DTYPE = {
 class PimsCziReader(FramesSequenceND):
     @classmethod
     def class_exts(cls) -> Set[str]:
-        return {".czi"}
+        return {"czi"}
 
     # class_priority is used in pims to pick the reader with the highest priority.
     # Default is 10, and bioformats priority (which is the only other reader supporting czi) is 2.

--- a/webknossos/webknossos/dataset/_utils/pims_dm_readers.py
+++ b/webknossos/webknossos/dataset/_utils/pims_dm_readers.py
@@ -20,7 +20,7 @@ except ImportError as e:
 class PimsDm3Reader(FramesSequenceND):
     @classmethod
     def class_exts(cls) -> Set[str]:
-        return {".dm3"}
+        return {"dm3"}
 
     # class_priority is used in pims to pick the reader with the highest priority.
     # Default is 10, and bioformats priority is 2.
@@ -52,7 +52,7 @@ class PimsDm3Reader(FramesSequenceND):
 class PimsDm4Reader(FramesSequenceND):
     @classmethod
     def class_exts(cls) -> Set[str]:
-        return {".dm4"}
+        return {"dm4"}
 
     # class_priority is used in pims to pick the reader with the highest priority.
     # Default is 10, and bioformats priority is 2.

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -567,7 +567,7 @@ def _get_all_pims_handlers() -> Iterable[
 def get_valid_pims_suffixes() -> Set[str]:
     valid_suffixes = set()
     for pims_handler in _get_all_pims_handlers():
-        valid_suffixes.update(pims_handler.class_exts())
+        valid_suffixes.update([ext.lstrip(".") for ext in pims_handler.class_exts()])
     return valid_suffixes
 
 


### PR DESCRIPTION
I got
`The following suffixes are supported: ['.czi', '.dm3', '.dm4', 'avbin', 'avi', 'bmp', 'cine', 'cut', 'dds',…]` and noticed that in that line, `'.czi'` still has a leading `.`, breaking the assertion despite my data having the right extension.

 - [x] Updated Changelog
