### PR TITLE
Announce dataset creation with API

### DIFF
--- a/webknossos/webknossos/client/api_client/wk_api_client.py
+++ b/webknossos/webknossos/client/api_client/wk_api_client.py
@@ -207,3 +207,14 @@ class WkApiClient(AbstractApiClient):
         return self.post_multipart_with_json_response(
             route, ApiTaskCreationResult, multipart_data=data, files=files
         )
+
+    def trigger_reload(
+        self,
+        organization_name: str,
+        dataset_name: str,
+        sharing_token: Optional[str] = None,
+    ):
+        route = (
+            f"/triggers/reload/{organization_name}/{dataset_name}?token={sharing_token}"
+        )
+        self._post(route)


### PR DESCRIPTION
### Description:
- Announce a dataset via the wk API before writing it to the file system. Team managers can create an entry in the database with the dataset name and assign a team, non-privileged webknossos users can then access their datasets.

### Issues:
- fixes #1138

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
