### PR TITLE
CLI tool for local merging of zip annotations with fallback layer

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.13...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.14...HEAD)
 
 ### Breaking Changes
 
@@ -16,6 +16,10 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+
+
+## [0.14.14](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.14) - 2024-01-12
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.13...v0.14.14)
 
 
 ## [0.14.13](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.13) - 2024-01-02

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -10,16 +10,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective _Breaking Changes_ sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.13...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.14...HEAD)
 
 ### Breaking Changes
 
 ### Added
-- Added a method to the Datasets class that calculates a dataset's bounding box covering all layers. [#975](https://github.com/scalableminds/webknossos-libs/pull/975)
 
 ### Changed
 
 ### Fixed
+
+
+## [0.14.14](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.14) - 2024-01-12
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.14.13...v0.14.14)
+
+### Added
+- Added a method to the Datasets class that calculates a dataset's bounding box covering all layers. [#975](https://github.com/scalableminds/webknossos-libs/pull/975)
 
 
 ## [0.14.13](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.13) - 2024-01-02

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Add CLI tool for offline merging of zip annotations with fallback datasets. [#996](https://github.com/scalableminds/webknossos-libs/pull/996)
 
 ### Changed
 

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -23,7 +23,7 @@ from tests.constants import (
     TESTDATA_DIR,
     use_minio,
 )
-from webknossos import BoundingBox, DataFormat, Dataset, Annotation
+from webknossos import Annotation, BoundingBox, DataFormat, Dataset
 from webknossos.cli.export_wkw_as_tiff import _make_tiff_name
 from webknossos.cli.main import app
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
@@ -482,24 +482,25 @@ def test_export_tiff_stack_tiles_per_dimension(tmp_path: Path) -> None:
                     f"is not equal to the original wkw_file."
                 )
 
-def test_merge_fallback(tmp_path: Path) -> None:
-    source_annotation = TESTDATA_DIR \
-        / "annotations" \
-        / "l4dense_motta_et_al_demo_v2__explorational__4a6356.zip"
-    
-    target_dataset_path = tmp_path / "merged_dataset"
-    fallback_dataset = Annotation.load(source_annotation)\
-        .export_volume_layer_to_dataset(tmp_path / "fallback_dataset")
 
+def test_merge_fallback_no_fallback_layer(tmp_path: Path) -> None:
+    # Test proposal
+    source_annotation_zip = (
+        TESTDATA_DIR
+        / "annotations"
+        / "l4dense_motta_et_al_demo_v2__explorational__4a6356.zip"
+    )
+
+    target_dataset_path = tmp_path / "merged_dataset"
 
     result = runner.invoke(
         app,
         [
             "merge-fallback",
             str(target_dataset_path),
-            str(source_annotation),
-            str(fallback_dataset),
-        ]
+            str(source_annotation_zip),
+            str(tmp_path),
+        ],
     )
 
     assert result.exit_code == 0

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -23,7 +23,7 @@ from tests.constants import (
     TESTDATA_DIR,
     use_minio,
 )
-from webknossos import Annotation, BoundingBox, DataFormat, Dataset
+from webknossos import BoundingBox, DataFormat, Dataset
 from webknossos.cli.export_wkw_as_tiff import _make_tiff_name
 from webknossos.cli.main import app
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -23,7 +23,7 @@ from tests.constants import (
     TESTDATA_DIR,
     use_minio,
 )
-from webknossos import BoundingBox, DataFormat, Dataset
+from webknossos import BoundingBox, DataFormat, Dataset, Annotation
 from webknossos.cli.export_wkw_as_tiff import _make_tiff_name
 from webknossos.cli.main import app
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
@@ -481,3 +481,25 @@ def test_export_tiff_stack_tiles_per_dimension(tmp_path: Path) -> None:
                     f"The tiff file {tiff_path} that was written "
                     f"is not equal to the original wkw_file."
                 )
+
+def test_merge_fallback(tmp_path: Path) -> None:
+    source_annotation = TESTDATA_DIR \
+        / "annotations" \
+        / "l4dense_motta_et_al_demo_v2__explorational__4a6356.zip"
+    
+    target_dataset_path = tmp_path / "merged_dataset"
+    fallback_dataset = Annotation.load(source_annotation)\
+        .export_volume_layer_to_dataset(tmp_path / "fallback_dataset")
+
+
+    result = runner.invoke(
+        app,
+        [
+            "merge-fallback",
+            str(target_dataset_path),
+            str(source_annotation),
+            str(fallback_dataset),
+        ]
+    )
+
+    assert result.exit_code == 0

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -484,12 +484,89 @@ def test_export_tiff_stack_tiles_per_dimension(tmp_path: Path) -> None:
 
 
 def test_merge_fallback_no_fallback_layer(tmp_path: Path) -> None:
-    # Test proposal
-    source_annotation_zip = (
-        TESTDATA_DIR
-        / "annotations"
-        / "l4dense_motta_et_al_demo_v2__explorational__4a6356.zip"
+    from zipfile import ZIP_DEFLATED, ZipFile
+    from zlib import Z_BEST_SPEED
+
+    import webknossos.annotation
+    from webknossos import SEGMENTATION_CATEGORY, Annotation, Skeleton
+
+    fallback_layer_data = np.ones((64, 64, 64), dtype=np.uint8)
+
+    fallback_mag = (
+        Dataset(tmp_path / "fallback_dataset", (11.24, 11.24, 25))
+        .add_layer(
+            "fallback_layer",
+            SEGMENTATION_CATEGORY,
+            dtype_per_channel=fallback_layer_data.dtype,
+        )
+        .add_mag(1, chunk_shape=(32,) * 3, chunks_per_shard=(1,) * 3)
     )
+
+    fallback_mag.write(absolute_offset=(0,) * 3, data=fallback_layer_data)
+
+    annotation_zip_path = tmp_path / "annotation.zip"
+    annotation_data = np.ones((32, 32, 32), dtype=fallback_layer_data.dtype) * 2
+    voxel_size = (11.24, 11.24, 25)
+
+    topleft = (32,) * 3
+
+    with TemporaryDirectory(dir=tmp_path) as tmp_dir:
+        tmp_ds_dir = Path(tmp_dir)
+        tmp_dataset = Dataset(tmp_ds_dir / "tmp_dataset", voxel_size)
+
+        largest_segment_id = int(annotation_data.max())
+
+        tmp_layer = tmp_dataset.add_layer(
+            "Volume",
+            SEGMENTATION_CATEGORY,
+            dtype_per_channel=annotation_data.dtype,
+            largest_segment_id=largest_segment_id,
+        )
+
+        mag1 = tmp_layer.add_mag(
+            1, chunk_shape=(32,) * 3, chunks_per_shard=(1,) * 3, compress=True
+        )
+
+        mag1.write(absolute_offset=topleft, data=annotation_data)
+
+        volume_layer_zip = tmp_ds_dir / "data_Volume.zip"
+
+        with ZipFile(
+            volume_layer_zip,
+            mode="x",
+            compression=ZIP_DEFLATED,
+            compresslevel=Z_BEST_SPEED,
+        ) as zf:
+            for dirname, _, files in os.walk(str(tmp_layer.path)):
+                arcname = str(Path(dirname).relative_to(tmp_layer.path))
+                for filename in files:
+                    if filename.endswith(".wkw"):
+                        zf.write(
+                            os.path.join(dirname, filename),
+                            os.path.join(arcname, filename),
+                        )
+
+        annotation = Annotation(
+            name="test_annotation",
+            skeleton=Skeleton(
+                voxel_size=tmp_dataset.voxel_size,
+                dataset_name=fallback_mag.layer.dataset.name,
+            ),
+        )
+
+        annotation._volume_layers = [
+            webknossos.annotation._VolumeLayer(  # type: ignore # pylint: disable=no-member
+                id=0,
+                name=tmp_layer.name,
+                fallback_layer_name=fallback_mag.layer.name,
+                zip=volume_layer_zip,
+                segments={},
+                data_format=DataFormat.WKW,
+                largest_segment_id=largest_segment_id,
+            ),
+        ]
+
+        annotation.save(annotation_zip_path)
 
     target_dataset_path = tmp_path / "merged_dataset"
 
@@ -498,9 +575,24 @@ def test_merge_fallback_no_fallback_layer(tmp_path: Path) -> None:
         [
             "merge-fallback",
             str(target_dataset_path),
-            str(source_annotation_zip),
+            str(annotation_zip_path),
             str(tmp_path),
         ],
     )
 
     assert result.exit_code == 0
