### PR TITLE
Fix poetry install issues

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Upgrades `black`, `mypy`, `pylint`, `pytest`. [#873](https://github.com/scalableminds/webknossos-libs/pull/873)
 
 ### Fixed
+- Fixed poetry build backend for new versions of Poetry. [#899](https://github.com/scalableminds/webknossos-libs/pull/899)
 
 
 ## [0.12.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.12.3) - 2023-02-22

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -131,5 +131,5 @@ markers = ["with_vcr: Runs with VCR recording and optionally blocked network"]
 testpaths = ["tests"]
 
 [build-system]
-requires = ["poetry>=1.1"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.1"]
+build-backend = "poetry.core.masonry.api"

--- a/wkcuber/pyproject.toml
+++ b/wkcuber/pyproject.toml
@@ -45,5 +45,5 @@ wkcuber = "wkcuber.__main__:main"
 disable = ["logging-format-interpolation","logging-fstring-interpolation","broad-except","broad-exception-raised","protected-access","R","C","fixme","global-statement","redefined-outer-name","arguments-differ","unused-argument"]
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry.core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
### Description:
- Updated our `pyproject.toml` files for `wklibs`and `wkcuber` to match the new build backend format [`poetry.core`](https://github.com/python-poetry/poetry-core)
- 

### Issues:
- Fixes an issue with Python 3.10 and Poetry 1.4.x where wkcuber could not install the wklibs as a local, editable  dependency
- See https://github.com/python-poetry/poetry/issues/7583

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
