### PR TITLE
No slashes in layer name

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+- The conversion folder structures to layer names does not allow slashes in the layer name anymore. [#918](https://github.com/scalableminds/webknossos-libs/issues/918)
 
 ### Fixed
 - Fixed a bug where compression in add_layer_from_images uses too much memory [#900](https://github.com/scalableminds/webknossos-libs/issues/900)

--- a/webknossos/tests/constants.py
+++ b/webknossos/tests/constants.py
@@ -11,8 +11,8 @@ from upath import UPath
 
 from webknossos.utils import rmtree
 
-TESTDATA_DIR = Path("testdata")
-TESTOUTPUT_DIR = Path("testoutput")
+TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
+TESTOUTPUT_DIR = Path(__file__).parent.parent / "testoutput"
 
 
 MINIO_ROOT_USER = "TtnuieannGt2rGuie2t8Tt7urarg5nauedRndrur"

--- a/webknossos/tests/dataset/test_from_images.py
+++ b/webknossos/tests/dataset/test_from_images.py
@@ -1,5 +1,6 @@
 import warnings
 from pathlib import Path
+from shutil import copytree
 from typing import Iterator
 
 import numpy as np
@@ -55,3 +56,14 @@ def test_multiple_multitiffs(tmp_path: Path) -> None:
         assert layer.dtype_per_channel == np.dtype(dtype)
         assert layer.num_channels == channels
         assert layer.bounding_box.size == size
+
+
+def test_no_slashes_in_layername(tmp_path: Path) -> None:
+    path_with_subfolders = tmp_path / "subfolder" / "tifffiles"
+    path_with_subfolders.mkdir()
+    copytree(Path("testdata") / "tiff", path_with_subfolders)
+
+    ds = wk.Dataset.from_images(tmp_path, tmp_path / "tiff", voxel_size=(10, 10, 10))
+
+    for layer in ds.layers:
+        assert "/" not in layer

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -20,6 +20,7 @@ from tests.constants import (
     MINIO_ROOT_PASSWORD,
     MINIO_ROOT_USER,
     REMOTE_TESTOUTPUT_DIR,
+    TESTDATA_DIR,
     use_minio,
 )
 from webknossos import BoundingBox, DataFormat, Dataset
@@ -41,9 +42,6 @@ def tmp_cwd() -> Iterator[None]:
             yield
         finally:
             os.chdir(prev_cwd)
-
-
-TESTDATA_DIR = Path(__file__).parent.parent / "testdata"
 
 
 @pytest.fixture(autouse=True, scope="module")

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -180,7 +180,7 @@ class Dataset:
             ConversionLayerMapping = Dataset.ConversionLayerMapping
 
             if self == ConversionLayerMapping.ENFORCE_LAYER_PER_FILE:
-                return str
+                return lambda p: p.as_posix().replace("/", "_")
             elif self == ConversionLayerMapping.ENFORCE_SINGLE_LAYER:
                 return lambda p: input_path.name
             elif self == ConversionLayerMapping.ENFORCE_LAYER_PER_FOLDER:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -185,7 +185,9 @@ class Dataset:
                 return lambda p: input_path.name
             elif self == ConversionLayerMapping.ENFORCE_LAYER_PER_FOLDER:
                 return (
-                    lambda p: input_path.name if p.parent == Path() else str(p.parent)
+                    lambda p: input_path.name
+                    if p.parent == Path()
+                    else p.parent.as_posix().replace("/", "_")
                 )
             elif self == ConversionLayerMapping.ENFORCE_LAYER_PER_TOPLEVEL_FOLDER:
                 return lambda p: input_path.name if p.parent == Path() else p.parts[0]
@@ -201,7 +203,7 @@ class Dataset:
                     )
                     else input_path.name
                     if p.parent == Path()
-                    else str(p.parent)
+                    else p.parent.as_posix().replace("/", "_")
                 )
             elif self == ConversionLayerMapping.INSPECT_SINGLE_FILE:
                 # As before, but only a single image is inspected to determine 2D vs 3D.
@@ -213,9 +215,7 @@ class Dataset:
                     return str
                 else:
                     return (
-                        lambda p: input_path.name
-                        if p.parent == Path()
-                        else str(p.parent)
+                        lambda p: input_path.name if p.parent == Path() else p.parts[-2]
                     )
             else:
                 raise ValueError(f"Got unexpected ConversionLayerMapping value: {self}")

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -231,6 +231,9 @@ class Layer:
             layer_name not in self.dataset.layers.keys()
         ), f"Failed to rename layer {self.name} to {layer_name}: The new name already exists."
         assert is_fs_path(self.path), f"Cannot rename remote layer {self.path}"
+        assert (
+            "/" not in layer_name
+        ), f"Cannot rename layer, because there is a '/' character in the layer name: {layer_name}"
         self.path.rename(self.dataset.path / layer_name)
         del self.dataset.layers[self.name]
         self.dataset.layers[layer_name] = self


### PR DESCRIPTION
### Description:
- Slashes in layer names resulted in bugs, because of the unconventional file naming. The conversion layer mapping was adapted to ensure, that layer names do not contain slashes.

### Issues:
- fixes #918 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [x] Added / Updated Tests
 - [ ] Considered adding this to the Examples
