### PR TITLE
Expose squeue polling interval to SlurmExecutor parameter and allow setting via env variable

### DIFF
--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -95,6 +95,7 @@ class ClusterExecutor(futures.Executor):
         job_resources: Optional[Dict[str, Any]] = None,
         job_name: Optional[str] = None,
         additional_setup_lines: Optional[List[str]] = None,
+        interval: Optional[int] = 2,  
         **kwargs: Any,
     ):
         """
@@ -133,7 +134,7 @@ class ClusterExecutor(futures.Executor):
         self.keep_logs = keep_logs
         self.is_shutting_down = False
 
-        self.wait_thread = FileWaitThread(self._completion, self)
+        self.wait_thread = FileWaitThread(self._completion, self, interval)
         self.wait_thread.start()
 
         os.makedirs(self.cfut_dir, exist_ok=True)

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -61,7 +61,7 @@ SLURM_STATES = {
     "Unclear": ["SUSPENDED", "REVOKED", "SIGNALING", "SPECIAL_EXIT", "STAGE_OUT"],
 }
 
-SLURM_QUEUE_CHECK_INTERVAL = 1 if "pytest" in sys.modules else 60
+SLURM_QUEUE_CHECK_INTERVAL = 1 if "pytest" in sys.modules else os.environ.get("SLURM_QUEUE_CHECK_INTERVAL", 60)
 
 T = TypeVar("T")
 
@@ -84,6 +84,7 @@ class SlurmExecutor(ClusterExecutor):
         job_resources: Optional[Dict[str, Any]] = None,
         job_name: Optional[str] = None,
         additional_setup_lines: Optional[List[str]] = None,
+        interval: Optional[int] = None,
         **kwargs: Any,
     ):
         super().__init__(
@@ -93,6 +94,7 @@ class SlurmExecutor(ClusterExecutor):
             job_resources=job_resources,
             job_name=job_name,
             additional_setup_lines=additional_setup_lines,
+            interval=interval if interval else SLURM_QUEUE_CHECK_INTERVAL, 
             **kwargs,
         )
         self.submit_threads: List["_JobSubmitThread"] = []


### PR DESCRIPTION
Hi,

we regularly run into problems with our SLURM cluster while running (very) large downsampling jobs on webknossos datasets either via CLI or chunk-wise processing of large datasets via the cluster-tools python API. In particular we get the error message:
```
 error: slurm_receive_msgs: [[$hostname]:$port] failed: Socket timed out on send/recv operation
``` 
our cluster team traced the error down to the SLURM controller being overwhelmed by the number `squeue` requests. Technically we could downscale the number of concurrent downsampling jobs, but that would negatively impact the overall cluster utilization as well as throughput.

Alternatively we searched for `squeue` commands in the cluster-tools API. We noticed the line `self.executor.get_pending_tasks()` in `file_wait_thread.py`. It seems like you already implemented a polling throttle there via the `interval` parameter but never expose the parameter to `ClusterExecutor` or `SlurmExecutor` to reduce the number of squeue calls.

Therefore I would like to propose a change where `SlurmExecutor` users can set the polling interval (in seconds) programmatically in their python program or alternatively via environment variable.

I am happy to make any additional changes to this pull request and add documentation if necessary.

Best wishes,
Eric 

### Issues:
- Expose the `FileWaitThread`'s `interval` parameter to `SlurmExecutor`
- Set the global variable `SLURM_QUEUE_CHECK_INTERVAL` via environment variable to provide the same functionality in a CLI-only setting.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
