### PR TITLE
Add calculation of a dataset's whole bounding box to Dataset

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added a method to the Datasets class that calculates a dataset's bounding box covering all layers. [#975](https://github.com/scalableminds/webknossos-libs/pull/975)
 
 ### Changed
 

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -1052,6 +1052,21 @@ def test_changing_layer_bounding_box(
     assure_exported_properties(ds)
 
 
+@pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
+def test_dataset_bounding_box_calculation(
+    data_format: DataFormat, output_path: Path
+) -> None:
+    ds_path = copy_simple_dataset(data_format, output_path, "change_layer_bounding_box")
+    ds = Dataset.open(ds_path)
+    layer = ds.get_layer("color")
+    # BoundingBox(topleft=(0, 0, 0), size=(24, 24, 24))
+    assert layer.bounding_box == ds.calculate_bounding_box(), "The calculated bounding box of the dataset does not " +\
+        "match the color layer's bounding box."
+    layer.bounding_box = layer.bounding_box.with_size((512,512,512))
+    assert layer.bounding_box == ds.calculate_bounding_box(), "The calculated bounding box of the dataset does not " +\
+        "match the color layer's enlarged bounding box."
+
+
 def test_get_view() -> None:
     ds_path = prepare_dataset_path(DataFormat.WKW, TESTOUTPUT_DIR, "get_view")
     ds = Dataset(ds_path, voxel_size=(1, 1, 1))

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -1060,11 +1060,15 @@ def test_dataset_bounding_box_calculation(
     ds = Dataset.open(ds_path)
     layer = ds.get_layer("color")
     # BoundingBox(topleft=(0, 0, 0), size=(24, 24, 24))
-    assert layer.bounding_box == ds.calculate_bounding_box(), "The calculated bounding box of the dataset does not " +\
-        "match the color layer's bounding box."
-    layer.bounding_box = layer.bounding_box.with_size((512,512,512))
-    assert layer.bounding_box == ds.calculate_bounding_box(), "The calculated bounding box of the dataset does not " +\
-        "match the color layer's enlarged bounding box."
+    assert layer.bounding_box == ds.calculate_bounding_box(), (
+        "The calculated bounding box of the dataset does not "
+        + "match the color layer's bounding box."
+    )
+    layer.bounding_box = layer.bounding_box.with_size((512, 512, 512))
+    assert layer.bounding_box == ds.calculate_bounding_box(), (
+        "The calculated bounding box of the dataset does not "
+        + "match the color layer's enlarged bounding box."
+    )
 
 
 def test_get_view() -> None:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1485,6 +1485,9 @@ class Dataset:
         return self.layers[new_layer_name]
 
     def calculate_bounding_box(self) -> BoundingBox:
+        """
+        Calculates and returns the enclosing bounding box of all data layers of the dataset.
+        """
         all_layers = list(self.layers.values())
         if len(all_layers) <= 0:
             return BoundingBox.empty()

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1484,6 +1484,16 @@ class Dataset:
         self._export_as_json()
         return self.layers[new_layer_name]
 
+    def calculate_bounding_box(self) -> BoundingBox:
+        all_layers = list(self.layers.values())
+        if len(all_layers) <= 0:
+            return BoundingBox.empty()
+        dataset_bbox = all_layers[0].bounding_box
+        for layer in all_layers[1:]:
+            bbox = layer.bounding_box
+            dataset_bbox = dataset_bbox.extended_by(bbox)
+        return dataset_bbox
+
     def copy_dataset(
         self,
         new_dataset_path: Union[str, Path],


### PR DESCRIPTION
### Description:
This PR adds a method to the dataset class that calculates the bounding box of the dataset (the bounds of all data layers). Previously, users had to iterate over all layers and extend the bounding boxes themselves. This is now solved by the new function `calculate_bounding_box`.

### Issues:
- No issue was created for this :D

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation <-- Not needed imo. (besides the doc string)
 - [x] Added / Updated Tests
 - [ ] Considered adding this to the Examples -> I think the use case is not common enough for this.
