### PR TITLE
set cafile when rebuilding the ssl context

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed unpickling of the SSL_Context to allow for a second or third pickling. [#1223](https://github.com/scalableminds/webknossos-libs/pull/1223)
 
 
 ## [0.16.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v0.16.0) - 2024-11-27

--- a/webknossos/webknossos/dataset/defaults.py
+++ b/webknossos/webknossos/dataset/defaults.py
@@ -19,7 +19,7 @@ def _create_sslcontext() -> ssl.SSLContext:
 def _save_sslcontext(
     obj: ssl.SSLContext,
 ) -> tuple[Callable[[Any, Any], ssl.SSLContext], tuple[ssl._SSLMethod, Optional[str]]]:
-    cafile = getattr(obj, "cafile")
+    cafile = getattr(obj, "cafile", None)
     return _rebuild_sslcontext, (obj.protocol, cafile)
 
 
@@ -29,6 +29,7 @@ def _rebuild_sslcontext(
     ssl_context = ssl.SSLContext(protocol)
     if cafile is not None:
         ssl_context.load_verify_locations(cafile=cafile)
+        ssl_context.cafile = cafile  # type: ignore
     return ssl_context
 
 


### PR DESCRIPTION
### Description:
- When unpickling the SSL_Context we need to set the cafile again to allow a second or third pickling.


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog

