### PR TITLE
Only deploy docs on changes to master branch

### DIFF
--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   docs:
-    if: github.ref == 'refs/heads/master'
+    if: ${{ github.ref == 'refs/heads/master' }}
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/publish_docs.yml
+++ b/.github/workflows/publish_docs.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   docs:
+    if: github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### Description:
- Only run the CI for publishing the docs for changes to the `master` branch
- Prevent feature branches from deploying their own docs (which are likely not removed later and get indexed by Google)

### Issues:
- fixes https://github.com/scalableminds/webknossos/issues/7656

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
