### PR TITLE
format doc strings as Google style

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -172,7 +172,7 @@ plugins:
             python:
                 options:
                     show_source: false
-                    docstring_style: null
+                    docstring_style: google
                     docstring_section_style: list
                     heading_level: 1
                     inherited_members: true

--- a/docs/src/webknossos-py/examples/dataset_usage.md
+++ b/docs/src/webknossos-py/examples/dataset_usage.md
@@ -7,7 +7,7 @@ The [`Dataset` class](../../api/webknossos/dataset/dataset.md) is the entry-poin
 The dataset stores the data on disk in `.wkw`-files.
 
 Each dataset consists of one or more [layers](../../api/webknossos/dataset/layer.md),
-which themselves can comprise multiple [magnifications represented via `MagView`s](../../api/webknossos/dataset/magview.md).
+which themselves can comprise multiple [magnifications represented via `MagView`s](../../api/webknossos/dataset/mag_view.md).
 
 ```python
 --8<--

--- a/docs/src/webknossos-py/examples/download_image_data.md
+++ b/docs/src/webknossos-py/examples/download_image_data.md
@@ -1,6 +1,6 @@
 # Download Image Data
 
-Downloads part of a [webknossos dataset](https://webknossos.org/datasets/scalable_minds/l4dense_motta_et_al_demo/view) from [webknossos.org](https://webknossos.org) using [`webknossos_context`](../../api/webknossos/client/webknossos_context.md#webknossos.client.context.webknossos_context).
+Downloads part of a [webknossos dataset](https://webknossos.org/datasets/scalable_minds/l4dense_motta_et_al_demo/view) from [webknossos.org](https://webknossos.org) using [`webknossos_context`](../../api/webknossos/client/context.md#webknossos.client.context.webknossos_context).
 
 ```python
 --8<--

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -224,7 +224,12 @@ class BoundingBox(NDBoundingBox):
     def _align_with_mag_slow(self, mag: Mag, ceil: bool = False) -> "BoundingBox":
         """Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
 
-        :argument ceil: If true, the bounding box is enlarged when necessary. If false, it's shrunk when necessary.
+        Args:
+            mag (Mag): The mag to align with.
+            ceil (bool): If true, the bounding box is enlarged when necessary. If false, it's shrunk when necessary.
+
+        Returns:
+            BoundingBox: The aligned bounding box.
         """
         np_mag = mag.to_np()
 
@@ -244,7 +249,12 @@ class BoundingBox(NDBoundingBox):
     ) -> "BoundingBox":
         """Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
 
-        :argument ceil: If true, the bounding box is enlarged when necessary. If false, it's shrunk when necessary.
+        Args:
+            mag (Mag): The mag to align with.
+            ceil (bool): If true, the bounding box is enlarged when necessary. If false, it's shrunk when necessary.
+
+        Returns:
+            BoundingBox: The aligned bounding box.
         """
         # This does the same as _align_with_mag_slow, which is more readable.
         # Same behavior is asserted in test_align_with_mag_against_numpy_implementation

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -210,7 +210,7 @@ class NDBoundingBox:
 
         Args:
             color (Optional[Tuple[float, float, float, float]]): The color to set for the bounding box.
-            The color should be specified as a tuple of four floats representing RGBA values.
+                The color should be specified as a tuple of four floats representing RGBA values.
 
         Returns:
             NDBoundingBox: A new instance of NDBoundingBox with the specified color.

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -134,10 +134,10 @@ class NDBoundingBox:
         Returns a new instance of `NDBoundingBox` with the specified name.
 
         Args:
-        - name (Optional[str]): The name to assign to the new `NDBoundingBox` instance.
+            name (Optional[str]): The name to assign to the new `NDBoundingBox` instance.
 
         Returns:
-        - NDBoundingBox: A new instance of `NDBoundingBox` with the specified name.
+            NDBoundingBox: A new instance of `NDBoundingBox` with the specified name.
         """
         return attr.evolve(self, name=name)
 
@@ -146,10 +146,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with the specified top left coordinates.
 
         Args:
-        - new_topleft (VecIntLike): The new top left coordinates for the bounding box.
+            new_topleft (VecIntLike): The new top left coordinates for the bounding box.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated top left coordinates.
+            NDBoundingBox: A new NDBoundingBox object with the updated top left coordinates.
         """
         return attr.evolve(self, topleft=VecInt(new_topleft, axes=self.axes))
 
@@ -158,10 +158,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with the specified size.
 
         Args:
