### PR TITLE
reproducable generated client, smaller tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,7 @@ jobs:
       run: ./typecheck.sh
 
     - name: Python tests
+      timeout-minutes: 30
       env:
         WK_TOKEN: ${{ secrets.WK_TOKEN }}
       run: ./test.sh --splits 3 --group ${{ matrix.group }}  --splitting-algorithm least_duration

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,7 +104,8 @@ The [WEBKNOSSOS-libs repository](https://github.com/scalableminds/webknossos-lib
 See below for specifics of the different packages. Let's have a look at the common tooling first:
 
 * [**poetry**](https://python-poetry.org) is used for dependency management and publishing.
-  By default, it creates a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for each package.
+  Use `poetry install --all-extras` in each package folder to install all dependencies for development.
+  By default, this creates a [virtual environment](https://docs.python.org/3/tutorial/venv.html) for each package.
   To run commands inside this package, prefix them with `poetry run`, e.g. `poetry run python myscript.py`,
   or enter the virtual environment with `poetry shell`.
   The creation of a separate environment can be disabled (e.g. if you want to manage this manually),

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ update-internal:
 	$(call in_each_pkg_by_dependency, poetry update $(packages_by_dependency))
 
 install:
-	$(call in_each_pkg_by_dependency, poetry install --extras all || poetry install)
+	$(call in_each_pkg_by_dependency, poetry install --all-extras)
 
 format:
 	$(call in_each_code_pkg, ./format.sh)

--- a/cluster_tools/cluster_tools/executors/multiprocessing.py
+++ b/cluster_tools/cluster_tools/executors/multiprocessing.py
@@ -258,6 +258,11 @@ class MultiprocessingExecutor(ProcessPoolExecutor):
         return fut.result()
 
     def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
-        super().shutdown(wait=wait, cancel_futures=cancel_futures)
+        if cancel_futures:
+            # cancel_futures was added in Python 3.9, ignoring it as 3.8 is supported:
+            logging.warning(
+                "The provided cancel_futures argument is ignored by MultiprocessingExecutor."
+            )
+        super().shutdown(wait=wait)
         if self._mp_logging_handler_pool is not None:
             self._mp_logging_handler_pool.close()

--- a/cluster_tools/cluster_tools/executors/multiprocessing.py
+++ b/cluster_tools/cluster_tools/executors/multiprocessing.py
@@ -26,7 +26,7 @@ from typing_extensions import Literal, ParamSpec, TypedDict
 
 from cluster_tools._utils import pickling
 from cluster_tools._utils.multiprocessing_logging_handler import (
-    _get_multiprocessing_logging_setup_fn,
+    _MultiprocessingLoggingHandlerPool,
 )
 from cluster_tools._utils.warning import enrich_future_with_uncaught_warning
 
@@ -80,6 +80,10 @@ class MultiprocessingExecutor(ProcessPoolExecutor):
             initializer=initializer,
             initargs=initargs,
         )
+        if self._mp_context.get_start_method() == "fork":
+            self._mp_logging_handler_pool = None
+        else:
+            self._mp_logging_handler_pool = _MultiprocessingLoggingHandlerPool()
 
     def submit(  # type: ignore[override]
         self,
@@ -111,25 +115,27 @@ class MultiprocessingExecutor(ProcessPoolExecutor):
         # The call_stack holds all of these wrapper functions and their arguments in the correct order.
         # For example, call_stack = [wrapper_fn_1, wrapper_fn_1_arg_1, wrapper_fn_2, actual_fn, actual_fn_arg_1]
         # where wrapper_fn_1 is called, which eventually calls wrapper_fn_2, which eventually calls actual_fn.
-        call_stack = []
+        call_stack: List[Callable] = []
 
-        if self._mp_context.get_start_method() != "fork":
+        if self._mp_logging_handler_pool is not None:
             # If a start_method other than the default "fork" is used, logging needs to be re-setup,
             # because the programming context is not inherited in those cases.
-            multiprocessing_logging_setup_fn = _get_multiprocessing_logging_setup_fn()
-            call_stack.extend(
-                [
+            multiprocessing_logging_setup_fn = (
+                self._mp_logging_handler_pool.get_multiprocessing_logging_setup_fn()
+            )
+            call_stack.append(
+                partial(
                     MultiprocessingExecutor._setup_logging_and_execute,
                     multiprocessing_logging_setup_fn,
-                ]
+                )
             )
 
         if output_pickle_path is not None:
-            call_stack.extend(
-                [
+            call_stack.append(
+                partial(
                     MultiprocessingExecutor._execute_and_persist_function,
                     output_pickle_path,
-                ]
+                )
             )
 
         fut = submit_fn(*call_stack, __fn, *args, **kwargs)
@@ -250,3 +256,8 @@ class MultiprocessingExecutor(ProcessPoolExecutor):
         # Since the default behavior of process pool executors is to show the log in the main process
         # we don't need to do anything except for blocking until the future is done.
         return fut.result()
+
+    def shutdown(self, wait: bool = True, *, cancel_futures: bool = False) -> None:
+        super().shutdown(wait=wait, cancel_futures=cancel_futures)
+        if self._mp_logging_handler_pool is not None:
+            self._mp_logging_handler_pool.close()

--- a/webknossos/__generate_client.py
+++ b/webknossos/__generate_client.py
@@ -430,7 +430,7 @@ def make_properties_required(  # pylint: disable=dangerous-default-value
 
 def remove_examples(
     x: Any,
-) -> List[str]:
+) -> None:
     if isinstance(x, dict):
         if "example" in x:
             del x["example"]

--- a/webknossos/__generate_client.py
+++ b/webknossos/__generate_client.py
@@ -428,6 +428,19 @@ def make_properties_required(  # pylint: disable=dangerous-default-value
     return handled_required_keys
 
 
+def remove_examples(
+    x: Any,
+) -> List[str]:
+    if isinstance(x, dict):
+        if "example" in x:
+            del x["example"]
+        for i in x.values():
+            remove_examples(i)
+    elif isinstance(x, list):
+        for i in x:
+            remove_examples(i)
+
+
 def set_response_schema_by_example(
     openapi_schema: Dict,
     example_response: bytes,
@@ -453,6 +466,7 @@ def set_response_schema_by_example(
         if path_method["operationId"] == operation_id
     ][0]
     handled_required_keys = make_properties_required(recorded_response_schema)
+    remove_examples(recorded_response_schema)
     request_schema["responses"]["200"]["content"] = recorded_response_schema
     return handled_required_keys
 

--- a/webknossos/examples/download_segments.py
+++ b/webknossos/examples/download_segments.py
@@ -5,7 +5,7 @@ import webknossos as wk
 
 ANNOTATION_ID = "634e8fe1010000b4006f3cf4"
 SEGMENT_IDS = [32, 667325]
-MAG = wk.Mag("4-4-1")
+MAG = wk.Mag("8-8-2")
 
 
 def main() -> None:
@@ -14,7 +14,7 @@ def main() -> None:
     )
     mag_view = dataset.get_segmentation_layers()[0].get_mag(MAG)
 
-    z = mag_view.layer.bounding_box.topleft.z
+    z = mag_view.bounding_box.topleft.z
     with mag_view.get_buffered_slice_reader() as reader:
         for slice_data in reader:
             slice_data = slice_data[0]  # First channel only

--- a/webknossos/examples/download_tiff_stack.py
+++ b/webknossos/examples/download_tiff_stack.py
@@ -4,7 +4,7 @@ import webknossos as wk
 
 DATASET_NAME = "l4_sample"
 LAYER_NAME = "color"
-MAG = wk.Mag("4-4-1")
+MAG = wk.Mag("16-16-4")
 
 
 def main() -> None:
@@ -15,7 +15,7 @@ def main() -> None:
     )
     mag_view = dataset.get_layer(LAYER_NAME).get_mag(MAG)
 
-    z = mag_view.layer.bounding_box.topleft.z
+    z = mag_view.bounding_box.topleft.z
     with mag_view.get_buffered_slice_reader() as reader:
         for slice_data in reader:
             slice_data = slice_data[0]  # First channel only

--- a/webknossos/examples/zarr_and_dask.py
+++ b/webknossos/examples/zarr_and_dask.py
@@ -2,6 +2,8 @@ import dask.array as da
 
 import webknossos as wk
 
+MAG = wk.Mag("8-8-2")
+
 
 def main() -> None:
     # Remote datasets are read-only, but can be used similar to normal datasets:
@@ -10,11 +12,11 @@ def main() -> None:
     )
 
     layer = l4_sample_dataset.get_layer("color")
-    mag = layer.get_finest_mag()
+    mag_view = layer.get_mag(MAG)
 
-    zarr_array = mag.get_zarr_array()
+    zarr_array = mag_view.get_zarr_array()
     dask_array = da.from_array(zarr_array, chunks=(1, 256, 256, 256))[
-        (0,) + layer.bounding_box.to_slices()
+        (0,) + mag_view.bounding_box.in_mag(MAG).to_slices()
     ]
 
     mean_value = dask_array.mean().compute()

--- a/webknossos/local_wk_setup.sh
+++ b/webknossos/local_wk_setup.sh
@@ -1,7 +1,7 @@
 function export_vars {
     export WK_TOKEN=1b88db86331a38c21a0b235794b9e459856490d70408bcffb767f64ade0f83d2bdb4c4e181b9a9a30cdece7cb7c65208cc43b6c1bb5987f5ece00d348b1a905502a266f8fc64f0371cd6559393d72e031d0c2d0cabad58cccf957bb258bc86f05b5dc3d4fff3d5e3d9c0389a6027d861a21e78e3222fb6c5b7944520ef21761e
     export WK_URL=http://localhost:9000
-    export DOCKER_TAG=master__10303
+    export DOCKER_TAG=master__21723
 }
 
 function ensure_local_test_wk {
@@ -26,7 +26,7 @@ function ensure_local_test_wk {
         while ! curl -sf localhost:9000/api/health; do
             sleep 5
         done
-        OUT=$(docker-compose exec -T webknossos tools/postgres/prepareTestDB.sh 2>&1) || echo "$OUT"
+        OUT=$(docker-compose exec -T webknossos tools/postgres/dbtool.js prepare-test-db 2>&1) || echo "$OUT"
         popd > /dev/null
     else
         echo "Using the already running local webknossos setup at localhost:9000"

--- a/webknossos/tests/test_annotation.py
+++ b/webknossos/tests/test_annotation.py
@@ -142,25 +142,25 @@ def test_annotation_from_file_with_multi_volume() -> None:
     ],
 )
 def test_annotation_from_url(url: str) -> None:
-
-    annotation = wk.Annotation.download(url)
+    annotation = wk.Annotation.download(url, skip_volume_data=True)
     assert annotation.dataset_name == "l4dense_motta_et_al_demo_v2"
     assert len(list(annotation.skeleton.flattened_trees())) == 1
 
+    mag = wk.Mag("16-16-8")
     node_bbox = wk.BoundingBox.from_points(
         next(annotation.skeleton.flattened_trees()).get_node_positions()
-    )
+    ).align_with_mag(mag, ceil=True)
     with wk.webknossos_context(url="https://webknossos.org"):
         ds = annotation.get_remote_annotation_dataset()
 
-    mag = ds.layers["Volume"].get_finest_mag()
-    annotated_data = mag.read(absolute_bounding_box=node_bbox)
-    assert annotated_data.size > 1000
+    mag_view = ds.layers["Volume"].get_mag(mag)
+    annotated_data = mag_view.read(absolute_bounding_box=node_bbox)
+    assert annotated_data.size > 10
     assert (annotated_data == 2504698).all()
-    assert mag.read(absolute_offset=(0, 0, 0), size=(10, 10, 10))[0, 0, 0, 0] == 0
+    assert mag_view.read(absolute_offset=(0, 0, 0), size=(16, 16, 8))[0, 0, 0, 0] == 0
     assert (
-        mag.read(absolute_offset=(128, 128, 128), size=(10, 10, 10))[0, 0, 0, 0]
-        == 286021
+        mag_view.read(absolute_offset=(128, 128, 128), size=(16, 16, 8))[0, 0, 0, 0]
+        == 286022
     )
     segment_info = annotation.get_volume_layer_segments("Volume")[2504698]
     assert segment_info.anchor_position == (2785, 4423, 1792)

--- a/webknossos/tests/test_examples.py
+++ b/webknossos/tests/test_examples.py
@@ -233,7 +233,7 @@ def test_zarr_and_dask() -> None:
 
     (mean_value,) = exec_main_and_get_vars(example, "mean_value")
 
-    assert 124 < mean_value < 125
+    assert 123 < mean_value < 125
 
 
 def test_upload_tiff_stack() -> None:
@@ -277,5 +277,5 @@ def test_download_tiff_stack() -> None:
 
         assert (
             len(list(output_path.iterdir()))
-            == mag_view.layer.bounding_box.size.z / mag_view.mag.z
+            == mag_view.bounding_box.size.z / mag_view.mag.z
         )

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200.py
@@ -37,12 +37,12 @@ T = TypeVar("T", bound="AnnotationInfoResponse200")
 class AnnotationInfoResponse200:
     """
     Attributes:
-        state (str):  Example: Active.
-        id (str):  Example: 58135c192faeb34c0081c05d.
+        state (str):
+        id (str):
         name (str):
         description (str):
-        typ (str):  Example: TracingBase.
-        organization (str):  Example: Organization_X.
+        typ (str):
+        organization (str):
         data_store (AnnotationInfoResponse200DataStore):
         tags (List[str]):
         modified (Union[Unset, int]):
@@ -50,11 +50,11 @@ class AnnotationInfoResponse200:
         task (Union[Unset, None, AnnotationInfoResponse200Task]):
         stats (Union[Unset, AnnotationInfoResponse200Stats]):
         restrictions (Union[Unset, AnnotationInfoResponse200Restrictions]):
-        formatted_hash (Union[Unset, str]):  Example: 81c05d.
+        formatted_hash (Union[Unset, str]):
         annotation_layers (Union[Unset, List['AnnotationInfoResponse200AnnotationLayersItem']]):
-        data_set_name (Union[Unset, str]):  Example: 2012-06-28_Cortex.
+        data_set_name (Union[Unset, str]):
         tracing_store (Union[Unset, AnnotationInfoResponse200TracingStore]):
-        visibility (Union[Unset, str]):  Example: Internal.
+        visibility (Union[Unset, str]):
         settings (Union[Unset, AnnotationInfoResponse200Settings]):
         tracing_time (Union[Unset, None, int]):
         teams (Union[Unset, List[Any]]):

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_annotation_layers_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_annotation_layers_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfoResponse200AnnotationLayersItem")
 class AnnotationInfoResponse200AnnotationLayersItem:
     """
     Attributes:
-        typ (str):  Example: Skeleton.
-        tracing_id (Union[Unset, str]):  Example: 76220a3a-9715-4792-bed5-6fda7ca8193f.
-        name (Union[Unset, str]):  Example: Skeleton.
+        typ (str):
+        tracing_id (Union[Unset, str]):
+        name (Union[Unset, str]):
     """
 
     typ: str

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_data_store.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_data_store.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfoResponse200DataStore")
 class AnnotationInfoResponse200DataStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
-        allows_upload (int):  Example: True.
+        name (str):
+        url (str):
+        allows_upload (int):
         is_scratch (Union[Unset, int]):
         is_connector (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_owner.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_owner.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="AnnotationInfoResponse200Owner")
 class AnnotationInfoResponse200Owner:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['AnnotationInfoResponse200OwnerTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_owner_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_owner_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfoResponse200OwnerTeamsItem")
 class AnnotationInfoResponse200OwnerTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_restrictions.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_restrictions.py
@@ -11,10 +11,10 @@ T = TypeVar("T", bound="AnnotationInfoResponse200Restrictions")
 class AnnotationInfoResponse200Restrictions:
     """
     Attributes:
-        allow_access (Union[Unset, int]):  Example: True.
-        allow_update (Union[Unset, int]):  Example: True.
-        allow_finish (Union[Unset, int]):  Example: True.
-        allow_download (Union[Unset, int]):  Example: True.
+        allow_access (Union[Unset, int]):
+        allow_update (Union[Unset, int]):
+        allow_finish (Union[Unset, int]):
+        allow_download (Union[Unset, int]):
     """
 
     allow_access: Union[Unset, int] = UNSET

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_settings.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_settings.py
@@ -18,10 +18,10 @@ class AnnotationInfoResponse200Settings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
-        merger_mode (Union[Unset, int]):  Example: True.
+        merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset, AnnotationInfoResponse200SettingsResolutionRestrictions]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task.py
@@ -23,15 +23,15 @@ T = TypeVar("T", bound="AnnotationInfoResponse200Task")
 class AnnotationInfoResponse200Task:
     """
     Attributes:
-        id (str):  Example: 581367a82faeb37a008a5354.
-        project_id (str):  Example: 68135bfd2faeb3190181c058.
-        team (str):  Example: team_X2.
-        data_set (str):  Example: 2012-06-28_Cortex.
-        created (int):  Example: 1477666728000.
+        id (str):
+        project_id (str):
+        team (str):
+        data_set (str):
+        created (int):
         status (AnnotationInfoResponse200TaskStatus):
         bounding_box (str):
-        formatted_hash (Union[Unset, str]):  Example: 8a5354.
-        project_name (Union[Unset, str]):  Example: Test_Project2.
+        formatted_hash (Union[Unset, str]):
+        project_name (Union[Unset, str]):
         type (Union[Unset, AnnotationInfoResponse200TaskType]):
         needed_experience (Union[Unset, AnnotationInfoResponse200TaskNeededExperience]):
         script (Union[Unset, str]):

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_needed_experience.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_needed_experience.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="AnnotationInfoResponse200TaskNeededExperience")
 class AnnotationInfoResponse200TaskNeededExperience:
     """
     Attributes:
-        domain (Union[Unset, str]):  Example: abc.
+        domain (Union[Unset, str]):
         value (Union[Unset, int]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_status.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_status.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="AnnotationInfoResponse200TaskStatus")
 class AnnotationInfoResponse200TaskStatus:
     """
     Attributes:
-        open_ (int):  Example: 10.
+        open_ (int):
         active (int):
         finished (int):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_type.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_type.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="AnnotationInfoResponse200TaskType")
 class AnnotationInfoResponse200TaskType:
     """
     Attributes:
-        id (str):  Example: 570b9f4c2a7c0e4c008da6ff.
-        description (str):  Example: Check those cells out!.
-        team_name (str):  Example: team_X2.
-        summary (Union[Unset, str]):  Example: ek_0674_BipolarCells.
-        team_id (Union[Unset, str]):  Example: 69882b370d889b84020efd4f.
+        id (str):
+        description (str):
+        team_name (str):
+        summary (Union[Unset, str]):
+        team_id (Union[Unset, str]):
         settings (Union[Unset, AnnotationInfoResponse200TaskTypeSettings]):
         recommended_configuration (Union[Unset, str]):
-        tracing_type (Union[Unset, str]):  Example: skeleton.
+        tracing_type (Union[Unset, str]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_type_settings.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_task_type_settings.py
@@ -18,10 +18,10 @@ class AnnotationInfoResponse200TaskTypeSettings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
-        merger_mode (Union[Unset, int]):  Example: True.
+        merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset, AnnotationInfoResponse200TaskTypeSettingsResolutionRestrictions]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_tracing_store.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_tracing_store.py
@@ -9,8 +9,8 @@ T = TypeVar("T", bound="AnnotationInfoResponse200TracingStore")
 class AnnotationInfoResponse200TracingStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
+        name (str):
+        url (str):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_user.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_user.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="AnnotationInfoResponse200User")
 class AnnotationInfoResponse200User:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['AnnotationInfoResponse200UserTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_info_response_200_user_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_info_response_200_user_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfoResponse200UserTeamsItem")
 class AnnotationInfoResponse200UserTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item.py
@@ -41,12 +41,12 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200Item")
 class AnnotationInfosByTaskIdResponse200Item:
     """
     Attributes:
-        state (str):  Example: Active.
-        id (str):  Example: 58135c402faeb34e0081c068.
+        state (str):
+        id (str):
         name (str):
         description (str):
-        typ (str):  Example: Task.
-        organization (str):  Example: Organization_X.
+        typ (str):
+        organization (str):
         data_store (AnnotationInfosByTaskIdResponse200ItemDataStore):
         tags (List[str]):
         modified (Union[Unset, int]):
@@ -54,11 +54,11 @@ class AnnotationInfosByTaskIdResponse200Item:
         task (Union[Unset, None, AnnotationInfosByTaskIdResponse200ItemTask]):
         stats (Union[Unset, AnnotationInfosByTaskIdResponse200ItemStats]):
         restrictions (Union[Unset, AnnotationInfosByTaskIdResponse200ItemRestrictions]):
-        formatted_hash (Union[Unset, str]):  Example: 81c068.
+        formatted_hash (Union[Unset, str]):
         annotation_layers (Union[Unset, List['AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem']]):
-        data_set_name (Union[Unset, str]):  Example: 2012-06-28_Cortex.
+        data_set_name (Union[Unset, str]):
         tracing_store (Union[Unset, AnnotationInfosByTaskIdResponse200ItemTracingStore]):
-        visibility (Union[Unset, str]):  Example: Internal.
+        visibility (Union[Unset, str]):
         settings (Union[Unset, AnnotationInfosByTaskIdResponse200ItemSettings]):
         tracing_time (Union[Unset, None, int]):
         teams (Union[Unset, List[Any]]):

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_annotation_layers_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_annotation_layers_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemAnnotationLayersIt
 class AnnotationInfosByTaskIdResponse200ItemAnnotationLayersItem:
     """
     Attributes:
-        typ (str):  Example: Skeleton.
-        tracing_id (Union[Unset, str]):  Example: 07fd0bd7-f7a6-46d1-aaa8-58a381da4d50.
-        name (Union[Unset, str]):  Example: Skeleton.
+        typ (str):
+        tracing_id (Union[Unset, str]):
+        name (Union[Unset, str]):
     """
 
     typ: str

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_data_store.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_data_store.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemDataStore")
 class AnnotationInfosByTaskIdResponse200ItemDataStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
-        allows_upload (int):  Example: True.
+        name (str):
+        url (str):
+        allows_upload (int):
         is_scratch (Union[Unset, int]):
         is_connector (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_owner.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_owner.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemOwner")
 class AnnotationInfosByTaskIdResponse200ItemOwner:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['AnnotationInfosByTaskIdResponse200ItemOwnerTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_owner_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_owner_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemOwnerTeamsItem")
 class AnnotationInfosByTaskIdResponse200ItemOwnerTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_restrictions.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_restrictions.py
@@ -11,10 +11,10 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemRestrictions")
 class AnnotationInfosByTaskIdResponse200ItemRestrictions:
     """
     Attributes:
-        allow_access (Union[Unset, int]):  Example: True.
-        allow_update (Union[Unset, int]):  Example: True.
-        allow_finish (Union[Unset, int]):  Example: True.
-        allow_download (Union[Unset, int]):  Example: True.
+        allow_access (Union[Unset, int]):
+        allow_update (Union[Unset, int]):
+        allow_finish (Union[Unset, int]):
+        allow_download (Union[Unset, int]):
     """
 
     allow_access: Union[Unset, int] = UNSET

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_settings.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_settings.py
@@ -18,8 +18,8 @@ class AnnotationInfosByTaskIdResponse200ItemSettings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
         merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset, AnnotationInfosByTaskIdResponse200ItemSettingsResolutionRestrictions]):

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task.py
@@ -23,15 +23,15 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTask")
 class AnnotationInfosByTaskIdResponse200ItemTask:
     """
     Attributes:
-        id (str):  Example: 581367a82faeb37a008a5352.
-        project_id (str):  Example: 58135bfd2faeb3190181c057.
-        team (str):  Example: team_X1.
-        data_set (str):  Example: 2012-06-28_Cortex.
-        created (int):  Example: 1477666728000.
+        id (str):
+        project_id (str):
+        team (str):
+        data_set (str):
+        created (int):
         status (AnnotationInfosByTaskIdResponse200ItemTaskStatus):
         bounding_box (str):
-        formatted_hash (Union[Unset, str]):  Example: 8a5352.
-        project_name (Union[Unset, str]):  Example: Test_Project.
+        formatted_hash (Union[Unset, str]):
+        project_name (Union[Unset, str]):
         type (Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskType]):
         needed_experience (Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskNeededExperience]):
         script (Union[Unset, str]):

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_needed_experience.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_needed_experience.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTaskNeededExperien
 class AnnotationInfosByTaskIdResponse200ItemTaskNeededExperience:
     """
     Attributes:
-        domain (Union[Unset, str]):  Example: abc.
+        domain (Union[Unset, str]):
         value (Union[Unset, int]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_status.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_status.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTaskStatus")
 class AnnotationInfosByTaskIdResponse200ItemTaskStatus:
     """
     Attributes:
-        open_ (int):  Example: 10.
-        active (int):  Example: 1.
-        finished (int):  Example: -1.
+        open_ (int):
+        active (int):
+        finished (int):
     """
 
     open_: int

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_type.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_type.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTaskType")
 class AnnotationInfosByTaskIdResponse200ItemTaskType:
     """
     Attributes:
-        id (str):  Example: 570b9f4c2a7c0e4c008da6ee.
-        description (str):  Example: Check those cells out!.
-        team_name (str):  Example: team_X1.
-        summary (Union[Unset, str]):  Example: ek_0563_BipolarCells.
-        team_id (Union[Unset, str]):  Example: 570b9f4b2a7c0e3b008da6ec.
+        id (str):
+        description (str):
+        team_name (str):
+        summary (Union[Unset, str]):
+        team_id (Union[Unset, str]):
         settings (Union[Unset, AnnotationInfosByTaskIdResponse200ItemTaskTypeSettings]):
         recommended_configuration (Union[Unset, str]):
-        tracing_type (Union[Unset, str]):  Example: skeleton.
+        tracing_type (Union[Unset, str]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_type_settings.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_task_type_settings.py
@@ -18,8 +18,8 @@ class AnnotationInfosByTaskIdResponse200ItemTaskTypeSettings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
         merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset,

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_tracing_store.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_tracing_store.py
@@ -9,8 +9,8 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemTracingStore")
 class AnnotationInfosByTaskIdResponse200ItemTracingStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
+        name (str):
+        url (str):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_user.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_user.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemUser")
 class AnnotationInfosByTaskIdResponse200ItemUser:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['AnnotationInfosByTaskIdResponse200ItemUserTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_user_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/annotation_infos_by_task_id_response_200_item_user_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="AnnotationInfosByTaskIdResponse200ItemUserTeamsItem")
 class AnnotationInfosByTaskIdResponse200ItemUserTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/build_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/build_info_response_200.py
@@ -22,9 +22,9 @@ class BuildInfoResponse200:
     Attributes:
         webknossos (Union[Unset, BuildInfoResponse200Webknossos]):
         webknossos_wrap (Union[Unset, BuildInfoResponse200WebknossosWrap]):
-        schema_version (Union[Unset, int]):  Example: 99.
-        local_data_store_enabled (Union[Unset, int]):  Example: True.
-        local_tracing_store_enabled (Union[Unset, int]):  Example: True.
+        schema_version (Union[Unset, int]):
+        local_data_store_enabled (Union[Unset, int]):
+        local_tracing_store_enabled (Union[Unset, int]):
     """
 
     webknossos: Union[Unset, "BuildInfoResponse200Webknossos"] = UNSET

--- a/webknossos/webknossos/client/_generated/models/build_info_response_200_webknossos.py
+++ b/webknossos/webknossos/client/_generated/models/build_info_response_200_webknossos.py
@@ -11,15 +11,15 @@ T = TypeVar("T", bound="BuildInfoResponse200Webknossos")
 class BuildInfoResponse200Webknossos:
     """
     Attributes:
-        name (str):  Example: webknossos.
+        name (str):
         ci_tag (Union[Unset, str]):
-        commit_hash (Union[Unset, str]):  Example: 0b870f2cf643e105e6e2a8010d64433a2f49ae52.
+        commit_hash (Union[Unset, str]):
         ci_build (Union[Unset, str]):
-        scala_version (Union[Unset, str]):  Example: 2.12.15.
-        version (Union[Unset, str]):  Example: dev.
-        sbt_version (Union[Unset, str]):  Example: 1.6.2.
-        datastore_api_version (Union[Unset, str]):  Example: 2.0.
-        commit_date (Union[Unset, str]):  Example: Tue Feb 14 16:29:48 2023 +0000.
+        scala_version (Union[Unset, str]):
+        version (Union[Unset, str]):
+        sbt_version (Union[Unset, str]):
+        datastore_api_version (Union[Unset, str]):
+        commit_date (Union[Unset, str]):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/build_info_response_200_webknossos_wrap.py
+++ b/webknossos/webknossos/client/_generated/models/build_info_response_200_webknossos_wrap.py
@@ -11,13 +11,13 @@ T = TypeVar("T", bound="BuildInfoResponse200WebknossosWrap")
 class BuildInfoResponse200WebknossosWrap:
     """
     Attributes:
-        name (str):  Example: webknossos-wrap.
-        built_at_millis (Union[Unset, str]):  Example: 1640035836569.
-        commit_hash (Union[Unset, str]):  Example: 8b842648702f469a3ffd90dc8a68c4310e64b351.
-        scala_version (Union[Unset, str]):  Example: 2.12.7.
-        version (Union[Unset, str]):  Example: 1.1.15.
-        sbt_version (Union[Unset, str]):  Example: 1.4.1.
-        built_at_string (Union[Unset, str]):  Example: 2021-12-20 21:30:36.569.
+        name (str):
+        built_at_millis (Union[Unset, str]):
+        commit_hash (Union[Unset, str]):
+        scala_version (Union[Unset, str]):
+        version (Union[Unset, str]):
+        sbt_version (Union[Unset, str]):
+        built_at_string (Union[Unset, str]):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/current_user_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/current_user_info_response_200.py
@@ -23,25 +23,25 @@ T = TypeVar("T", bound="CurrentUserInfoResponse200")
 class CurrentUserInfoResponse200:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
-        is_active (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
+        is_active (int):
         experiences (CurrentUserInfoResponse200Experiences):
-        last_activity (int):  Example: 1676459044291.
-        organization (str):  Example: Organization_X.
-        created (int):  Example: 1460379469000.
-        is_organization_owner (Union[Unset, int]):  Example: True.
+        last_activity (int):
+        organization (str):
+        created (int):
+        is_organization_owner (Union[Unset, int]):
         teams (Union[Unset, List['CurrentUserInfoResponse200TeamsItem']]):
         is_anonymous (Union[Unset, int]):
-        is_editable (Union[Unset, int]):  Example: True.
+        is_editable (Union[Unset, int]):
         novel_user_experience_infos (Union[Unset, CurrentUserInfoResponse200NovelUserExperienceInfos]):
-        selected_theme (Union[Unset, str]):  Example: auto.
+        selected_theme (Union[Unset, str]):
         last_task_type_id (Union[Unset, str]):
-        is_super_user (Union[Unset, int]):  Example: True.
+        is_super_user (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/current_user_info_response_200_experiences.py
+++ b/webknossos/webknossos/client/_generated/models/current_user_info_response_200_experiences.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="CurrentUserInfoResponse200Experiences")
 class CurrentUserInfoResponse200Experiences:
     """
     Attributes:
-        abc (Union[Unset, int]):  Example: 5.
+        abc (Union[Unset, int]):
     """
 
     abc: Union[Unset, int] = UNSET

--- a/webknossos/webknossos/client/_generated/models/current_user_info_response_200_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/current_user_info_response_200_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="CurrentUserInfoResponse200TeamsItem")
 class CurrentUserInfoResponse200TeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200.py
@@ -26,23 +26,23 @@ T = TypeVar("T", bound="DatasetInfoResponse200")
 class DatasetInfoResponse200:
     """
     Attributes:
-        name (str):  Example: l4_sample.
+        name (str):
         data_source (DatasetInfoResponse200DataSource):
         data_store (DatasetInfoResponse200DataStore):
         allowed_teams (List['DatasetInfoResponse200AllowedTeamsItem']):
-        is_active (int):  Example: True.
+        is_active (int):
         is_public (int):
         description (str):
         display_name (str):
-        created (int):  Example: 1508495293789.
+        created (int):
         tags (List[Any]):
-        folder_id (str):  Example: 570b9f4e4bb848d0885ea917.
-        owning_organization (Union[Unset, str]):  Example: Organization_X.
+        folder_id (str):
+        owning_organization (Union[Unset, str]):
         allowed_teams_cumulative (Union[Unset, List['DatasetInfoResponse200AllowedTeamsCumulativeItem']]):
-        is_editable (Union[Unset, int]):  Example: True.
-        last_used_by_user (Union[Unset, int]):  Example: 1676459044224.
-        logo_url (Union[Unset, str]):  Example: /assets/images/mpi-logos.svg.
-        sorting_key (Union[Unset, int]):  Example: 1508495293789.
+        is_editable (Union[Unset, int]):
+        last_used_by_user (Union[Unset, int]):
+        logo_url (Union[Unset, str]):
+        sorting_key (Union[Unset, int]):
         details (Union[Unset, str]):
         is_unreported (Union[Unset, int]):
         jobs_enabled (Union[Unset, int]):

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_allowed_teams_cumulative_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_allowed_teams_cumulative_item.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="DatasetInfoResponse200AllowedTeamsCumulativeItem")
 class DatasetInfoResponse200AllowedTeamsCumulativeItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        organization (str):  Example: Organization_X.
+        id (str):
+        name (str):
+        organization (str):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_allowed_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_allowed_teams_item.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="DatasetInfoResponse200AllowedTeamsItem")
 class DatasetInfoResponse200AllowedTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        organization (str):  Example: Organization_X.
+        id (str):
+        name (str):
+        organization (str):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_data_layers_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_data_layers_item.py
@@ -20,11 +20,11 @@ T = TypeVar("T", bound="DatasetInfoResponse200DataSourceDataLayersItem")
 class DatasetInfoResponse200DataSourceDataLayersItem:
     """
     Attributes:
-        name (str):  Example: color.
-        category (str):  Example: color.
+        name (str):
+        category (str):
         bounding_box (DatasetInfoResponse200DataSourceDataLayersItemBoundingBox):
         resolutions (List[List[int]]):
-        element_class (str):  Example: uint8.
+        element_class (str):
         default_view_configuration (Union[Unset,
             DatasetInfoResponse200DataSourceDataLayersItemDefaultViewConfiguration]):
     """

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_data_layers_item_bounding_box.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_data_layers_item_bounding_box.py
@@ -10,9 +10,9 @@ class DatasetInfoResponse200DataSourceDataLayersItemBoundingBox:
     """
     Attributes:
         top_left (List[int]):
-        width (int):  Example: 1024.
-        height (int):  Example: 1024.
-        depth (int):  Example: 1024.
+        width (int):
+        height (int):
+        depth (int):
     """
 
     top_left: List[int]

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_id.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_source_id.py
@@ -9,8 +9,8 @@ T = TypeVar("T", bound="DatasetInfoResponse200DataSourceId")
 class DatasetInfoResponse200DataSourceId:
     """
     Attributes:
-        name (str):  Example: l4_sample.
-        team (str):  Example: Organization_X.
+        name (str):
+        team (str):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_store.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_info_response_200_data_store.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="DatasetInfoResponse200DataStore")
 class DatasetInfoResponse200DataStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
-        allows_upload (int):  Example: True.
+        name (str):
+        url (str):
+        allows_upload (int):
         is_scratch (Union[Unset, int]):
         is_connector (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item.py
@@ -26,7 +26,7 @@ T = TypeVar("T", bound="DatasetListResponse200Item")
 class DatasetListResponse200Item:
     """
     Attributes:
-        name (str):  Example: 2012-06-28_Cortex.
+        name (str):
         data_source (DatasetListResponse200ItemDataSource):
         data_store (DatasetListResponse200ItemDataStore):
         allowed_teams (List['DatasetListResponse200ItemAllowedTeamsItem']):
@@ -34,17 +34,17 @@ class DatasetListResponse200Item:
         is_public (int):
         description (str):
         display_name (str):
-        created (int):  Example: 1460379470082.
+        created (int):
         tags (List[Any]):
-        folder_id (str):  Example: 570b9f4e4bb848d0885ea917.
-        owning_organization (Union[Unset, str]):  Example: Organization_X.
+        folder_id (str):
+        owning_organization (Union[Unset, str]):
         allowed_teams_cumulative (Union[Unset, List['DatasetListResponse200ItemAllowedTeamsCumulativeItem']]):
-        is_editable (Union[Unset, int]):  Example: True.
+        is_editable (Union[Unset, int]):
         last_used_by_user (Union[Unset, int]):
-        logo_url (Union[Unset, str]):  Example: /assets/images/mpi-logos.svg.
-        sorting_key (Union[Unset, int]):  Example: 1460379470082.
+        logo_url (Union[Unset, str]):
+        sorting_key (Union[Unset, int]):
         details (Union[Unset, str]):
-        is_unreported (Union[Unset, int]):  Example: True.
+        is_unreported (Union[Unset, int]):
         jobs_enabled (Union[Unset, int]):
         publication (Union[Unset, str]):
     """

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_allowed_teams_cumulative_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_allowed_teams_cumulative_item.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="DatasetListResponse200ItemAllowedTeamsCumulativeItem")
 class DatasetListResponse200ItemAllowedTeamsCumulativeItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        organization (str):  Example: Organization_X.
+        id (str):
+        name (str):
+        organization (str):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_allowed_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_allowed_teams_item.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="DatasetListResponse200ItemAllowedTeamsItem")
 class DatasetListResponse200ItemAllowedTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        organization (str):  Example: Organization_X.
