### PR TITLE
Typo in help strings: Typer flag equals variable name with minus instead of underscore

### DIFF
--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -65,7 +65,7 @@ webknossos convert-raw --layer-name color --voxel-size 10,10,30 --dtype uint8 --
 
 ### Parallelization
 
-Most tasks can be configured to be executed in a parallelized manner. Via `--distribution_strategy` you can pass `multiprocessing`, `slurm` or `kubernetes`. The first can be further configured with `--jobs` and the latter via `--job_resources='{"mem": "10M"}'`. Use `--help` to get more information.
+Most tasks can be configured to be executed in a parallelized manner. Via `--distribution_strategy` you can pass `multiprocessing`, `slurm` or `kubernetes`. The first can be further configured with `--jobs` and the latter via `--job-resources='{"mem": "10M"}'`. Use `--help` to get more information.
 
 
 ## Development

--- a/docs/src/cli/index.md
+++ b/docs/src/cli/index.md
@@ -65,7 +65,7 @@ webknossos convert-raw --layer-name color --voxel-size 10,10,30 --dtype uint8 --
 
 ### Parallelization
 
-Most tasks can be configured to be executed in a parallelized manner. Via `--distribution_strategy` you can pass `multiprocessing`, `slurm` or `kubernetes`. The first can be further configured with `--jobs` and the latter via `--job-resources='{"mem": "10M"}'`. Use `--help` to get more information.
+Most tasks can be configured to be executed in a parallelized manner. Via `--distribution-strategy` you can pass `multiprocessing`, `slurm` or `kubernetes`. The first can be further configured with `--jobs` and the latter via `--job-resources='{"mem": "10M"}'`. Use `--help` to get more information.
 
 
 ## Development

--- a/webknossos/webknossos/cli/check_equality.py
+++ b/webknossos/webknossos/cli/check_equality.py
@@ -57,7 +57,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/compress.py
+++ b/webknossos/webknossos/cli/compress.py
@@ -58,7 +58,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/convert.py
+++ b/webknossos/webknossos/cli/convert.py
@@ -129,7 +129,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/convert_knossos.py
+++ b/webknossos/webknossos/cli/convert_knossos.py
@@ -320,7 +320,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/convert_raw.py
+++ b/webknossos/webknossos/cli/convert_raw.py
@@ -254,7 +254,7 @@ def main(
         Optional[str],
         typer.Option(
             help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/convert_zarr.py
+++ b/webknossos/webknossos/cli/convert_zarr.py
@@ -237,7 +237,7 @@ When converting a folder, this option is ignored."
         Optional[str],
         typer.Option(
             help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/downsample.py
+++ b/webknossos/webknossos/cli/downsample.py
@@ -49,7 +49,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/export_wkw_as_tiff.py
+++ b/webknossos/webknossos/cli/export_wkw_as_tiff.py
@@ -253,7 +253,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -60,7 +60,7 @@ def main(
         Optional[str],
         typer.Option(
             help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/cli/upsample.py
+++ b/webknossos/webknossos/cli/upsample.py
@@ -58,7 +58,7 @@ Should be number or minus separated string (e.g. 2 or 2-2-2).",
         Optional[str],
         typer.Option(
             help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job_resources=\'{"mem": "10M"}\')\'',
+(e.g., --job-resources=\'{"mem": "10M"}\')\'',
             rich_help_panel="Executor options",
         ),
     ] = None,

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -82,7 +82,7 @@ def get_executor_for_args(
                 else '{"memory": "1G"}'
             )
             raise argparse.ArgumentTypeError(
-                f"Job resources (--job_resources) has to be provided when using {args.distribution_strategy} as distribution strategy. Example: --job_resources='{resources_example}'"
+                f"Job resources (--job-resources) has to be provided when using {args.distribution_strategy} as distribution strategy. Example: --job-resources='{resources_example}'"
             )
 
         executor = get_executor(


### PR DESCRIPTION
The help strings for the `--job-resources` cli flag have a typo due to the `typer` [behavior](https://typer.tiangolo.com/tutorial/options/name/#cli-option-name) to convert variables with underscores into cli flags with minus.