### PR TITLE
Fix buffered slice writer overwriting data under certain conditions

### DIFF
--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -174,13 +174,12 @@ def test_buffered_slice_writer_unaligned(
     )
     mag1 = layer.add_mag("1", chunk_shape=(32, 32, 32), chunks_per_shard=(8, 8, 8))
 
-
     # Write some data to z=32. We will check that this
     # data is left untouched by the buffered slice writer.
     ones_at_z32 = np.ones((512, 512, 4), dtype=np.uint8)
     ones_offset = (0, 0, 32)
     mag1.write(ones_at_z32, absolute_offset=ones_offset)
-    
+
     # Allocate some data (~ 8 MB). Note that this will write
     # from z=1 to z=31 (i.e., 31 slices instead of 32 which
     # is the buffer_size with which we configure the BufferedSliceWriter).
@@ -198,10 +197,14 @@ def test_buffered_slice_writer_unaligned(
                 writer.send(section)
 
     written_data = mag1.read(absolute_offset=offset, size=shape)
-    assert np.all(data == written_data), "Read data is not equal to the data that was just written."
+    assert np.all(
+        data == written_data
+    ), "Read data is not equal to the data that was just written."
 
     data_at_z32 = mag1.read(absolute_offset=ones_offset, size=ones_at_z32.shape)
-    assert np.all(ones_at_z32 == data_at_z32), "The BufferedSliceWriter seems to have overwritten older data."
+    assert np.all(
+        ones_at_z32 == data_at_z32
+    ), "The BufferedSliceWriter seems to have overwritten older data."
 
 
 def test_buffered_slice_writer_should_warn_about_unaligned_usage(

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -131,9 +131,7 @@ class BufferedSliceWriter:
             channel_count = self.slices_to_write[0].shape[0]
 
             buffer_depth = min(self.buffer_size, len(self.slices_to_write))
-            buffer_bbox = BoundingBox(
-                (0, 0, 0), (max_width, max_height, buffer_depth)
-            )
+            buffer_bbox = BoundingBox((0, 0, 0), (max_width, max_height, buffer_depth))
 
             shard_dimensions = self.view._get_file_dimensions().moveaxis(
                 -1, self.dimension

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -130,8 +130,9 @@ class BufferedSliceWriter:
             max_height = max(section.shape[-1] for section in self.slices_to_write)
             channel_count = self.slices_to_write[0].shape[0]
 
+            buffer_depth = min(self.buffer_size, len(self.slices_to_write))
             buffer_bbox = BoundingBox(
-                (0, 0, 0), (max_width, max_height, self.buffer_size)
+                (0, 0, 0), (max_width, max_height, buffer_depth)
             )
 
             shard_dimensions = self.view._get_file_dimensions().moveaxis(
@@ -140,13 +141,13 @@ class BufferedSliceWriter:
             chunk_size = Vec3Int(
                 min(shard_dimensions[0], max_width),
                 min(shard_dimensions[1], max_height),
-                self.buffer_size,
+                buffer_depth,
             )
             for chunk_bbox in buffer_bbox.chunk(chunk_size):
                 info(f"Writing chunk {chunk_bbox}")
-                width, height, _ = chunk_bbox.size
+                width, height, depth = chunk_bbox.size
                 data = np.zeros(
-                    (channel_count, width, height, self.buffer_size),
+                    (channel_count, width, height, depth),
                     dtype=self.slices_to_write[0].dtype,
                 )
 


### PR DESCRIPTION
### Description:
- Fixes that the buffered slice writer could overwrite data when writing less slices than `buffer_size` at an offset that is not aligned.

### Issues:
- fixes a regression caused by #937

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [X] Added / Updated Tests