-        - new_size (VecIntLike): The new size of the bounding box. Can be a VecInt or any object that can be converted to a VecInt.
+            new_size (VecIntLike): The new size of the bounding box. Can be a VecInt or any object that can be converted to a VecInt.
 
         Returns:
-        - A new NDBoundingBox object with the specified size.
+            A new NDBoundingBox object with the specified size.
         """
         return attr.evolve(self, size=VecInt(new_size, axes=self.axes))
 
@@ -170,10 +170,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with the specified index.
 
         Args:
-        - new_index (VecIntLike): The new axis order for the bounding box.
+            new_index (VecIntLike): The new axis order for the bounding box.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated index.
+            NDBoundingBox: A new NDBoundingBox object with the updated index.
         """
         axes, _ = zip(*sorted(zip(self.axes, new_index), key=lambda x: x[1]))
         return attr.evolve(self, index=VecInt(new_index, axes=axes))
@@ -183,10 +183,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox with an updated bottomright value.
 
         Args:
-        - new_bottomright (VecIntLike): The new bottom right corner coordinates.
+            new_bottomright (VecIntLike): The new bottom right corner coordinates.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated bottom right corner.
+            NDBoundingBox: A new NDBoundingBox object with the updated bottom right corner.
         """
         new_size = VecInt(new_bottomright, axes=self.axes) - self.topleft
 
@@ -197,10 +197,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with the specified visibility.
 
         Args:
-        - is_visible (bool): The visibility value to set.
+            is_visible (bool): The visibility value to set.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated visibility value.
+            NDBoundingBox: A new NDBoundingBox object with the updated visibility value.
         """
         return attr.evolve(self, is_visible=is_visible)
 
@@ -209,11 +209,11 @@ class NDBoundingBox:
         Returns a new instance of NDBoundingBox with the specified color.
 
         Args:
-        - color (Optional[Tuple[float, float, float, float]]): The color to set for the bounding box.
+            color (Optional[Tuple[float, float, float, float]]): The color to set for the bounding box.
             The color should be specified as a tuple of four floats representing RGBA values.
 
         Returns:
-        - NDBoundingBox: A new instance of NDBoundingBox with the specified color.
+            NDBoundingBox: A new instance of NDBoundingBox with the specified color.
         """
         return attr.evolve(self, color=color)
 
@@ -224,15 +224,15 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with updated bounds along the specified axis.
 
         Args:
-        - axis (str): The name of the axis to update.
-        - new_topleft (Optional[int]): The new value for the top-left coordinate along the specified axis.
-        - new_size (Optional[int]): The new size along the specified axis.
+            axis (str): The name of the axis to update.
+            new_topleft (Optional[int]): The new value for the top-left coordinate along the specified axis.
+            new_size (Optional[int]): The new size along the specified axis.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with updated bounds.
+            NDBoundingBox: A new NDBoundingBox object with updated bounds.
 
         Raises:
-        - ValueError: If the given axis name does not exist.
+            ValueError: If the given axis name does not exist.
 
         """
         try:
@@ -258,10 +258,10 @@ class NDBoundingBox:
         Returns the bounds of the given axis.
 
         Args:
-        - axis (str): The name of the axis to get the bounds for.
+            axis (str): The name of the axis to get the bounds for.
 
         Returns:
-        - Tuple[int, int]: A tuple containing the top-left and bottom-right coordinates along the specified axis.
+            Tuple[int, int]: A tuple containing the top-left and bottom-right coordinates along the specified axis.
         """
         try:
             index = self.axes.index(axis)
@@ -295,13 +295,13 @@ class NDBoundingBox:
         Create an instance of NDBoundingBox from a dictionary representation.
 
         Args:
-        - bbox (Dict): The dictionary representation of the bounding box.
+            bbox (Dict): The dictionary representation of the bounding box.
 
         Returns:
-        - NDBoundingBox: An instance of NDBoundingBox.
+            NDBoundingBox: An instance of NDBoundingBox.
 
         Raises:
-        - AssertionError: If additionalAxes are present but axisOrder is not provided.
+            AssertionError: If additionalAxes are present but axisOrder is not provided.
         """
 
         topleft: Tuple[int, ...] = bbox["topLeft"]
@@ -335,7 +335,7 @@ class NDBoundingBox:
         Converts the bounding box object to a json dictionary.
 
         Returns:
