### PR TITLE
Make `typing-extensions` a regular dependency

### DIFF
--- a/cluster_tools/pyproject.toml
+++ b/cluster_tools/pyproject.toml
@@ -6,6 +6,9 @@ authors = [{name= "scalable minds", email="hello@scalableminds.com"}]
 readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
+dependencies = [
+    "typing-extensions ~=4.12.0",
+]
 
 [project.urls]
 Repository = "https://github.com/scalableminds/webknossos-libs"
@@ -19,7 +22,6 @@ all=["cluster_tools[kubernetes]", "cluster_tools[dask]"]
 
 [tool.uv]
 dev-dependencies = [
-    "typing-extensions ~=4.12.0",
     "icecream ~=2.1.1",
     "mypy ~=1.0.0",
     "pytest ~=8.3.3",


### PR DESCRIPTION
Without this, installing `cluster_tools` from PyPI and then running `python slurm_example.py` results in the following error:

```
(connrecon) [mottales@vcl1062 connrecon]$ python slurm_example.py
Traceback (most recent call last):
  File "/tungstenfs/scratch/gfriedri/mottales/code/connrecon/slurm_example.py", line 5, in <module>
    import cluster_tools
  File "/tungstenfs/scratch/gfriedri/mottales/code/connrecon/.pixi/envs/default/lib/python3.11/site-packages/cluster_tools/__init__.py", line 4, in <module>
    from cluster_tools.executor_protocol import Executor
  File "/tungstenfs/scratch/gfriedri/mottales/code/connrecon/.pixi/envs/default/lib/python3.11/site-packages/cluster_tools/executor_protocol.py", line 14, in <module>
    from typing_extensions import ParamSpec
ModuleNotFoundError: No module named 'typing_extensions'
```

(In my opinion, it would be nicer if `typing_extensions` were, in fact, only a dev-dependency. But I don't know Python and its typing workflows well enough to implement this fix. So, this here is just the minimal-change fix.)