### PR TITLE
Fix cli download

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Moved functional parts of merge volume annotation CLI to Dataset and Annotation classes. [1055](https://github.com/scalableminds/webknossos-libs/pull/1055)
 
 ### Fixed
+- We've resolved an issue that was affecting the download of annotations through the Command Line Interface (CLI). Additionally, we've improved the CLI to better differentiate between dataset URLs and annotation URLs before initiating different download methods. [1083](https://github.com/scalableminds/webknossos-libs/pull/1083)
 
 
 ## [0.14.22](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.22) - 2024-05-13

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -21,7 +21,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Moved functional parts of merge volume annotation CLI to Dataset and Annotation classes. [1055](https://github.com/scalableminds/webknossos-libs/pull/1055)
 
 ### Fixed
-- We've resolved an issue that was affecting the download of annotations through the Command Line Interface (CLI). Additionally, we've improved the CLI to better differentiate between dataset URLs and annotation URLs before initiating different download methods. [1083](https://github.com/scalableminds/webknossos-libs/pull/1083)
+- Fixed an issue with downloading annotations through the Command Line Interface. [#1083](https://github.com/scalableminds/webknossos-libs/pull/1083)
 
 
 ## [0.14.22](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.22) - 2024-05-13

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -220,3 +220,19 @@ def pad_or_crop_to_size_and_topleft(
     )
 
     return cube_data
+
+
+def url_is_dataset(url: str) -> bool:
+    """
+    Classifies a URL as `annotation` or `dataset`.
+
+    Args:
+        url: URL to classify.
+
+    Returns:
+        bool: True if URL is a dataset, False if it is an annotation.
+
+    Raises:
+        ValueError: If URL is not a valid URL.
+    """
+    return False

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -220,19 +220,3 @@ def pad_or_crop_to_size_and_topleft(
     )
 
     return cube_data
-
-
-def url_is_dataset(url: str) -> bool:
-    """
-    Classifies a URL as `annotation` or `dataset`.
-
-    Args:
-        url: URL to classify.
-
-    Returns:
-        bool: True if URL is a dataset, False if it is an annotation.
-
-    Raises:
-        ValueError: If URL is not a valid URL.
-    """
-    return False

--- a/webknossos/webknossos/cli/download.py
+++ b/webknossos/webknossos/cli/download.py
@@ -78,23 +78,19 @@ def main(
 
     with webknossos_context(token=token):
         if re.match(_DATASET_URL_REGEX, url):
-            try:
-                Dataset.download(
-                    dataset_name_or_url=url,
-                    path=target,
-                    bbox=bbox,
-                    layers=layers,
-                    mags=mags,
-                )
-            except RuntimeError as err:
-                print(f"Dataset could not be downloaded: {err}")
+            Dataset.download(
+                dataset_name_or_url=url,
+                path=target,
+                bbox=bbox,
+                layers=layers,
+                mags=mags,
+            )
         elif re.match(_ANNOTATION_URL_REGEX, url):
-            try:
-                Annotation.download(annotation_id_or_url=url).save(target)
-            except AssertionError as err:
-                print(f"Annotation could not be downloaded: {err}")
+            Annotation.download(annotation_id_or_url=url).save(target)
         else:
-            print("The provided URL does not lead to a dataset or annotation.")
+            raise RuntimeError(
+                "The provided URL does not lead to a dataset or annotation."
+            )
 
 
 if __name__ == "__main__":

--- a/webknossos/webknossos/cli/download.py
+++ b/webknossos/webknossos/cli/download.py
@@ -9,7 +9,7 @@ from ..annotation import Annotation
 from ..client import webknossos_context
 from ..dataset import Dataset
 from ..geometry import BoundingBox, Mag
-from ._utils import parse_bbox, parse_mag, parse_path
+from ._utils import parse_bbox, parse_mag, parse_path, url_is_dataset
 
 
 def main(
@@ -75,6 +75,12 @@ def main(
 
     with webknossos_context(token=token):
         try:
+            is_dataset = url_is_dataset(url)
+        except ValueError as err:
+            print(f"The value could not be parsed to URL: {err}")
+            return
+
+        if is_dataset:
             Dataset.download(
                 dataset_name_or_url=url,
                 path=target,
@@ -82,5 +88,9 @@ def main(
                 layers=layers,
                 mags=mags,
             )
-        except AssertionError:
+        else:
             Annotation.download(annotation_id_or_url=url).save(target)
+
+
+if __name__ == "__main__":
+    typer.run(main)


### PR DESCRIPTION
### Description:
- When using the webknossos CLI to download an annotation, the download command is overloaded to take care of dataset downloads and annotation downloads. This PR uses the client to resolve a possible short link and compares the url to a dataset url regex and an annotation url regex to distinguish both cases.

### Issues:
- fixes #985 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
