### PR TITLE
[Docs] Fix embedded YouTube videos

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -149,6 +149,9 @@ plugins:
         "index.md": "webknossos/index.md"
   - mkdocs-video:
       is_video: True
+  - mkdocs-video:
+      is_video: False
+      mark: "youtube-video"
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
### Description:
- The PR fixes embedded YT video links. Requires [partner-PR in WK-repo](https://github.com/scalableminds/webknossos/pull/7102) to work
- The `mkdocs-video` plugin is configured to use native HTML5 video controls by default which makes a lot of sense for videos hosted by us on S3. Tis does not, however, work with YT videos which require an iFrame for embedding. The PR adds a seconds instance of the plugin with a different keyword `youtube-video` to handle YT videos. A future version ([`1.6.0`](https://github.com/soulless-viewer/mkdocs-video/pull/19)) might support overwriting a the global config with just one version of the plugin, e.g. `![type:video](https://www.youtube.com/embed/jsz0tc3tuKI?start=372){: iframe}`.

### Issues:
- no open issue

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
