### PR TITLE
Adding .nii fileending in list of suffixes supported by bioformats.

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Changed
 - Updated ruff to v0.4.0 [1047](https://github.com/scalableminds/webknossos-libs/pull/1047)
+- Added NIfTI suffix .nii to list of supported bioformats suffixes. [#1048](https://github.com/scalableminds/webknossos-libs/pull/1048) 
 
 ### Fixed
 

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -725,6 +725,7 @@ def get_valid_bioformats_suffixes() -> Set[str]:
         "raw",
         "xml",
         "gif",
+        "nii",
     }
 
 


### PR DESCRIPTION
### Description:
- Bioformats already supports NIfTI files. This PR just adds the .nii suffix to the list of supported suffixes by bioformats.

### Issues:
- fixes #931 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
