### PR TITLE
Ensure proper clean up when ctrl+c'ing cluster jobs

### DIFF
--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -176,6 +176,7 @@ class ClusterExecutor(futures.Executor):
 
         self.inner_handle_kill(signum, frame)
         self.wait_thread.stop()
+        self.clean_up()
 
         if (
             existing_sigint_handler != signal.default_int_handler
@@ -615,12 +616,15 @@ class ClusterExecutor(futures.Executor):
         self.wait_thread.stop()
         self.wait_thread.join()
 
+        self.clean_up()
+
+    def clean_up(self) -> None:
         for file_to_clean_up in self.files_to_clean_up:
             try:
                 os.unlink(file_to_clean_up)
             except OSError as exc:  # noqa: PERF203 `try`-`except` within a loop incurs performance overhead
                 logging.warning(
-                    f"Could not delete file during clean up. Path: {file_to_clean_up} Exception: {exc}"
+                    f"Could not delete file during clean up. Path: {file_to_clean_up} Exception: {exc}. Continuing..."
                 )
         self.files_to_clean_up = []
 

--- a/cluster_tools/tests/test_slurm.py
+++ b/cluster_tools/tests/test_slurm.py
@@ -79,7 +79,7 @@ def test_slurm_cfut_dir() -> None:
         assert future.result() == 4
 
     assert os.path.exists(cfut_dir)
-    assert len(os.listdir(cfut_dir)) == 2
+    assert len(os.listdir(cfut_dir)) == 1  # only the log file should still exist
 
 
 def test_slurm_max_submit_user() -> None:


### PR DESCRIPTION
### Description:
- even when shutting down slurm jobs early with ctrl+c, a clean up should happen
- also clean up meta file (contains function for array jobs etc)

### Issues:
- related to https://github.com/scalableminds/voxelytics/issues/3532