### PR TITLE
Deactivate tests that fail due to a vcr-py issue

### DIFF
--- a/webknossos/tests/test_examples.py
+++ b/webknossos/tests/test_examples.py
@@ -221,6 +221,7 @@ class _DummyNearestNeighborClassifier:
         return self.labels[nearest_neighbors]
 
 
+@pytest.mark.skip("This test currently fails due to a bug with vcr-py")
 @pytest.mark.block_network(allowed_hosts=[".*"])
 @pytest.mark.vcr(ignore_hosts=["webknossos.org", "data-humerus.webknossos.org"])
 def test_learned_segmenter() -> None:
@@ -275,6 +276,7 @@ def test_remote_datasets() -> None:
     assert ds in wk.Dataset.get_remote_datasets(tags=["test"]).values()
 
 
+@pytest.mark.skip("This test currently fails due to a bug with vcr-py")
 @pytest.mark.block_network(allowed_hosts=[".*"])
 @pytest.mark.vcr(ignore_hosts=["webknossos.org", "data-humerus.webknossos.org"])
 @pytest.mark.skipif(
@@ -310,6 +312,7 @@ def test_upload_dicom_stack() -> None:
         )
 
 
+@pytest.mark.skip("This test currently fails due to a bug with vcr-py")
 @pytest.mark.block_network(allowed_hosts=[".*"])
 @pytest.mark.vcr(ignore_hosts=["webknossos.org", "data-humerus.webknossos.org"])
 def test_download_segments() -> None:
@@ -327,6 +330,7 @@ def test_download_segments() -> None:
         )
 
 
+@pytest.mark.skip("This test currently fails due to a bug with vcr-py")
 @pytest.mark.block_network(allowed_hosts=[".*"])
 @pytest.mark.vcr(ignore_hosts=["webknossos.org", "data-humerus.webknossos.org"])
 def test_download_tiff_stack() -> None:


### PR DESCRIPTION
### Description:
- Some tests fail due to an issue with vcr-py. They are deactivated until a fix for the issue is found.