### PR TITLE
Fix "verify published" CI workflow

### DIFF
--- a/.github/workflows/verify_published.yml
+++ b/.github/workflows/verify_published.yml
@@ -38,5 +38,5 @@ jobs:
           
           if [ "${{ matrix.extras }}" = "[all]" ]; then
             # Verify some of the optional dependencies are available
-            python -c "import tifffile; from pylibCZIrw import czi;"
+            python -c "import tifffile; import imagecodecs; import pandas;"
           fi


### PR DESCRIPTION
### Description:
- Fix the nightly "verify published" CI workflow. 
- `pylibczi` was removed from the installation with `all` extras in PR #1219. 

### Issues:
- fixes Nighlty GitHub Actions workflow "Verify Pubished Package"
- https://github.com/scalableminds/webknossos-libs/actions/runs/12021324535/job/33511607526

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