+        id (str):
+        name (str):
+        organization (str):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_source.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_source.py
@@ -18,7 +18,7 @@ class DatasetListResponse200ItemDataSource:
     """
     Attributes:
         id (DatasetListResponse200ItemDataSourceId):
-        status (Union[Unset, str]):  Example: No longer available on datastore..
+        status (Union[Unset, str]):
     """
 
     id: "DatasetListResponse200ItemDataSourceId"

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_source_id.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_source_id.py
@@ -9,8 +9,8 @@ T = TypeVar("T", bound="DatasetListResponse200ItemDataSourceId")
 class DatasetListResponse200ItemDataSourceId:
     """
     Attributes:
-        name (str):  Example: 2012-06-28_Cortex.
-        team (str):  Example: Organization_X.
+        name (str):
+        team (str):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_store.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_list_response_200_item_data_store.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="DatasetListResponse200ItemDataStore")
 class DatasetListResponse200ItemDataStore:
     """
     Attributes:
-        name (str):  Example: localhost.
-        url (str):  Example: http://localhost:9000.
-        allows_upload (int):  Example: True.
+        name (str):
+        url (str):
+        allows_upload (int):
         is_scratch (Union[Unset, int]):
         is_connector (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/dataset_sharing_token_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/dataset_sharing_token_response_200.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="DatasetSharingTokenResponse200")
 class DatasetSharingTokenResponse200:
     """
     Attributes:
-        sharing_token (str):  Example: Vui0y7qCWj66ylpMhEzdJg.
+        sharing_token (str):
     """
 
     sharing_token: str

