### PR TITLE
Adds cwd propagation to DaskExecutor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
         if: ${{ matrix.executors == 'dask' && matrix.python-version != '3.8' }}
         run: |
           cd tests
-          PYTEST_EXECUTORS=dask poetry run python -m pytest -sv test_all.py
+          PYTEST_EXECUTORS=dask poetry run python -m pytest -sv test_all.py test_dask.py
 
   webknossos_linux:
     needs: changes

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Fixed working directory propagation in DaskExecutor. [#994](https://github.com/scalableminds/webknossos-libs/pull/994)
 
 
 ## [0.14.14](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.14) - 2024-01-12

--- a/cluster_tools/cluster_tools/executors/dask.py
+++ b/cluster_tools/cluster_tools/executors/dask.py
@@ -41,7 +41,6 @@ def _run_in_nanny(
         for key, value in __env.items():
             os.environ[key] = value
 
-        print(os.environ["PWD"])
         if "PWD" in os.environ:
             os.chdir(os.environ["PWD"])
         ret = __fn(*args, **kwargs)

--- a/cluster_tools/cluster_tools/executors/dask.py
+++ b/cluster_tools/cluster_tools/executors/dask.py
@@ -41,6 +41,9 @@ def _run_in_nanny(
         for key, value in __env.items():
             os.environ[key] = value
 
+        print(os.environ["PWD"])
+        if "PWD" in os.environ:
+            os.chdir(os.environ["PWD"])
         ret = __fn(*args, **kwargs)
         queue.put({"value": ret})
     except Exception as exc:
@@ -174,7 +177,9 @@ class DaskExecutor(futures.Executor):
                 ),
             )
 
-        kwargs["__env"] = os.environ.copy()
+        __env = os.environ.copy()
+        __env["PWD"] = os.getcwd()
+        kwargs["__env"] = __env
 
         # We run the functions in dask as a separate process to not hold the
         # GIL for too long, because dask workers need to be able to communicate

--- a/cluster_tools/tests/test_dask.py
+++ b/cluster_tools/tests/test_dask.py
@@ -1,0 +1,29 @@
+import os
+from typing import TYPE_CHECKING, List, Optional
+
+if TYPE_CHECKING:
+    from distributed import LocalCluster
+
+import cluster_tools
+
+_dask_cluster: Optional["LocalCluster"] = None
+
+
+def job(_arg: None) -> str:
+    return os.getcwd()
+
+
+def test_pass_cwd() -> None:
+    global _dask_cluster
+    if not _dask_cluster:
+        from distributed import LocalCluster, Worker
+
+        _dask_cluster = LocalCluster(
+            worker_class=Worker, resources={"mem": 20e9, "cpus": 4}, nthreads=6
+        )
+    with cluster_tools.get_executor(
+        "dask", job_resources={"address": _dask_cluster}
+    ) as exec:
+        tmp_path = os.path.realpath("/tmp")  # macOS redirects `/tmp` to `/private/tmp`
+        os.chdir(tmp_path)
+        assert list(exec.map(job, [None])) == [tmp_path]


### PR DESCRIPTION
### Description:
Adds working directory propagation to DaskExecutor. Previously, the working directory of the worker was used.

Fixes an issue in https://github.com/scalableminds/voxelytics/pull/3348

### Todos:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
