### PR TITLE
Fix install "all extras" for Python 3.12 

### DIFF
--- a/docs/src/webknossos-py/installation.md
+++ b/docs/src/webknossos-py/installation.md
@@ -17,8 +17,8 @@ For extended file format conversation support it is necessary to install the opt
 pip install "webknossos[all]"
 ```
 
-If you have issues with installing the `pylibczirw` package on macOS, try:
+For working with Zeiss CZI microscopy data utilizing the`pylibczirw` package run:
 
 ```bash
-pip install --extra-index-url https://pypi.scm.io/simple/ "webknossos[all]"
+pip install --extra-index-url https://pypi.scm.io/simple/ "webknossos[czi]"
 ```

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+Removed the CZI installation extra from `pip install webknossos[all]` by default. Users need to manually install it with `pip install --extra-index-url https://pypi.scm.io/simple/ webknossos[czi]`. [#1219](https://github.com/scalableminds/webknossos-libs/pull/1219)
 
 ### Fixed
 

--- a/webknossos/README.md
+++ b/webknossos/README.md
@@ -36,7 +36,9 @@ You can install it from [pypi](https://pypi.org/project/webknossos/), e.g. via p
 pip install webknossos
 ```
 
-To install `webknossos` with the depencies for all examples, support for CZI files, and BioFormats conversions, run: `pip install webknossos[all]`.
+To install `webknossos` with the dependencies for all examples, support for more file types, and BioFormats conversions, run: `pip install webknossos[all]`.
+
+For working with Zeiss CZI microscopy data use `pip install --extra-index-url https://pypi.scm.io/simple/ webknossos[czi]`.
 
 By default `webknossos` can only distribute any computations through multiprocessing or Slurm. For Kubernetes or Dask install these additional dependencies:
 

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -23,6 +23,10 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Visualization",
     "Topic :: Software Development :: Libraries",
     "Typing :: Typed",
+    "Programming Language :: Python :: 3.9", 
+    "Programming Language :: Python :: 3.10", 
+    "Programming Language :: Python :: 3.11", 
+    "Programming Language :: Python :: 3.12", 
 ]
 
 requires-python = ">=3.9,<3.13"
@@ -81,7 +85,6 @@ all = [
     "webknossos[tifffile]",
     "webknossos[imagecodecs]",
     "webknossos[bioformats]",
-    "webknossos[czi]",
     "webknossos[examples]",
 ]
 

--- a/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_czi_reader.py
@@ -10,7 +10,7 @@ try:
     from pylibCZIrw import czi as pyczi
 except ImportError as e:
     raise ImportError(
-        "Cannot import pylibCZIrw, please install it e.g. using 'webknossos[czi]'"
+        "Cannot import pylibCZIrw, please install it e.g. using pip install --extra-index-url https://pypi.scm.io/simple/ webknossos[czi]"
     ) from e
 
 PIXEL_TYPE_TO_DTYPE = {

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -824,7 +824,7 @@ class Dataset:
 
         Note:
             This method needs extra packages like tifffile or pylibczirw.
-            Install with `python -m pip install "webknossos[all]"`.
+            Install with `pip install "webknossos[all]"` and `pip install --extra-index-url https://pypi.scm.io/simple/ "webknossos[czi]"`.
         """
 
         input_upath = UPath(input_path)


### PR DESCRIPTION
### Description:
- This PR fixes the installation for `pip install webknossos[all]` for Python 3.12
- The main issue is that the "extras" group all includes the extra `czi` which in turn installs `pylibCZIrw`. 
  - `pylibCZIrw` is only available for Python <= 3.11. There is an [open issue to support Py 3.12](https://github.com/ZEISS/pylibczirw/issues/47).
  - alternatively, users can manually install `pip install --extra-index-url https://pypi.scm.io/simple/ webknossos[czi]` which works with Python 3.12 and MacOS
  - Update README and documentation to match
  - Unrelated: restored "classifiers" on PyPI page and consequently should fix the little icon badge in the README.

### Test
- in a clean Python 3.12 environment run:
```
cd webknossos
uv build
pip install dist/webknosssos*.wheel
```

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
