### PR TITLE
Sanitize layer names in from_images

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Add CLI tool for offline merging of zip annotations with fallback datasets. [#996](https://github.com/scalableminds/webknossos-libs/pull/996)
 
 ### Changed
+- The rules for naming the layers have been tightened to match the allowed layer names on webknossos.
 
 ### Fixed
 

--- a/webknossos/examples/upload_image_data.py
+++ b/webknossos/examples/upload_image_data.py
@@ -31,7 +31,7 @@ def main() -> None:
     # The example microscopy data has two channels
     # Channel 0 contains cell membranes, channel 1 contains nuclei.
     layer_membranes = ds.add_layer(
-        "cell membranes",
+        "cell_membranes",
         COLOR_CATEGORY,
         dtype_per_layer=img.dtype,
     )

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -122,12 +122,9 @@ def test_repo_images(
 ) -> wk.Dataset:
     with wk.utils.get_executor_for_args(None) as executor:
         ds = wk.Dataset(tmp_path, (1, 1, 1))
-        layer_name = "__".join(
-            (path if isinstance(path, str) else str(path[0])).split("/")[1:]
-        )
         l = ds.add_layer_from_images(
             path,
-            layer_name=layer_name,
+            layer_name="color",
             compress=True,
             executor=executor,
             use_bioformats=False,
@@ -248,7 +245,7 @@ def test_bioformats(
     with wk.utils.get_executor_for_args(None) as executor:
         l = ds.add_layer_from_images(
             str(unzip_path / filename),
-            layer_name=filename,
+            layer_name="color",
             compress=True,
             executor=executor,
             use_bioformats=True,

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -103,6 +103,8 @@ _DATASET_URL_REGEX = re.compile(
     + r"(?P<organization_id>[^/]*)/(?P<dataset_name>[^/]*)(/(view)?)?"
     + r"(\?token=(?P<sharing_token>[^#]*))?"
 )
+_ALLOWED_LAYER_NAME_REGEX = re.compile(r"^[A-Za-z0-9_\-]+[A-Za-z0-9_\-\.]*$")
+_UNALLOWED_LAYER_NAME_CHARS = re.compile(r"[^A-Za-z0-9_\-\.]")
 
 
 def _find_array_info(layer_path: Path) -> Optional[ArrayInfo]:
@@ -187,8 +189,8 @@ class Dataset:
             elif self == ConversionLayerMapping.ENFORCE_SINGLE_LAYER:
                 return lambda p: input_path.name
             elif self == ConversionLayerMapping.ENFORCE_LAYER_PER_FOLDER:
-                return (
-                    lambda p: input_path.name
+                return lambda p: (
+                    input_path.name
                     if p.parent == Path()
                     else p.parent.as_posix().replace("/", "_")
                 )
@@ -197,16 +199,18 @@ class Dataset:
             elif self == ConversionLayerMapping.INSPECT_EVERY_FILE:
                 # If a file has z dimensions, it becomes its own layer,
                 # if it's 2D, the folder becomes a layer.
-                return (
-                    lambda p: str(p)
+                return lambda p: (
+                    str(p)
                     if has_image_z_dimension(
                         input_path / p,
                         use_bioformats=use_bioformats,
                         is_segmentation=guess_if_segmentation_path(p),
                     )
-                    else input_path.name
-                    if p.parent == Path()
-                    else p.parent.as_posix().replace("/", "_")
+                    else (
+                        input_path.name
+                        if p.parent == Path()
+                        else p.parent.as_posix().replace("/", "_")
+                    )
                 )
             elif self == ConversionLayerMapping.INSPECT_SINGLE_FILE:
                 # As before, but only a single image is inspected to determine 2D vs 3D.
@@ -217,8 +221,8 @@ class Dataset:
                 ):
                     return str
                 else:
-                    return (
-                        lambda p: input_path.name if p.parent == Path() else p.parts[-2]
+                    return lambda p: (
+                        input_path.name if p.parent == Path() else p.parts[-2]
                     )
             else:
                 raise ValueError(f"Got unexpected ConversionLayerMapping value: {self}")
@@ -316,9 +320,11 @@ class Dataset:
                 layer_properties.num_channels,
                 UPath(dataset_path),
                 layer_properties.name,
-                layer_properties.mags[0].mag
-                if len(layer_properties.mags) > 0
-                else None,
+                (
+                    layer_properties.mags[0].mag
+                    if len(layer_properties.mags) > 0
+                    else None
+                ),
             )
             layer_properties.num_channels = num_channels
 
@@ -391,7 +397,7 @@ class Dataset:
 
         dataset_name_or_url = resolve_short_link(dataset_name_or_url)
 
-        match = re.match(_DATASET_URL_REGEX, dataset_name_or_url)
+        match = _DATASET_URL_REGEX.match(dataset_name_or_url)
         if match is not None:
             assert (
                 organization_id is None
@@ -617,6 +623,15 @@ class Dataset:
         filepaths_per_layer: Dict[str, List[Path]] = {}
         for input_file in input_files:
             layer_name = map_filepath_to_layer_name(input_file)
+            # Remove characters from layer name that are not allowed
+            layer_name = _UNALLOWED_LAYER_NAME_CHARS.sub("", layer_name)
+            # Ensure layer name does not start with a dot
+            layer_name = layer_name.lstrip(".")
+
+            assert (
+                layer_name != ""
+            ), f"Could not determine a layer name for {input_file}."
+
             filepaths_per_layer.setdefault(layer_name, []).append(
                 input_path / input_file
             )
@@ -776,6 +791,10 @@ class Dataset:
         """
 
         self._ensure_writable()
+
+        assert _ALLOWED_LAYER_NAME_REGEX.match(
+            layer_name
+        ), f"The layer name '{layer_name}' is invalid. It must only contain letters, numbers, underscores, hyphens and dots."
 
         if "dtype" in kwargs:
             raise ValueError(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -103,7 +103,11 @@ _DATASET_URL_REGEX = re.compile(
     + r"(?P<organization_id>[^/]*)/(?P<dataset_name>[^/]*)(/(view)?)?"
     + r"(\?token=(?P<sharing_token>[^#]*))?"
 )
+# A layer name is allowed to contain letters, numbers, underscores, hyphens and dots.
+# As the begin and the end are anchored, all of the name must match the regex.
+# The first regex group ensures that the name does not start with a dot.
 _ALLOWED_LAYER_NAME_REGEX = re.compile(r"^[A-Za-z0-9_\-]+[A-Za-z0-9_\-\.]*$")
+# This regex matches any character that is not allowed in a layer name.
 _UNALLOWED_LAYER_NAME_CHARS = re.compile(r"[^A-Za-z0-9_\-\.]")
 
 


### PR DESCRIPTION
### Description:
- in WEBKNOSSOS layer names have to match the pattern  [A-Za-z0-9_\\-\\.]*. This wasn't ensured by wklibs yet. This PR adds a check for correct layer names in the `add_layer` method and sanitizes the generated layer names of `from_images`.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Added / Updated Tests
