### PR TITLE
Fix parsing ApiProject in wk api client

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Fixed
 
+- Fixed a bug in reading project info from webknossos using the api client. [#970](https://github.com/scalableminds/webknossos-libs/pull/970)
+
 
 ## [0.14.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.9) - 2023-11-29
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.8...v0.14.9)

--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -235,7 +235,7 @@ class ApiProject:
     name: str
     team: str
     team_name: str
-    owner: ApiUser
+    owner: ApiUserCompact
     priority: int
     paused: bool
     expected_time: Optional[int] = None


### PR DESCRIPTION
### Description:
- Parsing the response of the project info json failed. Needs to be ApiUserCompact (uses the backend’s compactWrites method)

### Todos:
 - [x] Updated Changelog