### PR TITLE
Add GA workflow to verify the wk package installation

### DIFF
--- a/.github/workflows/verify_published.yml
+++ b/.github/workflows/verify_published.yml
@@ -1,0 +1,42 @@
+name: Verify Published Package
+
+# Verifies that the published webknossos package on PyPi.org can be installed and imported 
+# across different Python versions. Tests both basic installation and "all" optional
+# dependencies. Runs nightly to ensure consistent package availability.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # Run every night at midnight
+  workflow_dispatch:  # Allow manual trigger
+
+jobs:
+  verify-published:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12", "3.11", "3.10", "3.9"]
+        extras: ["", "[all]"]
+    steps:
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Create virtual environment
+        run: |
+          python -m venv .venv
+          source .venv/bin/activate
+
+      - name: Install webknossos
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install webknossos${{ matrix.extras }}
+
+      - name: Verify installation
+        run: |
+          python -c "import webknossos; print(f'webknossos version: {webknossos.__version__}')"
+          
+          if [ "${{ matrix.extras }}" = "[all]" ]; then
+            # Verify some of the optional dependencies are available
+            python -c "import tifffile; from pylibCZIrw import czi;"
+          fi

--- a/.github/workflows/verify_published.yml
+++ b/.github/workflows/verify_published.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Verify installation
         run: |
-          python -c "import webknossos; print(f'webknossos version: {webknossos.__version__}')"
+          python -c "import webknossos; from webknossos import version; print(f'webknossos version: {version.__version__}')"
           
           if [ "${{ matrix.extras }}" = "[all]" ]; then
             # Verify some of the optional dependencies are available


### PR DESCRIPTION
### Description:
- Added a nightly GitHub Actions workflow to verify the `webknossos` package installation from PyPi.org works. Hopefully this should prevent (hidden) issues with `pip` version resolution.
- As a first result, we discovered the `pip install webknossos[all]` does not work out of the box for Python 3.12. See [Slack](https://scm.slack.com/archives/C02Q35Q28P5/p1732196612012389).
- "successful" CI run: https://github.com/scalableminds/webknossos-libs/actions/runs/11935233158


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [x] Added / Updated Tests
 - [ ] Considered adding this to the Examples
