### PR TITLE
Add converter to voxel_size factor.

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Add a converter to the VoxelSize field `factor`, to ensure it is a tuple.
 
 
 ## [0.14.25](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.25) - 2024-07-18

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -359,7 +359,7 @@ class Dataset:
             else:
                 assert (
                     self.voxel_size_with_unit == voxel_size_with_unit
-                ), f"Cannot open Dataset: The dataset {dataset_path} already exists, but the voxel_sizes do not match ({self.voxel_size} != {voxel_size})"
+                ), f"Cannot open Dataset: The dataset {dataset_path} already exists, but the voxel_sizes do not match ({self.voxel_size_with_unit} != {voxel_size_with_unit})"
             if name is not None:
                 assert (
                     self.name == name

--- a/webknossos/webknossos/dataset/properties.py
+++ b/webknossos/webknossos/dataset/properties.py
@@ -4,6 +4,7 @@ from typing import (
     Any,
     Callable,
     Dict,
+    Iterable,
     List,
     Optional,
     Tuple,
@@ -63,6 +64,18 @@ def _extract_num_channels(
             f"If the layer does not contain any data, you can also delete the layer and add it again.",
         ) from e
     return array.info.num_channels
+
+
+def float_tpl(voxel_size: Union[List, Tuple]) -> Iterable:
+    # Fix for mypy bug https://github.com/python/mypy/issues/5313.
+    # Solution based on other issue for the same bug: https://github.com/python/mypy/issues/8389.
+    return tuple(
+        (
+            voxel_size[0],
+            voxel_size[1],
+            voxel_size[2],
+        )
+    )
 
 
 _properties_floating_type_to_python_type: Dict[Union[str, type], np.dtype] = {
@@ -183,7 +196,7 @@ class SegmentationLayerProperties(LayerProperties):
 
 @attr.define
 class VoxelSize:
-    factor: Tuple[float, float, float] = attr.field(converter=tuple)
+    factor: Tuple[float, float, float] = attr.field(converter=float_tpl)
     unit: LengthUnit = DEFAULT_LENGTH_UNIT
 
     def to_nanometer(self) -> Tuple[float, float, float]:

--- a/webknossos/webknossos/dataset/properties.py
+++ b/webknossos/webknossos/dataset/properties.py
@@ -183,7 +183,7 @@ class SegmentationLayerProperties(LayerProperties):
 
 @attr.define
 class VoxelSize:
-    factor: Tuple[float, float, float]
+    factor: Tuple[float, float, float] = attr.field(converter=tuple)
     unit: LengthUnit = DEFAULT_LENGTH_UNIT
 
     def to_nanometer(self) -> Tuple[float, float, float]:


### PR DESCRIPTION
### Description:
- VoxelSize factor is supposed to be a Tuple[float, float, float] This was not enforced before. By adding a converter to the attr field the value is converted to a tuple.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
