### PR TITLE
Fix compressed from images oom

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed a bug where compression in add_layer_from_images uses too much memory [#900](https://github.com/scalableminds/webknossos-libs/issues/900)
 
 
 ## [0.13.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.13.0) - 2023-06-21

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -7,14 +7,14 @@ from typing import Iterator, Optional, Tuple, cast
 import numpy as np
 import pytest
 from jsonschema import validate
+from upath import UPath
+
 from tests.constants import (
     REMOTE_TESTOUTPUT_DIR,
     TESTDATA_DIR,
     TESTOUTPUT_DIR,
     use_minio,
 )
-from upath import UPath
-
 from webknossos.dataset import (
     COLOR_CATEGORY,
     SEGMENTATION_CATEGORY,

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -13,8 +13,6 @@ from typing import Iterator, Union
 import numpy as np
 import pytest
 from PIL import Image
-from typer.testing import CliRunner
-
 from tests.constants import (
     MINIO_PORT,
     MINIO_ROOT_PASSWORD,
@@ -22,10 +20,13 @@ from tests.constants import (
     REMOTE_TESTOUTPUT_DIR,
     use_minio,
 )
+from typer.testing import CliRunner
+
 from webknossos import BoundingBox, DataFormat, Dataset
 from webknossos.cli.export_wkw_as_tiff import _make_tiff_name
 from webknossos.cli.main import app
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
+from webknossos.dataset.view import _BLOCK_ALIGNMENT_WARNING
 
 runner = CliRunner()
 
@@ -202,29 +203,28 @@ def test_convert() -> None:
         assert (wkw_path / PROPERTIES_FILE_NAME).exists()
 
 
-@pytest.mark.filterwarnings("ignore::UserWarning")
 def test_convert_with_all_params() -> None:
     """Tests the functionality of convert subcommand."""
 
     with tmp_cwd():
         origin_path = TESTDATA_DIR / "tiff"
         wkw_path = Path("wkw_from_tiff_extended")
-
-        result = runner.invoke(
-            app,
-            [
-                "convert",
-                "--voxel-size",
-                "11.0,11.0,11.0",
-                "--data-format",
-                "wkw",
-                "--name",
-                "wkw_from_tiff",
-                "--compress",
-                str(origin_path),
-                str(wkw_path),
-            ],
-        )
+        with pytest.warns(UserWarning):
+            result = runner.invoke(
+                app,
+                [
+                    "convert",
+                    "--voxel-size",
+                    "11.0,11.0,11.0",
+                    "--data-format",
+                    "wkw",
+                    "--name",
+                    "wkw_from_tiff",
+                    "--compress",
+                    str(origin_path),
+                    str(wkw_path),
+                ],
+            )
 
         assert result.exit_code == 0
         assert (wkw_path / PROPERTIES_FILE_NAME).exists()

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -13,6 +13,8 @@ from typing import Iterator, Union
 import numpy as np
 import pytest
 from PIL import Image
+from typer.testing import CliRunner
+
 from tests.constants import (
     MINIO_PORT,
     MINIO_ROOT_PASSWORD,
@@ -20,13 +22,10 @@ from tests.constants import (
     REMOTE_TESTOUTPUT_DIR,
     use_minio,
 )
-from typer.testing import CliRunner
-
 from webknossos import BoundingBox, DataFormat, Dataset
 from webknossos.cli.export_wkw_as_tiff import _make_tiff_name
 from webknossos.cli.main import app
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
-from webknossos.dataset.view import _BLOCK_ALIGNMENT_WARNING
 
 runner = CliRunner()
 

--- a/webknossos/webknossos/cli/convert.py
+++ b/webknossos/webknossos/cli/convert.py
@@ -92,15 +92,12 @@ def main(
     )
 
     with get_executor_for_args(args=executor_args) as executor:
-        dataset = Dataset.from_images(
+        Dataset.from_images(
             source,
             target,
             voxel_size,
             name=name,
             data_format=data_format,
             executor=executor,
+            compress=compress,
         )
-        # TODO  pylint: disable=fixme
-        # Include this in the from_images() call as soon as issue #900 is resolved
-        if compress:
-            dataset.compress()

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -253,16 +253,20 @@ class View:
         current_mag_bbox = mag1_bbox.in_mag(self._mag)
 
         if self._is_compressed():
-            for current_mag_bbox, chunked_data in self._handle_compressed_write(
+            for current_mag_bbox, chunked_data in self._prepare_compressed_write(
                 current_mag_bbox, data
             ):
                 self._array.write(current_mag_bbox.topleft, chunked_data)
         else:
             self._array.write(current_mag_bbox.topleft, data)
 
-    def _handle_compressed_write(
+    def _prepare_compressed_write(
         self, current_mag_bbox: BoundingBox, data: np.ndarray
     ) -> Iterator[Tuple[BoundingBox, np.ndarray]]:
+        """This method takes an arbitrary sized chunk of data with an accompanying bbox,
+        divides these into chunks of shard_shape size and delegates
+        the preparation to _prepare_compressed_write_chunk."""
+
         chunked_bboxes = current_mag_bbox.chunk(
             self.info.shard_shape,
             chunk_border_alignments=self.info.shard_shape,
@@ -278,11 +282,17 @@ class View:
                     -current_mag_bbox.topleft
                 ).to_slices()
 
-            yield self._handle_compressed_write_chunk(chunked_bbox, data[source_slice])
+            yield self._prepare_compressed_write_chunk(chunked_bbox, data[source_slice])
 
-    def _handle_compressed_write_chunk(
+    def _prepare_compressed_write_chunk(
         self, current_mag_bbox: BoundingBox, data: np.ndarray
     ) -> Tuple[BoundingBox, np.ndarray]:
+        """This method takes an arbitrary sized chunk of data with an accompanying bbox
+        (ideally not larger than a shard) and enlarges that chunk to fit the shard it
+        resides in (by reading the entire shard data and writing the passed data ndarray
+        into the specified volume). That way, the returned data can be written as a whole
+        shard which is a requirement for compressed writes."""
+
         aligned_bbox = current_mag_bbox.align_with_mag(self.info.shard_shape, ceil=True)
 
         if current_mag_bbox != aligned_bbox:

--- a/webknossos/webknossos/dataset/view.py
+++ b/webknossos/webknossos/dataset/view.py
@@ -16,7 +16,6 @@ from typing import (
 
 import numpy as np
 import wkw
-
 from cluster_tools import Executor
 
 from ..geometry import BoundingBox, Mag, Vec3Int, Vec3IntLike


### PR DESCRIPTION
### Description:
- Compressed add_layer_from_images used too much memory. This is now avoided by chunking the data before it is written.

### Issues:
- fixes #900

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
