### PR TITLE
Project owner is optional (None if you have no read access rights)

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,8 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Fixed
 
+- Fixed a bug in reading project info from webknossos using the api client for non-admins. [#972](https://github.com/scalableminds/webknossos-libs/pull/972)
+
 
 ## [0.14.11](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.11) - 2023-12-06
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.10...v0.14.11)

--- a/webknossos/webknossos/administration/project.py
+++ b/webknossos/webknossos/administration/project.py
@@ -19,7 +19,7 @@ class Project:
     name: str
     team_id: str
     team_name: str
-    owner_id: str
+    owner_id: Optional[str]  # None in case you have no read access on the owner
     priority: int
     paused: bool
     expected_time: Optional[int]
@@ -75,16 +75,22 @@ class Project:
 
     def get_owner(self) -> User:
         """Returns the user that is the owner of this task"""
+        assert (
+            self.owner_id is not None
+        ), "Project owner is None, you may not have enough access rights to read the project owner."
         return User.get_by_id(self.owner_id)
 
     @classmethod
     def _from_api_project(cls, api_project: ApiProject) -> "Project":
+        owner_id = None
+        if api_project.owner is not None:
+            owner_id = api_project.owner.id
         return cls(
             api_project.id,
             api_project.name,
             api_project.team,
             api_project.team_name,
-            api_project.owner.id,
+            owner_id,
             api_project.priority,
             api_project.paused,
             api_project.expected_time,

--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -235,7 +235,7 @@ class ApiProject:
     name: str
     team: str
     team_name: str
-    owner: ApiUserCompact
+    owner: Optional[ApiUserCompact]  # None in case you have no read access on the owner
     priority: int
     paused: bool
     expected_time: Optional[int] = None


### PR DESCRIPTION
Normal users/annotators can read the api project but should not get info about the project owner. There it is null/None. This PR reflects that in the libs.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
