### PR TITLE
Tweak docs navbar readability

### DIFF
--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -38,6 +38,14 @@
 		[dir=ltr] .md-header__title {
 			margin-left: 0;
 		}
+		.md-nav__item--section>.md-nav__link[for] {
+			/* Navbar Section Headers */
+			color: var(--md-typeset-color);
+    }
+		.md-nav__item--section>.md-nav>.md-nav__list>.md-nav__item {
+			/* Navbar Section Items */
+ 		  padding-left: 15px;
+		}
 	</style>
 {% endblock styles %}
 

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -6,6 +6,7 @@ authors = ["scalable minds <hello@scalableminds.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
+# mkdocs-video is not ready for Py3.11 because of bugs in lxml lib https://github.com/getnikola/nikola/issues/3679
 python = ">=3.8,<3.11"
 mkdocs-glightbox = "^0.3.4"
 


### PR DESCRIPTION
### Description:
The navbar sections have become increaseingly hard to spot and differentiate. Hence, I applied some slight re-styling based on @albanedlvg design to improve the readbility:
- Slightly indent the navbar items
- Slightly darken the navbar headers (use the same color as navbar items)
<img width="531" alt="image" src="https://github.com/scalableminds/webknossos-libs/assets/1105056/6dd44db3-1e8f-47f2-91d5-dee1405d5c42">


### Issues:
- None

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