+
+    expected_data = fallback_layer_data
+    expected_data[
+        tuple(slice(t, t + s) for t, s in zip(topleft, annotation_data.shape))
+    ] = annotation_data
+
+    merged_data = (
+        Dataset.open(target_dataset_path)
+        .get_layer(fallback_mag.layer.name)
+        .get_mag(1)
+        .read()
+        .squeeze(0)
+    )
+
+    assert (merged_data == expected_data).all()

--- a/webknossos/webknossos/cli/main.py
+++ b/webknossos/webknossos/cli/main.py
@@ -13,6 +13,7 @@ from . import (
     download,
     downsample,
     export_wkw_as_tiff,
+    merge_fallback,
     upload,
     upsample,
 )
@@ -29,5 +30,6 @@ app.command("convert-zarr")(convert_zarr.main)
 app.command("download")(download.main)
 app.command("downsample")(downsample.main)
 app.command("export-wkw-as-tiff")(export_wkw_as_tiff.main)
+app.command("merge-fallback")(merge_fallback.main)
 app.command("upload")(upload.main)
 app.command("upsample")(upsample.main)

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -35,7 +35,7 @@ def main(
             parser=parse_path,
         ),
     ],
-    dataset_folder: Annotated[
+    dataset_directory: Annotated[
         Any,
         typer.Argument(
             help="Path to your WEBKNOSSOS dataset folder.",
@@ -105,7 +105,7 @@ def main(
         annotation.export_volume_layer_to_dataset(output_dataset)
 
     else:
-        fallback_dataset_path = dataset_folder / annotation.dataset_name
+        fallback_dataset_path = dataset_directory / annotation.dataset_name
         fallback_layer = Dataset.open(fallback_dataset_path).get_layer(
             fallback_layer_name
         )

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -175,7 +175,7 @@ def merge_mags(
 
     logging.info(f"Grouping {len(bboxes)} bboxes according to output shards.")
     shards_with_bboxes = BoundingBox.group_boxes_with_aligned_mag(
-        bboxes, Mag(output_mag.info.shard_size * output_mag.mag)
+        bboxes, Mag(output_mag.info.shard_shape * output_mag.mag)
     )
 
     args = [

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -9,12 +9,16 @@ from typing import Any, List, Optional, Tuple
 import typer
 from cluster_tools import Executor
 from typing_extensions import Annotated
+from rich.progress import track
+
 
 from ..annotation import Annotation
 from ..dataset import Dataset, MagView
 from ..geometry import BoundingBox, Mag
 from ..utils import get_executor_for_args
 from ._utils import DistributionStrategy, parse_path
+
+logging.basicConfig(level=logging.INFO)
 
 
 def main(
@@ -35,10 +39,10 @@ def main(
             parser=parse_path,
         ),
     ],
-    fallback_dataset: Annotated[
+    dataset_folder: Annotated[
         Any,
         typer.Argument(
-            help="Path to your WEBKNOSSOS dataset with fallback layer(s).",
+            help="Path to your WEBKNOSSOS dataset folder.",
             show_default=False,
             parser=parse_path,
         ),
@@ -105,10 +109,8 @@ def main(
         annotation.export_volume_layer_to_dataset(output_dataset)
 
     else:
-        logging.info(
-            f"Merge volume layer {volume_layer_name} with fallback layer {fallback_layer_name} from {fallback_dataset}"
-        )
-        fallback_layer = Dataset.open(fallback_dataset).get_layer(fallback_layer_name)
+        fallback_dataset_path = dataset_folder / annotation.dataset_name
+        fallback_layer = Dataset.open(fallback_dataset_path).get_layer(fallback_layer_name)
 
         with get_executor_for_args(args=executor_args) as executor:
             if volume_layer.zip is None:
@@ -118,31 +120,43 @@ def main(
                 )
 
             else:
-                with annotation.temporary_volume_layer_copy(
+                tmp_annotation_layer_name = f"{annotation.name}-TMP"
+                logging.info(f"Unpack annotation layer {volume_layer_name} temporarily in {output_dataset.name} as {tmp_annotation_layer_name}")
+                # NOTE(erjel): Cannot use "temporary_volume_layer_copy" here, since tmp folders
+                # might not be accessible from slurm compute nodes.
+                input_annotation_layer = annotation.export_volume_layer_to_dataset(
+                    output_dataset, 
+                    layer_name=tmp_annotation_layer_name,
                     volume_layer_name=volume_layer_name
-                ) as input_annotation_layer:
-                    input_annotation_mag = input_annotation_layer.get_finest_mag()
-                    fallback_mag = fallback_layer.get_mag(input_annotation_mag.mag)
+                )
 
-                    output_layer = output_dataset.add_layer_like(
-                        fallback_layer, fallback_layer.name
-                    )
-                    output_mag = output_layer.add_copy_mag(fallback_mag, compress=True)
+                input_annotation_mag = input_annotation_layer.get_finest_mag()
+                fallback_mag = fallback_layer.get_mag(input_annotation_mag.mag)
 
-                    merge_mags(output_mag, input_annotation_mag, executor)
+                logging.info(f"Create layer {fallback_layer.name} in {output_dataset.path}")
+                output_layer = output_dataset.add_layer_like(
+                    fallback_layer, fallback_layer.name
+                )
+                logging.info(f"Copy Mag {fallback_mag.mag} from {fallback_layer.path} to {output_layer.path}")
+                output_mag = output_layer.add_copy_mag(
+                    fallback_mag,
+                    compress=True,
+                    executor=executor,
+                )
 
+                merge_mags(output_mag, input_annotation_mag, executor)
+
+                ## TODO(erjel): Is there no blocking until all executor tasks are done?
+                #logging.info("Delete temporary annotation layer")
+                #output_dataset.delete_layer(tmp_annotation_layer_name)
+                #logging.info("Done.")
 
 def merge_mags(
     output_mag: MagView,
     input_annotation_mag: MagView,
     executor: Executor,
 ) -> None:
-    bboxes = list(bbox for bbox in input_annotation_mag.get_bounding_boxes_on_disk())
-
-    shards_with_bboxes = BoundingBox.group_boxes_with_aligned_mag(
-        bboxes, Mag(output_mag.info.shard_size)
-    )
-
+    
     assert all(
         input_annotation_mag.info.chunks_per_shard.to_np() == 1
     ), "volume annotation must have file_len=1"
@@ -153,22 +167,27 @@ def merge_mags(
         input_annotation_mag.mag == output_mag.mag
     ), f"Volume annotation mag {input_annotation_mag.mag} must match the fallback layer mag {output_mag.mag}"
 
-    executor.map(
-        partial(merge_chunk, mag_in=input_annotation_mag, mag_out=output_mag),
-        shards_with_bboxes.items(),
+    logging.info(f"Scan disk for annotation shards.")
+    bboxes = list(bbox for bbox in input_annotation_mag.get_bounding_boxes_on_disk())
+
+    logging.info(f"Grouping {len(bboxes)} bboxes according to output shards.")
+    shards_with_bboxes = BoundingBox.group_boxes_with_aligned_mag(
+        bboxes, Mag(output_mag.info.shard_size * output_mag.mag) 
     )
+
+    args = [(input_annotation_mag, output_mag, shard, bboxes) for shard, bboxes in shards_with_bboxes.items()]
+
+    logging.info(f"Merging {len(args)} shards.")        
+    executor.map(merge_chunk, args)
 
 
 def merge_chunk(
-    mag_in: MagView,
-    mag_out: MagView,
-    shards_with_bboxes: Tuple[BoundingBox, List[BoundingBox]],
+    args: Tuple[MagView, MagView, BoundingBox, List[BoundingBox]]
 ) -> None:
-    shard, bboxes = shards_with_bboxes
+    mag_in, mag_out, shard, bboxes = args
+    data_buffer = mag_out.read(absolute_bounding_box=shard)[0]
 
-    data_buffer = mag_in.read(absolute_bounding_box=shard)[0]
-
-    for bbox in bboxes:
+    for bbox in track(bboxes, description="Processing..."):
         read_data = mag_in.read(absolute_bounding_box=bbox)[0]
         data_buffer[
             bbox.offset(-shard.topleft).in_mag(mag_in.mag).to_slices()

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -1,0 +1,177 @@
+"""This module merges a volume annotation layer with its fallback layer."""
+
+import logging
+from argparse import Namespace
+from functools import partial
+from multiprocessing import cpu_count
+from typing import Any, List, Optional, Tuple
+
+import typer
+from cluster_tools import Executor
+from typing_extensions import Annotated
+
+from ..annotation import Annotation
+from ..dataset import Dataset, MagView
+from ..geometry import BoundingBox, Mag
+from ..utils import get_executor_for_args
+from ._utils import DistributionStrategy, parse_path
+
+
+def main(
+    *,
+    target: Annotated[
+        Any,
+        typer.Argument(
+            help="Path to your WEBKNOSSOS output dataset.",
+            show_default=False,
+            parser=parse_path,
+        ),
+    ],
+    source_annotation: Annotated[
+        Any,
+        typer.Argument(
+            help="Path to your WEBKNOSSOS zip annotation",
+            show_default=False,
+            parser=parse_path,
+        ),
+    ],
+    fallback_dataset: Annotated[
+        Any,
+        typer.Argument(
+            help="Path to your WEBKNOSSOS dataset with fallback layer(s).",
+            show_default=False,
+            parser=parse_path,
+        ),
+    ],
+    volume_layer_name: Annotated[
+        Optional[str],
+        typer.Option(help="Name of the volume layer to merge with fallback layer."),
+    ] = None,
+    jobs: Annotated[
+        int,
+        typer.Option(
+            help="Number of processes to be spawned.",
+            rich_help_panel="Executor options",
+        ),
+    ] = cpu_count(),
+    distribution_strategy: Annotated[
+        DistributionStrategy,
+        typer.Option(
+            help="Strategy to distribute the task across CPUs or nodes.",
+            rich_help_panel="Executor options",
+        ),
+    ] = DistributionStrategy.MULTIPROCESSING,
+    job_resources: Annotated[
+        Optional[str],
+        typer.Option(
+            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
+            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            rich_help_panel="Executor options",
+        ),
+    ] = None,
+) -> None:
+    """Merges a given WEBKNOSSOS annotation."""
+
+    executor_args = Namespace(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy.value,
+        job_resources=job_resources,
+    )
+
+    annotation = Annotation.load(source_annotation)
+    annotation_volumes = list(annotation.get_volume_layer_names())
+
+    output_dataset = Dataset(
+        target,
+        voxel_size=annotation.voxel_size,
+    )
+    assert len(annotation_volumes) > 0, "Annotation does not contain any volume layers!"
+
+    if not volume_layer_name is None:
+        assert (
+            volume_layer_name in annotation_volumes
+        ), f'Volume layer name "{volume_layer_name}" not found in annotation'
+    else:
+        assert (
+            len(annotation_volumes) == 1
+        ), "Volume layer name was not provided and more than one volume layer found in annotation"
+        volume_layer_name = annotation_volumes[0]
+
+    volume_layer = annotation._get_volume_layer(volume_layer_name=volume_layer_name)
+    fallback_layer_name = volume_layer.fallback_layer_name
+
+    if fallback_layer_name is None:
+        logging.info("No fallback layer found, save annotation as dataset.")
+        annotation.export_volume_layer_to_dataset(output_dataset)
+
+    else:
+        logging.info(
+            f"Merge volume layer {volume_layer_name} with fallback layer {fallback_layer_name} from {fallback_dataset}"
+        )
+        fallback_layer = Dataset.open(fallback_dataset).get_layer(fallback_layer_name)
+
+        with get_executor_for_args(args=executor_args) as executor:
+            if volume_layer.zip is None:
+                logging.info("No volume annotation found. Copy fallback layer.")
+                output_dataset.add_copy_layer(
+                    fallback_layer, compress=True, executor=executor
+                )
+
+            else:
+                with annotation.temporary_volume_layer_copy(
+                    volume_layer_name=volume_layer_name
+                ) as input_annotation_layer:
+                    input_annotation_mag = input_annotation_layer.get_finest_mag()
+                    fallback_mag = fallback_layer.get_mag(input_annotation_mag.mag)
+
+                    output_layer = output_dataset.add_layer_like(
+                        fallback_layer, fallback_layer.name
+                    )
+                    output_mag = output_layer.add_copy_mag(fallback_mag, compress=True)
+
+                    merge_mags(output_mag, input_annotation_mag, executor)
+
+
+def merge_mags(
+    output_mag: MagView,
+    input_annotation_mag: MagView,
+    executor: Executor,
+) -> None:
+    bboxes = list(bbox for bbox in input_annotation_mag.get_bounding_boxes_on_disk())
+
+    shards_with_bboxes = BoundingBox.group_boxes_with_aligned_mag(
+        bboxes, Mag(output_mag.info.shard_size)
+    )
+
+    assert all(
+        input_annotation_mag.info.chunks_per_shard.to_np() == 1
+    ), "volume annotation must have file_len=1"
+    assert (
+        input_annotation_mag.info.voxel_type == output_mag.info.voxel_type
+    ), "Volume annotation must have same dtype as fallback layer"
+    assert (
+        input_annotation_mag.mag == output_mag.mag
+    ), f"Volume annotation mag {input_annotation_mag.mag} must match the fallback layer mag {output_mag.mag}"
+
+    executor.map(
+        partial(merge_chunk, mag_in=input_annotation_mag, mag_out=output_mag),
+        shards_with_bboxes.items(),
+    )
+
+
+def merge_chunk(
+    mag_in: MagView,
+    mag_out: MagView,
+    shards_with_bboxes: Tuple[BoundingBox, List[BoundingBox]],
+) -> None:
+    shard, bboxes = shards_with_bboxes
+
+    data_buffer = mag_in.read(absolute_bounding_box=shard)[0]
+
+    for bbox in bboxes:
+        read_data = mag_in.read(absolute_bounding_box=bbox)[0]
+        data_buffer[
+            bbox.offset(-shard.topleft).in_mag(mag_in.mag).to_slices()
+        ] = read_data
+
+    mag_out.write(data_buffer, absolute_offset=shard.topleft)


### PR DESCRIPTION
Hey, 

I would like to provide code for a CLI tool which merges annotation zip files with local fallback layers. The main benefit would be that users which have file-level access to their dataset can merge annotations with fallback layer without streaming the entire merged dataset via the webknossos web server (and using cluster executors to speed up the process). Another benefit is that by pushing this upstream is the better maintainability: The existing gist is not integrated in the CI pipeline and thus suffers from several breaking changes already.  

I am happy to further change the code according to match additional requirements (i.e. provide additional test cases/ change documentation).

Best wishes,
Eric

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [x] Added / Updated Tests
 - [ ] Considered adding this to the Examples
