### PR TITLE
fixes a bug with upsampling a dataset that has a non-aligned bounding…

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed a bug where upsampling of a layer would fail, if the layer had a bounding box that doesn't align with the from_mag mag. [#915](https://github.com/scalableminds/webknossos-libs/pull/915)
 
 
 ## [0.12.6](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.12.6) - 2023-06-09

--- a/webknossos/tests/dataset/test_upsampling.py
+++ b/webknossos/tests/dataset/test_upsampling.py
@@ -2,7 +2,14 @@ from pathlib import Path
 
 import numpy as np
 
-from webknossos import COLOR_CATEGORY, Dataset, Mag, Vec3Int
+from webknossos import (
+    COLOR_CATEGORY,
+    SEGMENTATION_CATEGORY,
+    BoundingBox,
+    Dataset,
+    Mag,
+    Vec3Int,
+)
 from webknossos.dataset._upsampling_utils import upsample_cube, upsample_cube_job
 from webknossos.dataset.sampling_modes import SamplingModes
 
@@ -125,3 +132,19 @@ def test_upsample_multi_channel(tmp_path: Path) -> None:
     target_buffer = l.get_mag("1").read()
     assert np.any(target_buffer != 0)
     assert np.all(target_buffer == joined_buffer)
+
+
+def test_upsampling_non_aligned(tmp_path: Path):
+    ds = Dataset(tmp_path / "test", (50, 50, 50))
+    l = ds.add_layer(
+        "color", SEGMENTATION_CATEGORY, dtype_per_channel="uint8", largest_segment_id=0
+    )
+    l.bounding_box = BoundingBox(topleft=(0, 0, 0), size=(8409, 10267, 5271))
+    l.add_mag(32)
+
+    l.upsample(
+        from_mag=Mag(32),
+        finest_mag=Mag(8),
+        sampling_mode=SamplingModes.ISOTROPIC,
+        compress=True,
+    )

--- a/webknossos/tests/dataset/test_upsampling.py
+++ b/webknossos/tests/dataset/test_upsampling.py
@@ -134,7 +134,7 @@ def test_upsample_multi_channel(tmp_path: Path) -> None:
     assert np.all(target_buffer == joined_buffer)
 
 
-def test_upsampling_non_aligned(tmp_path: Path):
+def test_upsampling_non_aligned(tmp_path: Path) -> None:
     ds = Dataset(tmp_path / "test", (50, 50, 50))
     l = ds.add_layer(
         "color", SEGMENTATION_CATEGORY, dtype_per_channel="uint8", largest_segment_id=0
@@ -148,3 +148,5 @@ def test_upsampling_non_aligned(tmp_path: Path):
         sampling_mode=SamplingModes.ISOTROPIC,
         compress=True,
     )
+    # The original bbox should be unchanged
+    assert l.bounding_box == BoundingBox(topleft=(0, 0, 0), size=(8409, 10267, 5271))

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -1050,6 +1050,11 @@ class Layer:
                 target_mag, prev_mag_view, compress
             )
 
+            # We need to make sure the layer's bounding box is aligned
+            # with the previous mag. Otherwise, `for_zipped_chunks` will fail.
+            # Saving the original layer bbox for later restore
+            old_layer_bbox = self.bounding_box
+            self.bounding_box = prev_mag_view.bounding_box
             # Get target view
             target_view = target_mag_view.get_view()
 
@@ -1069,6 +1074,8 @@ class Layer:
                     executor=actual_executor,
                     progress_desc=f"Upsampling from Mag {prev_mag} to Mag {target_mag}",
                 )
+            # Restoring the original layer bbox
+            self.bounding_box = old_layer_bbox
 
     def _setup_mag(self, mag: Mag) -> None:
         # This method is used to initialize the mag when opening the Dataset. This does not create e.g. the wk_header.


### PR DESCRIPTION
### Description:
- Fixes a bug where upsampling of a layer would fail, if the layer had a bounding box that doesn't align with the `from_mag` mag.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