--- a/webknossos/webknossos/client/_generated/models/datastore_list_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/datastore_list_response_200_item.py
@@ -11,11 +11,11 @@ T = TypeVar("T", bound="DatastoreListResponse200Item")
 class DatastoreListResponse200Item:
     """
     Attributes:
-        name (str):  Example: connect.
-        url (str):  Example: http://localhost:8000.
+        name (str):
+        url (str):
         allows_upload (int):
         is_scratch (Union[Unset, int]):
-        is_connector (Union[Unset, int]):  Example: True.
+        is_connector (Union[Unset, int]):
     """
 
     name: str

--- a/webknossos/webknossos/client/_generated/models/folder_tree_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/folder_tree_response_200_item.py
@@ -11,10 +11,10 @@ T = TypeVar("T", bound="FolderTreeResponse200Item")
 class FolderTreeResponse200Item:
     """
     Attributes:
-        id (str):  Example: 570b9f4e4bb848d08880712a.
-        name (str):  Example: A subfolder!.
-        parent (Union[Unset, str]):  Example: 570b9f4e4bb848d0885ea917.
-        is_editable (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        parent (Union[Unset, str]):
+        is_editable (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/generate_token_for_data_store_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/generate_token_for_data_store_response_200.py
@@ -9,7 +9,7 @@ T = TypeVar("T", bound="GenerateTokenForDataStoreResponse200")
 class GenerateTokenForDataStoreResponse200:
     """
     Attributes:
