### PR TITLE
Add note that minio is necessary for tests on MacOS.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,7 +140,7 @@ npm install --global proxay
 # or if you're using yarn
 yarn global add proxay
 ```
-When running the `./test.sh` script on iOS, it is also necessary to install `minio` using the following command:
+When running the `./test.sh` script on MacOS, it is also necessary to install `minio` using the following command:
 
 ```bash
 brew install minio

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -140,6 +140,11 @@ npm install --global proxay
 # or if you're using yarn
 yarn global add proxay
 ```
+When running the `./test.sh` script on iOS, it is also necessary to install `minio` using the following command:
+
+```bash
+brew install minio
+```
 
 The tests also contain functionality for the WEBKNOSSOS client. There a two modes to run the tests:
 


### PR DESCRIPTION
### Description:
- Adds a line to the CONTRIBUTING.md file for installation of the test setup on MacOS.
