### PR TITLE
add reader for imagej tiffs and auto-conversion for big endian dtypes

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,10 +15,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
-- Added support to import ImageJ Hyperstack tiff files via `Dataset.from_images` and `dataset.add_layer_from_images`.
+- Added support to import ImageJ Hyperstack tiff files via `Dataset.from_images` and `dataset.add_layer_from_images`. [#877](https://github.com/scalableminds/webknossos-libs/pull/877)
 
 ### Changed
-- `Dataset.from_images` and `dataset.add_layer_from_images` now automatically convert big endian dtypes to their little endian counterparts by default.
+- `Dataset.from_images` and `dataset.add_layer_from_images` now automatically convert big endian dtypes to their little endian counterparts by default. [#877](https://github.com/scalableminds/webknossos-libs/pull/877)
 
 ### Fixed
 - Fixed reading czi files with non-zero axis offsets. [#876](https://github.com/scalableminds/webknossos-libs/pull/876)

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added support to import ImageJ Hyperstack tiff files via `Dataset.from_images` and `dataset.add_layer_from_images`.
 
 ### Changed
+- `Dataset.from_images` and `dataset.add_layer_from_images` now automatically convert big endian dtypes to their little endian counterparts by default.
 
 ### Fixed
 - Fixed reading czi files with non-zero axis offsets. [#876](https://github.com/scalableminds/webknossos-libs/pull/876)

--- a/webknossos/webknossos/dataset/_utils/pims_imagej_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_imagej_tiff_reader.py
@@ -1,0 +1,57 @@
+from os import PathLike
+from pathlib import Path
+from typing import Set
+
+import numpy as np
+
+try:
+    from pims import FramesSequenceND
+except ImportError as e:
+    raise RuntimeError(
+        "Cannot import pims, please install it e.g. using 'webknossos[all]'"
+    ) from e
+
+try:
+    import tifffile
+except ImportError as e:
+    raise RuntimeError(
+        "Cannot import tifffile, please install it e.g. using 'webknossos[tifffile]'"
+    ) from e
+
+
+class PimsImagejTiffReader(FramesSequenceND):
+    @classmethod
+    def class_exts(cls) -> Set[str]:
+        return {"tif", "tiff"}
+
+    # class_priority is used in pims to pick the reader with the highest priority.
+    # Default is 10, and bioformats priority is 2.
+    # See http://soft-matter.github.io/pims/v0.6.1/custom_readers.html#plugging-into-pims-s-open-function
+    class_priority = 20
+
+    def __init__(self, path: PathLike) -> None:
+        super().__init__()
+        path = Path(path)
+        tiff = tifffile.TiffFile(path)
+        assert tiff.is_imagej, f"{path} is not an ImageJ Tiff"
+        channels = tiff.imagej_metadata["channels"]
+        z = tiff.imagej_metadata["images"] / channels
+
+        self.memmap = tifffile.memmap(self.path)
+        # shape should be zcyx
+        assert len(self.memmap.shape) == 4
+        assert self.memmap.shape[0] == z
+        assert self.memmap.shape[1] == channels
+
+        self._init_axis("x", self.memmap.shape[3])
+        self._init_axis("y", self.memmap.shape[2])
+        self._init_axis("z", z)
+        self._init_axis("c", channels)
+        self._register_get_frame(self._get_frame, "cyx")
+
+    @property
+    def pixel_type(self) -> np.dtype:
+        return self.memmap.dtype
+
+    def _get_frame(self, **ind: int) -> np.ndarray:
+        return self.memmap[ind["z"]]

--- a/webknossos/webknossos/dataset/_utils/pims_imagej_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_imagej_tiff_reader.py
@@ -37,7 +37,7 @@ class PimsImagejTiffReader(FramesSequenceND):
         channels = tiff.imagej_metadata["channels"]
         z = tiff.imagej_metadata["images"] / channels
 
-        self.memmap = tifffile.memmap(self.path)
+        self.memmap = tifffile.memmap(path)
         # shape should be zcyx
         assert len(self.memmap.shape) == 4
         assert self.memmap.shape[0] == z

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -34,7 +34,6 @@ try:
     import webknossos.dataset._utils.pims_dm_readers
 except ImportError:
     pass
-# pylint: enable=unused-import
 
 try:
     import webknossos.dataset._utils.pims_imagej_tiff_reader

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -36,6 +36,12 @@ except ImportError:
     pass
 # pylint: enable=unused-import
 
+try:
+    import webknossos.dataset._utils.pims_imagej_tiff_reader
+except ImportError:
+    pass
+# pylint: enable=unused-import
+
 from webknossos.dataset.mag_view import MagView
 from webknossos.geometry.vec3_int import Vec3Int
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1149,11 +1149,17 @@ class Dataset:
                     is_segmentation=category == "segmentation",
                     **pims_open_kwargs,
                 )
+            if dtype is None:
+                current_dtype = np.dtype(pims_images.dtype)
+                if current_dtype.byteorder == ">":
+                    current_dtype = current_dtype.newbyteorder("<")
+            else:
+                current_dtype = np.dtype(dtype)
             layer = self.add_layer(
                 layer_name=layer_name + layer_name_suffix,
                 category=category,
                 data_format=data_format,
-                dtype_per_channel=pims_images.dtype if dtype is None else dtype,
+                dtype_per_channel=current_dtype,
                 num_channels=pims_images.num_channels,
                 **add_layer_kwargs,  # type: ignore[arg-type]
             )
@@ -1198,7 +1204,7 @@ class Dataset:
                 pims_images.copy_to_view,
                 mag_view=mag_view,
                 is_segmentation=category == "segmentation",
-                dtype=dtype,
+                dtype=current_dtype,
             )
 
             args = []


### PR DESCRIPTION
### Description:
- added a reader for imagej tifffiles, supporting hyperstacks
- added auto-conversion from big endian dtype to little endian if nothing is specified manually

I tested this locally with [those files](https://scm.slack.com/archives/C5AKLAV0B/p1676539393839729?thread_ts=1676475091.980849&cid=C5AKLAV0B), which resulted in [this dataset](https://webknossos.org/datasets/scalable_minds/test-ds). I couldn't find public test data.

I'll also verify this with [this dataset](https://scm.slack.com/archives/C02Q35Q28P5/p1676472393336519?thread_ts=1676468774.644139&cid=C02Q35Q28P5) when deployed, to be sure.

### Issues:
- fixes #869
- fixes #870

### Todos:
 - [x] Updated Changelog