-        token (str):  Example: sqduSj-lk-PmK8yCrO6alw.
+        token (str):
     """
 
     token: str

--- a/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="ProjectInfoByIdResponse200")
 class ProjectInfoByIdResponse200:
     """
     Attributes:
-        name (str):  Example: Test_Project.
-        team (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        team_name (str):  Example: team_X1.
-        priority (int):  Example: 100.
+        name (str):
+        team (str):
+        team_name (str):
+        priority (int):
         paused (int):
-        expected_time (int):  Example: 5400000.
-        id (str):  Example: 58135bfd2faeb3190181c057.
-        created (int):  Example: 1477663741000.
+        expected_time (int):
+        id (str):
+        created (int):
         owner (Union[Unset, ProjectInfoByIdResponse200Owner]):
         is_blacklisted_from_report (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200_owner.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200_owner.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="ProjectInfoByIdResponse200Owner")
 class ProjectInfoByIdResponse200Owner:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['ProjectInfoByIdResponse200OwnerTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200_owner_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_id_response_200_owner_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="ProjectInfoByIdResponse200OwnerTeamsItem")
 class ProjectInfoByIdResponse200OwnerTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="ProjectInfoByNameResponse200")
 class ProjectInfoByNameResponse200:
     """
     Attributes:
-        name (str):  Example: Test_Project.
-        team (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        team_name (str):  Example: team_X1.
-        priority (int):  Example: 100.
+        name (str):
+        team (str):
+        team_name (str):
+        priority (int):
         paused (int):
-        expected_time (int):  Example: 5400000.
-        id (str):  Example: 58135bfd2faeb3190181c057.
-        created (int):  Example: 1477663741000.
+        expected_time (int):
+        id (str):
+        created (int):
         owner (Union[Unset, ProjectInfoByNameResponse200Owner]):
         is_blacklisted_from_report (Union[Unset, int]):
     """

--- a/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200_owner.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200_owner.py
@@ -17,12 +17,12 @@ T = TypeVar("T", bound="ProjectInfoByNameResponse200Owner")
 class ProjectInfoByNameResponse200Owner:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
         is_anonymous (Union[Unset, int]):
         teams (Union[Unset, List['ProjectInfoByNameResponse200OwnerTeamsItem']]):
     """

--- a/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200_owner_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/project_info_by_name_response_200_owner_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="ProjectInfoByNameResponse200OwnerTeamsItem")
 class ProjectInfoByNameResponse200OwnerTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/short_link_by_key_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/short_link_by_key_response_200.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="ShortLinkByKeyResponse200")
 class ShortLinkByKeyResponse200:
     """
     Attributes:
-        long_link (str):  Example: http://localhost:9000.
-        id (Union[Unset, str]):  Example: 63ecbc24e00100ad02ba81ec.
-        key (Union[Unset, str]):  Example: kfu75s6Nm8-imvW4.
+        long_link (str):
+        id (Union[Unset, str]):
+        key (Union[Unset, str]):
     """
 
     long_link: str

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200.py
@@ -19,15 +19,15 @@ T = TypeVar("T", bound="TaskInfoResponse200")
 class TaskInfoResponse200:
     """
     Attributes:
-        id (str):  Example: 581367a82faeb37a008a5352.
-        project_id (str):  Example: 58135bfd2faeb3190181c057.
-        team (str):  Example: team_X1.
-        data_set (str):  Example: 2012-06-28_Cortex.
-        created (int):  Example: 1477666728000.
+        id (str):
+        project_id (str):
+        team (str):
+        data_set (str):
+        created (int):
         status (TaskInfoResponse200Status):
         bounding_box (str):
-        formatted_hash (Union[Unset, str]):  Example: 8a5352.
-        project_name (Union[Unset, str]):  Example: Test_Project.
+        formatted_hash (Union[Unset, str]):
+        project_name (Union[Unset, str]):
         type (Union[Unset, TaskInfoResponse200Type]):
         needed_experience (Union[Unset, TaskInfoResponse200NeededExperience]):
         script (Union[Unset, str]):

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200_needed_experience.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200_needed_experience.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="TaskInfoResponse200NeededExperience")
 class TaskInfoResponse200NeededExperience:
     """
     Attributes:
-        domain (Union[Unset, str]):  Example: abc.
+        domain (Union[Unset, str]):
         value (Union[Unset, int]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200_status.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200_status.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="TaskInfoResponse200Status")
 class TaskInfoResponse200Status:
     """
     Attributes:
