### PR TITLE
Deactivate truncate_rgba_to_rgb in from_images conversion

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -13,6 +13,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v0.15.2...HEAD)
 
 ### Breaking Changes
+- Conversion of images with 4 channels creates a dataset with four layers instead of a dataset with one RGB layer. [#1192](https://github.com/scalableminds/webknossos-libs/pull/1192)
 
 ### Added
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -787,6 +787,7 @@ class Dataset:
                         batch_size=batch_size,
                         allow_multiple_layers=True,
                         max_layers=max_layers - len(ds.layers),
+                        truncate_rgba_to_rgb=False,
                         executor=executor,
                     )
 


### PR DESCRIPTION
### Description:
- A dataset with 4 channels was previously converted to a dataset with one uint48 layer, instead it should become a dataset with four uint16 layers. 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
