### PR TITLE
Remove trailing slash from search path for remote folders.

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -28,6 +28,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Fixed
 - Fixed issue with webknossos URL and context URL being considered different when opening a remote dataset due to trailing slashes. [#1137](https://github.com/scalableminds/webknossos-libs/pull/1137)
+- Fix an issue where the remote folder was not found when the folder path query includes a trailing slash. [#1164](https://github.com/scalableminds/webknossos-libs/pull/1164)
 
 
 ## [0.14.26](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.14.26) - 2024-07-22

--- a/webknossos/webknossos/dataset/remote_folder.py
+++ b/webknossos/webknossos/dataset/remote_folder.py
@@ -37,6 +37,7 @@ class RemoteFolder:
     def get_by_path(cls, path: str) -> "RemoteFolder":
         from ..client.context import _get_api_client
 
+        path = path.rstrip("/")
         client = _get_api_client(enforce_auth=True)
         folder_tree_response: List[ApiFolderWithParent] = client.folder_tree()
 


### PR DESCRIPTION
### Description:
- Fix an issue where the remote folder was not found when the folder path query includes a trailing slash.

### Issues:
- fixes #1161

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
