### PR TITLE
Adapt from images to convert single file

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 - Added options `--layer-name` and `--mag` for compress command of the CLI. [#1141](https://github.com/scalableminds/webknossos-libs/pull/1141)
 - Added options `--chunk-shape` and `--chunks-per-shard` for convert command of the CLI. [#1150](https://github.com/scalableminds/webknossos-libs/pull/1150)
+- The `from_images` method of the `Dataset` supports directories and single files as `input_path` now. [#1152](https://github.com/scalableminds/webknossos-libs/pull/1152)
 
 ### Fixed
 - Fixed issue with webknossos URL and context URL being considered different when opening a remote dataset due to trailing slashes. [#1137](https://github.com/scalableminds/webknossos-libs/pull/1137)

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -238,6 +238,32 @@ def test_convert() -> None:
         assert (wkw_path / PROPERTIES_FILE_NAME).exists()
 
 
+@pytest.mark.filterwarnings("ignore::UserWarning")
+def test_convert_single_file() -> None:
+    """Tests the functionality of convert subcommand."""
+
+    result_without_args = runner.invoke(app, ["convert"])
+    assert result_without_args.exit_code == 2
+
+    with tmp_cwd():
+        origin_path = TESTDATA_DIR / "tiff" / "test.0000.tiff"
+        wkw_path = Path("wkw_from_tiff_single_file")
+
+        result = runner.invoke(
+            app,
+            [
+                "convert",
+                "--voxel-size",
+                "11.0,11.0,11.0",
+                str(origin_path),
+                str(wkw_path),
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert (wkw_path / PROPERTIES_FILE_NAME).exists()
+
+
 def test_convert_with_all_params() -> None:
     """Tests the functionality of convert subcommand."""
 

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -240,10 +240,7 @@ def test_convert() -> None:
 
 @pytest.mark.filterwarnings("ignore::UserWarning")
 def test_convert_single_file() -> None:
-    """Tests the functionality of convert subcommand."""
-
-    result_without_args = runner.invoke(app, ["convert"])
-    assert result_without_args.exit_code == 2
+    """Tests the functionality of convert subcommand when given single file instead of directory."""
 
     with tmp_cwd():
         origin_path = TESTDATA_DIR / "tiff" / "test.0000.tiff"

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -598,12 +598,12 @@ class Dataset:
         executor: Optional[Executor] = None,
     ) -> "Dataset":
         """
-        This method imports image data in a folder as a WEBKNOSSOS dataset. The
-        image data can be 3D images (such as multipage tiffs) or stacks of 2D
-        images. In case of multiple 3D images or image stacks, those are mapped
-        to different layers. The exact mapping is handled by the argument
-        `map_filepath_to_layer_name`, which can be a pre-defined strategy from
-        the enum `ConversionLayerMapping`, or a custom callable, taking
+        This method imports image data in a folder or from a file as a
+        WEBKNOSSOS dataset. The image data can be 3D images (such as multipage
+        tiffs) or stacks of 2D images. In case of multiple 3D images or image
+        stacks, those are mapped to different layers. The exact mapping is handled
+        by the argument `map_filepath_to_layer_name`, which can be a pre-defined
+        strategy from the enum `ConversionLayerMapping`, or a custom callable, taking
         a path of an image file and returning the corresponding layer name. All
         files belonging to the same layer name are then grouped. In case of
         multiple files per layer, those are usually mapped to the z-dimension.
@@ -615,7 +615,9 @@ class Dataset:
 
         The category of layers (`color` vs `segmentation`) is determined
         automatically by checking if `segmentation` is part of the path.
-        Alternatively, a category can be enforced by passing `layer_category`.
+        The category decision is evaluated and corrected after data import with a
+        data driven approach. Alternatively, a category can be enforced by passing
+        `layer_category`.
 
         Further arguments behave as in `add_layer_from_images`, please also
         refer to its documentation.

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -630,11 +630,17 @@ class Dataset:
         if use_bioformats is not False:
             valid_suffixes.update(pims_images.get_valid_bioformats_suffixes())
 
-        input_files = [
-            i.relative_to(input_upath)
-            for i in input_upath.glob("**/*")
-            if i.is_file() and i.suffix.lstrip(".").lower() in valid_suffixes
-        ]
+        if input_upath.is_dir():
+            input_files = [
+                i.relative_to(input_upath)
+                for i in input_upath.glob("**/*")
+                if i.is_file() and i.suffix.lstrip(".").lower() in valid_suffixes
+            ]
+        else:
+            if input_upath.suffix.lstrip(".").lower() in valid_suffixes:
+                input_files = [input_upath.name]
+                input_upath = input_upath.parent
+
         if len(input_files) == 0:
             raise ValueError(
                 "Could not find any supported image data. "
@@ -683,7 +689,7 @@ class Dataset:
             ), f"Could not determine a layer name for {input_file}."
 
             filepaths_per_layer.setdefault(layer_name_from_mapping, []).append(
-                input_path / input_file
+                input_upath / input_file
             )
 
         if layer_name is not None:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -638,7 +638,7 @@ class Dataset:
             ]
         else:
             if input_upath.suffix.lstrip(".").lower() in valid_suffixes:
-                input_files = [input_upath.name]
+                input_files = [UPath(input_upath.name)]
                 input_upath = input_upath.parent
 
         if len(input_files) == 0:


### PR DESCRIPTION
### Description:
- This PR adapts the `from_images` method of the `Dataset` class to convert a single image file into a layer if the `input_path` is a file rather than a directory.

### Issues:
- fixes #1149

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
