### PR TITLE
Fix add layer from images for unaligned topleft

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed a bug, where using an unaligned topleft value for `add_layer_from_images` leads to corrupted data. [#1036](https://github.com/scalableminds/webknossos-libs/pull/1036)
 
 
 ## [0.14.17](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.17) - 2024-04-10

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -49,14 +49,14 @@ def test_compare_nd_tifffile(tmp_path: Path) -> None:
         "testdata/4D/4D_series/4D-series.ome.tif",
         layer_name="color",
         category="color",
-        topleft=(100, 100, 55),
+        topleft=(2, 55, 100, 100),
         use_bioformats=True,
         data_format="zarr3",
         chunk_shape=(8, 8, 8),
         chunks_per_shard=(8, 8, 8),
     )
     assert layer.bounding_box.topleft == wk.VecInt(
-        0, 55, 100, 100, axes=("t", "z", "y", "x")
+        2, 55, 100, 100, axes=("t", "z", "y", "x")
     )
     assert layer.bounding_box.size == wk.VecInt(
         7, 5, 167, 439, axes=("t", "z", "y", "x")

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -504,15 +504,19 @@ class PimsImages:
         copy_to_view returns an iterable of image shapes and largest segment ids. When using this
         method a manual update of the bounding box and the largest segment id might be necessary.
         """
-        relative_bbox = args
+        absolute_bbox = args
 
         assert all(
             size == 1
-            for size, axis in zip(relative_bbox.size, relative_bbox.axes)
+            for size, axis in zip(absolute_bbox.size, absolute_bbox.axes)
             if axis not in ("x", "y", "z")
         ), "The delivered BoundingBox has to be flat except for x,y and z dimension."
 
-        z_start, z_end = relative_bbox.get_bounds("z")
+        # z_start and z_end are relative to the bounding box of the mag_view
+        # to access the correct data from the images
+        z_start, z_end = absolute_bbox.offset(
+            -mag_view.bounding_box.topleft
+        ).get_bounds("z")
         shapes = []
         max_id: Optional[int]
         if is_segmentation:
@@ -522,13 +526,13 @@ class PimsImages:
 
         with self._open_images() as images:
             if self._iter_axes is not None and self._iter_loop_size is not None:
-                # select the range of images that represents one xyz combination
+                # select the range of images that represents one xyz combination in the mag_view
                 lower_bounds = sum(
                     self._iter_loop_size[axis_name]
-                    * relative_bbox.get_bounds(axis_name)[0]
+                    * absolute_bbox.get_bounds(axis_name)[0]
                     for axis_name in self._iter_axes[:-1]
                 )
-                upper_bounds = lower_bounds + relative_bbox.get_shape("z")
+                upper_bounds = lower_bounds + mag_view.bounding_box.get_shape("z")
                 images = images[lower_bounds:upper_bounds]
             if self._flip_z:
                 images = images[::-1]  # pylint: disable=unsubscriptable-object
@@ -536,8 +540,8 @@ class PimsImages:
             with mag_view.get_buffered_slice_writer(
                 # Previously only z_start and its end were important, now the slice writer needs to know
                 # which axis is currently written.
-                relative_bounding_box=relative_bbox,
-                buffer_size=mag_view.info.chunk_shape.z,
+                absolute_bounding_box=absolute_bbox,
+                buffer_size=absolute_bbox.get_shape("z"),
                 # copy_to_view is typically used in a multiprocessing-context. Therefore the
                 # buffered slice writer should not update the json file to avoid race conditions.
                 json_update_allowed=False,

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -505,6 +505,7 @@ class PimsImages:
         method a manual update of the bounding box and the largest segment id might be necessary.
         """
         absolute_bbox = args
+        relative_bbox = absolute_bbox.offset(-mag_view.bounding_box.topleft)
 
         assert all(
             size == 1
@@ -514,9 +515,7 @@ class PimsImages:
 
         # z_start and z_end are relative to the bounding box of the mag_view
         # to access the correct data from the images
-        z_start, z_end = absolute_bbox.offset(
-            -mag_view.bounding_box.topleft
-        ).get_bounds("z")
+        z_start, z_end = relative_bbox.get_bounds("z")
         shapes = []
         max_id: Optional[int]
         if is_segmentation:
@@ -529,7 +528,7 @@ class PimsImages:
                 # select the range of images that represents one xyz combination in the mag_view
                 lower_bounds = sum(
                     self._iter_loop_size[axis_name]
-                    * absolute_bbox.get_bounds(axis_name)[0]
+                    * relative_bbox.get_bounds(axis_name)[0]
                     for axis_name in self._iter_axes[:-1]
                 )
                 upper_bounds = lower_bounds + mag_view.bounding_box.get_shape("z")

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1273,7 +1273,7 @@ class Dataset:
                 set(layer.bounding_box.axes).difference("x", "y", "z")
             ) and layer.data_format != DataFormat.Zarr3:
                 raise RuntimeError(
-                    "The data stores additional axes with shape bigger than 1. These are only supported by data format Zarr3."
+                    "The data stores additional axes other than x, y and z."
                 )
 
             buffered_slice_writer_shape = layer.bounding_box.size_xyz.with_z(batch_size)

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -1270,18 +1270,10 @@ class Dataset:
             )
 
             if (
-                additional_axes := set(layer.bounding_box.axes).difference(
-                    "x", "y", "z"
-                )
+                set(layer.bounding_box.axes).difference("x", "y", "z")
             ) and layer.data_format != DataFormat.Zarr3:
-                assert all(
-                    layer.bounding_box.get_shape(axis) == 1 for axis in additional_axes
-                ), "The data stores additional axes with shape bigger than 1. These are only supported by data format Zarr3."
-
-                # Convert NDBoundingBox to 3D BoundingBox
-                layer.bounding_box = BoundingBox(
-                    layer.bounding_box.topleft_xyz,
-                    layer.bounding_box.topleft_xyz,
+                raise RuntimeError(
+                    "The data stores additional axes with shape bigger than 1. These are only supported by data format Zarr3."
                 )
 
             buffered_slice_writer_shape = layer.bounding_box.size_xyz.with_z(batch_size)


### PR DESCRIPTION
### Description:
- The method `add_layer_from_images` instantiates multiple BufferedSliceWriters. If `topleft` is set to an unaligned value in z-axis, it can lead to multiple BufferedSliceWriters writing into one chunk simultaneously. This leads to corrupt data in the resulting dataset. To avoid this, the instantiation of BufferedSliceWriters is adapted, so that their BoundingBox is aligned with the chunk_size.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Writing into an N-dimensional zarr array leads to assertion errors. The reason for this needs to be investigated.
 - [x] Updated Changelog
