### PR TITLE
Fix skeleton doc example

### DIFF
--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -50,15 +50,19 @@ def create_dummy_skeleton() -> wk.Skeleton:
 
     return nml
 
+
 def test_doc_example() -> None:
-    annotation = wk.Annotation("my_annotation", voxel_size=(11, 11, 24))
+    from webknossos import Annotation
+
+    annotation = Annotation(
+        name="my_annotation", dataset_name="my_dataset", voxel_size=(11, 11, 24)
+    )
     group = annotation.skeleton.add_group("a group")
     tree = group.add_tree("a tree")
     node_1 = tree.add_node(position=(0, 0, 0), comment="node 1")
     node_2 = tree.add_node(position=(100, 100, 100), comment="node 2")
 
     tree.add_edge(node_1, node_2)
-
 
 
 def test_immutability() -> None:

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -50,6 +50,16 @@ def create_dummy_skeleton() -> wk.Skeleton:
 
     return nml
 
+def test_doc_example() -> None:
+    annotation = wk.Annotation("my_annotation", voxel_size=(11, 11, 24))
+    group = annotation.skeleton.add_group("a group")
+    tree = group.add_tree("a tree")
+    node_1 = tree.add_node(position=(0, 0, 0), comment="node 1")
+    node_2 = tree.add_node(position=(100, 100, 100), comment="node 2")
+
+    tree.add_edge(node_1, node_2)
+
+
 
 def test_immutability() -> None:
     skeleton = create_dummy_skeleton()

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -23,7 +23,9 @@ class Skeleton(Group):
     A small usage example:
 
     ```python
-    annotation = Annotation("my_annotation", voxel_size=(11, 11, 24))
+    annotation = Annotation(
+        name="my_annotation", dataset_name="my_dataset", voxel_size=(11, 11, 24)
+    )
     group = annotation.skeleton.add_group("a group")
     tree = group.add_tree("a tree")
     node_1 = tree.add_node(position=(0, 0, 0), comment="node 1")


### PR DESCRIPTION
### Description:
- The "simple example" in the skeleton documentation is broken. I copy/pasted it to the tests, fixed the problem and updated the doc accordingly.

### Todos:
Make sure to delete unnecessary points or to check all before merging:

 - [x] Updated Documentation
 - [x] Added / Updated Tests
