### PR TITLE
Require organisation id in Annotation constructor.

### DIFF
--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -51,6 +51,7 @@ from upath import UPath
 from zipp import Path as ZipPath
 
 import webknossos._nml as wknml
+from webknossos.client.context import _get_context
 
 from ..dataset import (
     SEGMENTATION_CATEGORY,
@@ -149,6 +150,11 @@ class Annotation:
             assert (
                 self._voxel_size is not None
             ), "Please supply a voxel_size for Annotation()."
+            if self._organization_id is None:
+                self._organization_id = _get_context().organization_id
+            assert (
+                self._organization_id is not None
+            ), "Please supply an organization_id for Annotation()."
             self.skeleton = Skeleton(
                 dataset_name=self._dataset_name,
                 voxel_size=self._voxel_size,


### PR DESCRIPTION
### Description:
- When calling the `Annotation()` constructor, an `organisation_id` is mandatory now. The `organization_id` might be provided directly within the `Annotation()` call, or it is inferred from current webknossos context.

### Issues:
- fixes #1015

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
