### PR TITLE
Fix nested Slurm scheduling for newer Slurm versions

### DIFF
--- a/cluster_tools/tests/test_slurm.py
+++ b/cluster_tools/tests/test_slurm.py
@@ -533,3 +533,15 @@ def test_preliminary_file_map() -> None:
                 assert (
                     not preliminary_output_path.exists()
                 ), "Preliminary output file should not exist anymore"
+
+
+def test_cpu_bind_regression() -> None:
+    os.environ[
+        "SLURM_CPU_BIND"
+    ] = "quiet,mask_cpu:0x000000000000040000000000000000040000"
+
+    with cluster_tools.get_executor("slurm") as executor:
+        # The slurm job should not fail, although an invalid CPU mask was set before the submission
+        # See https://bugs.schedmd.com/show_bug.cgi?id=14298
+        future = executor.submit(square, 2)
+        assert future.result() == 4


### PR DESCRIPTION
### Description:
- Slurm version >=22.05 changed the behavior of the `SLURM_CPU_BIND` variable leading to errors when scheduling nested Slurm jobs
- I added a test and confirmed that the issue was reproducible before this PR
- See https://scm.slack.com/archives/C03B6160ATY/p1700666715939549 for more context

### Issues:
- fixes #...

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Added / Updated Tests
