### PR TITLE
Handle axis offsets in czi files

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed reading czi files with non-zero axis offsets. [#876](https://github.com/scalableminds/webknossos-libs/pull/876)
 
 
 ## [0.12.2](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.12.2) - 2023-02-20

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
-from typing import Iterator, List, Set
+from typing import Iterator, List, Set, Dict
 
 import numpy as np
 
@@ -47,20 +47,23 @@ class PimsCziReader(FramesSequenceND):
     def __init__(self, path: PathLike, czi_channel: int = 0) -> None:
         self.path = Path(path)
         self.czi_channel = czi_channel
+        self.axis_offsets: Dict[str, int] = {}
         super().__init__()
         with self.czi_file() as czi_file:
             for axis, (
                 start,
-                length,
+                end,
             ) in czi_file.total_bounding_box.items():
                 axis = axis.lower()
                 if axis == "c":
                     continue
-                assert start == 0
+                length = end - start
                 if axis not in "xy" and length == 1:
                     # not propagating axes of length one
                     continue
+                assert length >= 0, f"axis length must be >= 0, got {length}"
                 self._init_axis(axis, length)
+                self.axis_offsets[axis] = start
             self._czi_pixel_type = czi_file.get_channel_pixel_type(self.czi_channel)
             if self._czi_pixel_type.startswith("Bgra"):
                 self._init_axis("c", 4)
@@ -94,6 +97,9 @@ class PimsCziReader(FramesSequenceND):
 
     def get_frame_2D(self, **ind: int) -> np.ndarray:
         plane = {k.upper(): v for k, v in ind.items()}
+        for axis in plane.keys():
+            if axis in self.axis_offsets:
+                plane[axis] += self.axis_offsets[axis]
 
         # safe-guard against x/y in ind argument,
         # we always read the whole slice here:

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -1,7 +1,7 @@
 from contextlib import contextmanager
 from os import PathLike
 from pathlib import Path
-from typing import Iterator, List, Set, Dict
+from typing import Dict, Iterator, List, Set
 
 import numpy as np
 


### PR DESCRIPTION
### Description:
- we got some czi files where the axis start was not at 0
- this pr adapts the czi reader to read the axis offset from the metadata, and adds this offset when reading at a position.

### Todos:
 - [x] Updated Changelog
