### PR TITLE
Disable PILs image size limit.

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -21,6 +21,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Added options `--layer-name` and `--mag` for compress command of the CLI. [#1141](https://github.com/scalableminds/webknossos-libs/pull/1141)
 - Added options `--chunk-shape` and `--chunks-per-shard` for convert command of the CLI. [#1150](https://github.com/scalableminds/webknossos-libs/pull/1150)
 - The `from_images` method of the `Dataset` supports directories and single files as `input_path` now. [#1152](https://github.com/scalableminds/webknossos-libs/pull/1152)
+- The number of pixel limit for JPG conversion is disabled now. [#1154](https://github.com/scalableminds/webknossos-libs/pull/1154)
 
 ### Fixed
 - Fixed issue with webknossos URL and context URL being considered different when opening a remote dataset due to trailing slashes. [#1137](https://github.com/scalableminds/webknossos-libs/pull/1137)

--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -311,6 +311,11 @@ class PimsImages:
                 + "(use_bioformats is False)."
             )
 
+    def _disable_pil_image_size_limit(self) -> None:
+        from PIL import Image
+
+        Image.MAX_IMAGE_PIXELS = None
+
     def _try_open_pims_images(
         self, original_images: Union[str, List[str]], exceptions: List[Exception]
     ) -> Optional[pims.FramesSequence]:
@@ -376,6 +381,8 @@ class PimsImages:
                 )
             else:
                 return None
+
+        self._disable_pil_image_size_limit()
 
         for strategy in [strategy_0, strategy_1, strategy_2]:
             try:


### PR DESCRIPTION
### Description:
- Conversion of JPG images with a size that exceeds 178 megapixels leaded to a `DecompressionBombError` disabling the limit prevents the occurrence of the error, but might lead to high RAM consumption during conversion.

### Issues:
- fixes #1153 
- fixes #892

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