-        - dict: A json dictionary representing the bounding box.
+            dict: A json dictionary representing the bounding box.
         """
         topleft = [None, None, None]
         width, height, depth = None, None, None
@@ -378,7 +378,7 @@ class NDBoundingBox:
         Returns a dictionary representation of the bounding box.
 
         Returns:
-        - dict: A dictionary representation of the bounding box.
+            dict: A dictionary representation of the bounding box.
         """
         return {
             "topleft": self.topleft.to_list(),
@@ -391,7 +391,7 @@ class NDBoundingBox:
         Returns a string representation of the bounding box that can be used as a checkpoint name.
 
         Returns:
-        - str: A string representation of the bounding box.
+            str: A string representation of the bounding box.
         """
         return f"{'_'.join(str(element) for element in self.topleft)}_{'_'.join(str(element) for element in self.size)}"
 
@@ -416,10 +416,10 @@ class NDBoundingBox:
         Returns the size of the bounding box along the specified axis.
 
         Args:
-        - axis_name (str): The name of the axis to get the size for.
+            axis_name (str): The name of the axis to get the size for.
 
         Returns:
-        - int: The size of the bounding box along the specified axis.
+            int: The size of the bounding box along the specified axis.
         """
         try:
             index = self.axes.index(axis_name)
@@ -479,10 +479,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with changed x, y and z coordinates of the topleft corner.
 
         Args:
-        - new_xyz (Vec3IntLike): The new x, y and z coordinates for the topleft corner.
+            new_xyz (Vec3IntLike): The new x, y and z coordinates for the topleft corner.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated x, y and z coordinates of the topleft corner.
+            NDBoundingBox: A new NDBoundingBox object with the updated x, y and z coordinates of the topleft corner.
         """
         new_topleft = self._get_attr_with_replaced_xyz("topleft", new_xyz)
 
@@ -493,10 +493,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with changed x, y and z size.
 
         Args:
-        - new_xyz (Vec3IntLike): The new x, y and z size for the bounding box.
+            new_xyz (Vec3IntLike): The new x, y and z size for the bounding box.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated x, y and z size.
+            NDBoundingBox: A new NDBoundingBox object with the updated x, y and z size.
         """
         new_size = self._get_attr_with_replaced_xyz("size", new_xyz)
 
@@ -507,10 +507,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with changed x, y and z coordinates of the bottomright corner.
 
         Args:
-        - new_xyz (Vec3IntLike): The new x, y and z coordinates for the bottomright corner.
+            new_xyz (Vec3IntLike): The new x, y and z coordinates for the bottomright corner.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated x, y and z coordinates of the bottomright corner.
+            NDBoundingBox: A new NDBoundingBox object with the updated x, y and z coordinates of the bottomright corner.
         """
         new_bottomright = self._get_attr_with_replaced_xyz("bottomright", new_xyz)
 
@@ -521,10 +521,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with changed x, y and z index.
 
         Args:
-        - new_xyz (Vec3IntLike): The new x, y and z index for the bounding box.
+            new_xyz (Vec3IntLike): The new x, y and z index for the bounding box.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the updated x, y and z index.
+            NDBoundingBox: A new NDBoundingBox object with the updated x, y and z index.
         """
         new_index = self._get_attr_with_replaced_xyz("index", new_xyz)
 
@@ -558,11 +558,11 @@ class NDBoundingBox:
         If dont_assert is set to False, this method may return empty bounding boxes (size == (0, 0, 0))
 
         Args:
-        - other (NDBoundingBox): The other bounding box to intersect with.
-        - dont_assert (bool): If True, the method may return empty bounding boxes.
+            other (NDBoundingBox): The other bounding box to intersect with.
+            dont_assert (bool): If True, the method may return empty bounding boxes.
 
         Returns:
-        - NDBoundingBox: The intersection of the two bounding boxes.
+            NDBoundingBox: The intersection of the two bounding boxes.
         """
 
         self._check_compatibility(other)
@@ -584,10 +584,10 @@ class NDBoundingBox:
         Returns the smallest bounding box that contains both bounding boxes.
 
         Args:
-        - other (NDBoundingBox): The other bounding box to extend with.
+            other (NDBoundingBox): The other bounding box to extend with.
 
         Returns:
-        - NDBoundingBox: The smallest bounding box that contains both bounding boxes.
+            NDBoundingBox: The smallest bounding box that contains both bounding boxes.
         """
         self._check_compatibility(other)
         if self.is_empty():
@@ -606,7 +606,7 @@ class NDBoundingBox:
         Boolean check whether the boundung box is empty.
 
         Returns:
-        - bool: True if the bounding box is empty, False otherwise.
+            bool: True if the bounding box is empty, False otherwise.
         """
         return not self.size.is_positive(strictly_positive=True)
 
@@ -615,10 +615,10 @@ class NDBoundingBox:
         Returns the bounding box in the given mag.
 
         Args:
-        - mag (Mag): The magnification to convert the bounding box to.
+            mag (Mag): The magnification to convert the bounding box to.
 
         Returns:
-        - NDBoundingBox: The bounding box in the given magnification.
+            NDBoundingBox: The bounding box in the given magnification.
         """
         mag_vec = mag.to_vec3_int()
 
@@ -638,10 +638,10 @@ class NDBoundingBox:
         Returns the bounging box in the finest magnification (Mag(1)).
 
         Args:
-        - from_mag (Mag): The current magnification of the bounding box.
+            from_mag (Mag): The current magnification of the bounding box.
 
         Returns:
-        - NDBoundingBox: The bounding box in the given magnification.
+            NDBoundingBox: The bounding box in the given magnification.
         """
         mag_vec = from_mag.to_vec3_int()
 
@@ -674,11 +674,11 @@ class NDBoundingBox:
         Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
 
         Args:
-        - mag (Union[Mag, Vec3Int]): The magnification to align the bounding box to.
-        - ceil (bool): If True, the bounding box is enlarged when necessary. If False, it's shrunk when necessary.
+            mag (Union[Mag, Vec3Int]): The magnification to align the bounding box to.
+            ceil (bool): If True, the bounding box is enlarged when necessary. If False, it's shrunk when necessary.
 
         Returns:
-        - NDBoundingBox: The aligned bounding box.
+            NDBoundingBox: The aligned bounding box.
         """
         # This does the same as _align_with_mag_slow, which is more readable.
         # Same behavior is asserted in test_align_with_mag_against_numpy_implementation
@@ -706,10 +706,10 @@ class NDBoundingBox:
         Note that the point may have float coordinates in the ndarray case
 
         Args:
-        - coord (VecIntLike): The coordinates to check.
+            coord (VecIntLike): The coordinates to check.
 
         Returns:
-        - bool: True if the point is inside of the bounding box, False otherwise.
+            bool: True if the point is inside of the bounding box, False otherwise.
         """
 
         if isinstance(coord, np.ndarray):
@@ -735,10 +735,10 @@ class NDBoundingBox:
         Check whether a bounding box is completely inside of the bounding box.
 
         Args:
-        - inner_bbox (NDBoundingBox): The bounding box to check.
+            inner_bbox (NDBoundingBox): The bounding box to check.
 
         Returns:
-        - bool: True if the bounding box is completely inside of the bounding box, False otherwise.
+            bool: True if the bounding box is completely inside of the bounding box, False otherwise.
         """
         self._check_compatibility(inner_bbox)
         return inner_bbox.intersected_with(self, dont_assert=True) == inner_bbox
@@ -756,12 +756,12 @@ class NDBoundingBox:
         *between two chunks* will be divisible by that value.
 
         Args:
-        - chunk_shape (VecIntLike): The size of the chunks to generate.
-        - chunk_border_alignments (Optional[VecIntLike]): The alignment of the chunk borders.
+            chunk_shape (VecIntLike): The size of the chunks to generate.
+            chunk_border_alignments (Optional[VecIntLike]): The alignment of the chunk borders.
 
 
         Yields:
-        - Generator[NDBoundingBox]: A generator of the chunks.
+            Generator[NDBoundingBox]: A generator of the chunks.
         """
 
         start = self.topleft.to_np()
@@ -878,10 +878,10 @@ class NDBoundingBox:
         Returns a new NDBoundingBox object with the specified offset.
 
         Args:
-        - vector (VecIntLike): The offset to apply to the bounding box.
+            vector (VecIntLike): The offset to apply to the bounding box.
 
         Returns:
-        - NDBoundingBox: A new NDBoundingBox object with the specified offset.
+            NDBoundingBox: A new NDBoundingBox object with the specified offset.
         """
         try:
             return self.with_topleft_xyz(self.topleft_xyz + Vec3Int(vector))

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -652,7 +652,12 @@ class NDBoundingBox:
     def _align_with_mag_slow(self: _T, mag: Mag, ceil: bool = False) -> _T:
         """Rounds the bounding box, so that both topleft and bottomright are divisible by mag.
 
-        :argument ceil: If true, the bounding box is enlarged when necessary. If false, it's shrunk when necessary.
+        Args:
+            mag (Mag): The mag to align the bounding box to.
+            ceil (bool): If True, the bounding box is enlarged when necessary. If False, it's shrunk when necessary.
+
+        Returns:
+            NDBoundingBox: The aligned bounding box.
         """
         np_mag = mag.to_np()
 

--- a/webknossos/webknossos/geometry/vec_int.py
+++ b/webknossos/webknossos/geometry/vec_int.py
@@ -126,10 +126,10 @@ class VecInt(tuple):
         Returns a new ND Vector from a string representation.
 
         Args:
-        - string (str): The string representation of the vector.
+            string (str): The string representation of the vector.
 
         Returns:
-        - VecInt: The new vector.
+            VecInt: The new vector.
         """
         return VecInt(tuple(map(int, re.findall(r"\d+", string))))
 
@@ -169,10 +169,10 @@ class VecInt(tuple):
         Checks if all elements in the vector are positive.
 
         Args:
-        - strictly_positive (bool): If True, checks if all elements are strictly positive.
+            strictly_positive (bool): If True, checks if all elements are strictly positive.
 
         Returns:
-        - bool: True if all elements are positive, False otherwise.
+            bool: True if all elements are positive, False otherwise.
         """
         if strictly_positive:
             return all(i > 0 for i in self)
@@ -260,10 +260,10 @@ class VecInt(tuple):
         Adds two VecInts or returns None if the other is None.
 
         Args:
-        - other (Optional[VecInt]): The other vector to add.
+            other (Optional[VecInt]): The other vector to add.
 
         Returns:
-        - Optional[VecInt]: The sum of the two vectors or None if the other is None.
+            Optional[VecInt]: The sum of the two vectors or None if the other is None.
         """
         return None if other is None else self + other
 
@@ -276,11 +276,11 @@ class VecInt(tuple):
         source so that the other elements move when necessary.
 
         Args:
-        - source (Union[int, List[int]]): The index of the element to move.
-        - target (Union[int, List[int]]): The index where the element should be moved to.
+            source (Union[int, List[int]]): The index of the element to move.
+            target (Union[int, List[int]]): The index where the element should be moved to.
 
         Returns:
-        - VecInt: A new vector with the moved element.
+            VecInt: A new vector with the moved element.
         """
 
         # Piggy-back on np.moveaxis by creating an auxiliary array where the indices 0, 1 and
@@ -298,10 +298,10 @@ class VecInt(tuple):
         Returns a new ND Vector with all elements set to 0.
 
         Args:
-        - axes (Tuple[str, ...]): The axes of the vector.
+            axes (Tuple[str, ...]): The axes of the vector.
 
         Returns:
-        - VecInt: The new vector.
+            VecInt: The new vector.
         """
         return cls((0 for _ in range(len(axes))), axes=axes)
 
@@ -311,10 +311,10 @@ class VecInt(tuple):
         Returns a new ND Vector with all elements set to 1.
 
         Args:
-        - axes (Tuple[str, ...]): The axes of the vector.
+            axes (Tuple[str, ...]): The axes of the vector.
 
         Returns:
-        - VecInt: The new vector.
+            VecInt: The new vector.
         """
         return cls((1 for _ in range(len(axes))), axes=axes)
 
@@ -324,11 +324,11 @@ class VecInt(tuple):
         Returns a new ND Vector with all elements set to the same value.
 
         Args:
-        - an_int (int): The value to set all elements to.
-        - axes (Tuple[str, ...]): The axes of the vector.
+            an_int (int): The value to set all elements to.
+            axes (Tuple[str, ...]): The axes of the vector.
 
         Returns:
-        - VecInt: The new vector.
+            VecInt: The new vector.
         """
         return cls((an_int for _ in range(len(axes))), axes=axes)
 


### PR DESCRIPTION
### Description:
- Reformat some doc string to follow the [Google style guide](https://google.github.io/styleguide/pyguide.html) and update the API doc rendering. Fixed some wrong document links.

## Before
<img width="820" alt="Screenshot 2024-09-03 at 14 01 33" src="https://github.com/user-attachments/assets/43389c48-76d6-4bb2-88f8-cd82fdf827e2">

## After
<img width="830" alt="Screenshot 2024-09-03 at 14 02 22" src="https://github.com/user-attachments/assets/b4d26fad-2a6e-4077-89c6-8cb1ea45f571">


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
