### PR TITLE
changes from_kwargs to from_config

### DIFF
--- a/cluster_tools/cluster_tools/__init__.py
+++ b/cluster_tools/cluster_tools/__init__.py
@@ -114,7 +114,7 @@ def get_executor(environment: str, **kwargs: Any) -> "Executor":
         if "client" in kwargs:
             return DaskExecutor(kwargs["client"])
         else:
-            return DaskExecutor.from_kwargs(**kwargs)
+            return DaskExecutor.from_config(**kwargs)
     elif environment == "multiprocessing":
         global did_start_test_multiprocessing
         if not did_start_test_multiprocessing:

--- a/cluster_tools/cluster_tools/executors/dask.py
+++ b/cluster_tools/cluster_tools/executors/dask.py
@@ -6,6 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Callable,
+    Dict,
     Iterable,
     Iterator,
     List,
@@ -37,13 +38,13 @@ class DaskExecutor(futures.Executor):
         self.client = client
 
     @classmethod
-    def from_kwargs(
+    def from_config(
         cls,
-        **kwargs: Any,
+        job_resources: Dict[str, Any],
     ) -> "DaskExecutor":
         from distributed import Client
 
-        return cls(Client(**kwargs))
+        return cls(Client(**job_resources))
 
     @classmethod
     def as_completed(cls, futures: List["Future[_T]"]) -> Iterator["Future[_T]"]:


### PR DESCRIPTION
While trying out the dask executor in voxelytics, I noticed that the signature for creating an executor is not consistent. That makes this breaking change necessary. I don't think it is a big deal, because I doubt anybody else has used it in the meantime.