-        open_ (int):  Example: 10.
-        active (int):  Example: 1.
-        finished (int):  Example: -1.
+        open_ (int):
+        active (int):
+        finished (int):
     """
 
     open_: int

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200_type.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200_type.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="TaskInfoResponse200Type")
 class TaskInfoResponse200Type:
     """
     Attributes:
-        id (str):  Example: 570b9f4c2a7c0e4c008da6ee.
-        description (str):  Example: Check those cells out!.
-        team_name (str):  Example: team_X1.
-        summary (Union[Unset, str]):  Example: ek_0563_BipolarCells.
-        team_id (Union[Unset, str]):  Example: 570b9f4b2a7c0e3b008da6ec.
+        id (str):
+        description (str):
+        team_name (str):
+        summary (Union[Unset, str]):
+        team_id (Union[Unset, str]):
         settings (Union[Unset, TaskInfoResponse200TypeSettings]):
         recommended_configuration (Union[Unset, str]):
-        tracing_type (Union[Unset, str]):  Example: skeleton.
+        tracing_type (Union[Unset, str]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/task_info_response_200_type_settings.py
+++ b/webknossos/webknossos/client/_generated/models/task_info_response_200_type_settings.py
@@ -18,8 +18,8 @@ class TaskInfoResponse200TypeSettings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
         merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset, TaskInfoResponse200TypeSettingsResolutionRestrictions]):

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item.py
@@ -23,15 +23,15 @@ T = TypeVar("T", bound="TaskInfosByProjectIdResponse200Item")
 class TaskInfosByProjectIdResponse200Item:
     """
     Attributes:
-        id (str):  Example: 581367a82faeb37a008a5352.
-        project_id (str):  Example: 58135bfd2faeb3190181c057.
-        team (str):  Example: team_X1.
-        data_set (str):  Example: 2012-06-28_Cortex.
-        created (int):  Example: 1477666728000.
+        id (str):
+        project_id (str):
+        team (str):
+        data_set (str):
+        created (int):
         status (TaskInfosByProjectIdResponse200ItemStatus):
         bounding_box (str):
-        formatted_hash (Union[Unset, str]):  Example: 8a5352.
-        project_name (Union[Unset, str]):  Example: Test_Project.
+        formatted_hash (Union[Unset, str]):
+        project_name (Union[Unset, str]):
         type (Union[Unset, TaskInfosByProjectIdResponse200ItemType]):
         needed_experience (Union[Unset, TaskInfosByProjectIdResponse200ItemNeededExperience]):
         script (Union[Unset, str]):

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_needed_experience.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_needed_experience.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="TaskInfosByProjectIdResponse200ItemNeededExperience")
 class TaskInfosByProjectIdResponse200ItemNeededExperience:
     """
     Attributes:
