### PR TITLE
Add fix for issue in setuptools.

### DIFF
--- a/cluster_tools/pyproject.toml
+++ b/cluster_tools/pyproject.toml
@@ -37,6 +37,10 @@ where = ["."]
 include = ["cluster_tools*"]
 exclude = ["cluster_tools.tests"]
 
+# This is a fix for an issue in setuptools. See: https://github.com/pypa/setuptools/issues/4759
+# This shoulde be removed when the issue is resolved.
+[tool.setuptools]
+license-files = []
 
 [tool.ruff]
 # Exclude a variety of commonly ignored directories.

--- a/webknossos/pyproject.toml
+++ b/webknossos/pyproject.toml
@@ -188,6 +188,11 @@ testpaths = ["tests"]
 requires = ["setuptools>=70.0", "wheel; python_version>='3.12'"]
 build-backend = "setuptools.build_meta"
 
+# This is a fix for an issue in setuptools. See: https://github.com/pypa/setuptools/issues/4759
+# This shoulde be removed when the issue is resolved.
+[tool.setuptools]
+license-files = []
+
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["webknossos*", "webknossos/version.py"]


### PR DESCRIPTION
### Description:
- The pypi release failed because of an issue with setuptools (https://github.com/pypa/setuptools/issues/4759). This PR adds the license-files entry with an empty list to its pyproject.toml file as sugested in this discussion: https://github.com/astral-sh/uv/issues/9513.
