### PR TITLE
Update Python metadata to include py3.13

### DIFF
--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -27,6 +27,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10", 
     "Programming Language :: Python :: 3.11", 
     "Programming Language :: Python :: 3.12", 
+    "Programming Language :: Python :: 3.13", 
 ]
 
 requires-python = ">=3.9,<=3.13"


### PR DESCRIPTION
### Description:
- Add Python 3.13 to Python metadata file so it get's parsed correctly by PyPi and the icon badges in our readme


### Issues:
- fixes:
  - <img width="310" alt="Screenshot 2025-01-31 at 10 40 25" src="https://github.com/user-attachments/assets/5c970269-e136-4b7d-b436-6753a8b15afb" />
  - <img width="405" alt="Screenshot 2025-01-31 at 10 39 29" src="https://github.com/user-attachments/assets/4497b520-0cc0-4aeb-b9e6-e619f1c90f21" />
- Related to #1239 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