-        domain (Union[Unset, str]):  Example: abc.
+        domain (Union[Unset, str]):
         value (Union[Unset, int]):
     """
 

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_status.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_status.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="TaskInfosByProjectIdResponse200ItemStatus")
 class TaskInfosByProjectIdResponse200ItemStatus:
     """
     Attributes:
-        open_ (int):  Example: 10.
-        active (int):  Example: 1.
-        finished (int):  Example: -1.
+        open_ (int):
+        active (int):
+        finished (int):
     """
 
     open_: int

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_type.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_type.py
@@ -17,14 +17,14 @@ T = TypeVar("T", bound="TaskInfosByProjectIdResponse200ItemType")
 class TaskInfosByProjectIdResponse200ItemType:
     """
     Attributes:
-        id (str):  Example: 570b9f4c2a7c0e4c008da6ee.
-        description (str):  Example: Check those cells out!.
-        team_name (str):  Example: team_X1.
-        summary (Union[Unset, str]):  Example: ek_0563_BipolarCells.
-        team_id (Union[Unset, str]):  Example: 570b9f4b2a7c0e3b008da6ec.
+        id (str):
+        description (str):
+        team_name (str):
+        summary (Union[Unset, str]):
+        team_id (Union[Unset, str]):
         settings (Union[Unset, TaskInfosByProjectIdResponse200ItemTypeSettings]):
         recommended_configuration (Union[Unset, str]):
-        tracing_type (Union[Unset, str]):  Example: skeleton.
+        tracing_type (Union[Unset, str]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_type_settings.py
+++ b/webknossos/webknossos/client/_generated/models/task_infos_by_project_id_response_200_item_type_settings.py
@@ -18,8 +18,8 @@ class TaskInfosByProjectIdResponse200ItemTypeSettings:
     """
     Attributes:
         allowed_modes (Union[Unset, List[str]]):
-        branch_points_allowed (Union[Unset, int]):  Example: True.
-        soma_clicking_allowed (Union[Unset, int]):  Example: True.
+        branch_points_allowed (Union[Unset, int]):
+        soma_clicking_allowed (Union[Unset, int]):
         volume_interpolation_allowed (Union[Unset, int]):
         merger_mode (Union[Unset, int]):
         resolution_restrictions (Union[Unset, TaskInfosByProjectIdResponse200ItemTypeSettingsResolutionRestrictions]):

--- a/webknossos/webknossos/client/_generated/models/team_list_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/team_list_response_200_item.py
@@ -9,9 +9,9 @@ T = TypeVar("T", bound="TeamListResponse200Item")
 class TeamListResponse200Item:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        organization (str):  Example: Organization_X.
+        id (str):
+        name (str):
+        organization (str):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200.py
+++ b/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200.py
@@ -23,25 +23,25 @@ T = TypeVar("T", bound="UserInfoByIdResponse200")
 class UserInfoByIdResponse200:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
-        is_active (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
+        is_active (int):
         experiences (UserInfoByIdResponse200Experiences):
-        last_activity (int):  Example: 1676459044291.
-        organization (str):  Example: Organization_X.
-        created (int):  Example: 1460379469000.
-        is_organization_owner (Union[Unset, int]):  Example: True.
+        last_activity (int):
+        organization (str):
+        created (int):
+        is_organization_owner (Union[Unset, int]):
         teams (Union[Unset, List['UserInfoByIdResponse200TeamsItem']]):
         is_anonymous (Union[Unset, int]):
-        is_editable (Union[Unset, int]):  Example: True.
+        is_editable (Union[Unset, int]):
         novel_user_experience_infos (Union[Unset, UserInfoByIdResponse200NovelUserExperienceInfos]):
-        selected_theme (Union[Unset, str]):  Example: auto.
+        selected_theme (Union[Unset, str]):
         last_task_type_id (Union[Unset, str]):
-        is_super_user (Union[Unset, int]):  Example: True.
+        is_super_user (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200_experiences.py
+++ b/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200_experiences.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="UserInfoByIdResponse200Experiences")
 class UserInfoByIdResponse200Experiences:
     """
     Attributes:
-        abc (Union[Unset, int]):  Example: 5.
+        abc (Union[Unset, int]):
     """
 
     abc: Union[Unset, int] = UNSET

--- a/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/user_info_by_id_response_200_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="UserInfoByIdResponse200TeamsItem")
 class UserInfoByIdResponse200TeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/user_list_response_200_item.py
+++ b/webknossos/webknossos/client/_generated/models/user_list_response_200_item.py
@@ -23,25 +23,25 @@ T = TypeVar("T", bound="UserListResponse200Item")
 class UserListResponse200Item:
     """
     Attributes:
-        id (str):  Example: 570b9f4d2a7c0e4d008da6ef.
-        email (str):  Example: user_A@scalableminds.com.
-        first_name (str):  Example: user_A.
-        last_name (str):  Example: BoyA.
-        is_admin (int):  Example: True.
-        is_dataset_manager (int):  Example: True.
-        is_active (int):  Example: True.
+        id (str):
+        email (str):
+        first_name (str):
+        last_name (str):
+        is_admin (int):
+        is_dataset_manager (int):
+        is_active (int):
         experiences (UserListResponse200ItemExperiences):
-        last_activity (int):  Example: 1676459044612.
-        organization (str):  Example: Organization_X.
-        created (int):  Example: 1460379469000.
-        is_organization_owner (Union[Unset, int]):  Example: True.
+        last_activity (int):
+        organization (str):
+        created (int):
+        is_organization_owner (Union[Unset, int]):
         teams (Union[Unset, List['UserListResponse200ItemTeamsItem']]):
         is_anonymous (Union[Unset, int]):
-        is_editable (Union[Unset, int]):  Example: True.
+        is_editable (Union[Unset, int]):
         novel_user_experience_infos (Union[Unset, UserListResponse200ItemNovelUserExperienceInfos]):
-        selected_theme (Union[Unset, str]):  Example: auto.
+        selected_theme (Union[Unset, str]):
         last_task_type_id (Union[Unset, str]):
-        is_super_user (Union[Unset, int]):  Example: True.
+        is_super_user (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/user_list_response_200_item_experiences.py
+++ b/webknossos/webknossos/client/_generated/models/user_list_response_200_item_experiences.py
@@ -11,7 +11,7 @@ T = TypeVar("T", bound="UserListResponse200ItemExperiences")
 class UserListResponse200ItemExperiences:
     """
     Attributes:
-        abc (Union[Unset, int]):  Example: 5.
+        abc (Union[Unset, int]):
     """
 
     abc: Union[Unset, int] = UNSET

--- a/webknossos/webknossos/client/_generated/models/user_list_response_200_item_teams_item.py
+++ b/webknossos/webknossos/client/_generated/models/user_list_response_200_item_teams_item.py
@@ -11,9 +11,9 @@ T = TypeVar("T", bound="UserListResponse200ItemTeamsItem")
 class UserListResponse200ItemTeamsItem:
     """
     Attributes:
-        id (str):  Example: 570b9f4b2a7c0e3b008da6ec.
-        name (str):  Example: team_X1.
-        is_team_manager (Union[Unset, int]):  Example: True.
+        id (str):
+        name (str):
+        is_team_manager (Union[Unset, int]):
     """
 
     id: str

--- a/webknossos/webknossos/client/_generated/models/user_logged_time_response_200_logged_time_item.py
+++ b/webknossos/webknossos/client/_generated/models/user_logged_time_response_200_logged_time_item.py
@@ -16,7 +16,7 @@ class UserLoggedTimeResponse200LoggedTimeItem:
     """
     Attributes:
         payment_interval (UserLoggedTimeResponse200LoggedTimeItemPaymentInterval):
-        duration_in_seconds (int):  Example: 265.
+        duration_in_seconds (int):
     """
 
     payment_interval: "UserLoggedTimeResponse200LoggedTimeItemPaymentInterval"

--- a/webknossos/webknossos/client/_generated/models/user_logged_time_response_200_logged_time_item_payment_interval.py
+++ b/webknossos/webknossos/client/_generated/models/user_logged_time_response_200_logged_time_item_payment_interval.py
@@ -9,8 +9,8 @@ T = TypeVar("T", bound="UserLoggedTimeResponse200LoggedTimeItemPaymentInterval")
 class UserLoggedTimeResponse200LoggedTimeItemPaymentInterval:
     """
     Attributes:
-        month (int):  Example: 8.
-        year (int):  Example: 2018.
+        month (int):
+        year (int):
     """
 
     month: int


### PR DESCRIPTION
### Description:
- Removes the examples during client generation to avoid timestamps and random ids in the generated code
- Shrinks some test cases that took a while
- Cleans up the multiprocessing loggers when closing an executor. This produced superflouos processes before which were only cleaned up after all tests ran.
