### PR TITLE
Show pims import errors only once

### DIFF
--- a/webknossos/webknossos/dataset/_utils/pims_images.py
+++ b/webknossos/webknossos/dataset/_utils/pims_images.py
@@ -35,6 +35,52 @@ from ..mag_view import MagView
 pims.ImageIOReader.frame_shape = pims.FramesSequenceND.frame_shape
 
 
+def _pims_imports() -> Optional[str]:
+    import_exceptions = []
+
+    try:
+        from .pims_czi_reader import PimsCziReader  # noqa: F401 unused-import
+    except ImportError as import_error:
+        import_exceptions.append(f"PimsCziReader: {import_error.msg}")
+
+    try:
+        from .pims_dm_readers import (  # noqa: F401 unused-import
+            PimsDm3Reader,
+            PimsDm4Reader,
+        )
+    except ImportError as import_error:
+        import_exceptions.append(f"PimsDmReaders: {import_error.msg}")
+
+    try:
+        from .pims_imagej_tiff_reader import (  # noqa: F401 unused-import
+            PimsImagejTiffReader,
+        )
+    except ImportError as import_error:
+        import_exceptions.append(f"PimsImagejTiffReader: {import_error.msg}")
+
+    try:
+        from .pims_tiff_reader import PimsTiffReader  # noqa: F401 unused-import
+    except ImportError as import_error:
+        import_exceptions.append(f"PimsTiffReader: {import_error.msg}")
+
+    if import_exceptions:
+        import_exception_string = "".join(
+            f"\t- {import_exception}\n" for import_exception in import_exceptions
+        )
+
+        return import_exception_string
+    return None
+
+
+if (errors := _pims_imports()) is not None:
+    warnings.warn(
+        f"[WARNING] Not all pims readers could be imported:\n{errors}Install the readers you need or use 'webknossos[all]' to install all readers.",
+        category=UserWarning,
+        source=None,
+        stacklevel=2,
+    )
+
+
 def _assume_color_channel(dim_size: int, dtype: np.dtype) -> bool:
     return dim_size == 1 or (dim_size == 3 and dtype == np.dtype("uint8"))
 
@@ -319,40 +365,6 @@ class PimsImages:
     def _try_open_pims_images(
         self, original_images: Union[str, List[str]], exceptions: List[Exception]
     ) -> Optional[pims.FramesSequence]:
-        import_exceptions = []
-
-        try:
-            from .pims_czi_reader import PimsCziReader  # noqa: F401 unused-import
-        except ImportError as import_error:
-            import_exceptions.append(f"PimsCziReader: {import_error.msg}")
-
-        try:
-            from .pims_dm_readers import (  # noqa: F401 unused-import
-                PimsDm3Reader,
-                PimsDm4Reader,
-            )
-        except ImportError as import_error:
-            import_exceptions.append(f"PimsDmReaders: {import_error.msg}")
-
-        try:
-            from .pims_imagej_tiff_reader import (  # noqa: F401 unused-import
-                PimsImagejTiffReader,
-            )
-        except ImportError as import_error:
-            import_exceptions.append(f"PimsImagejTiffReader: {import_error.msg}")
-
-        try:
-            from .pims_tiff_reader import PimsTiffReader  # noqa: F401 unused-import
-        except ImportError as import_error:
-            import_exceptions.append(f"PimsTiffReader: {import_error.msg}")
-
-        if import_exceptions:
-            import_exception_string = "\n\t" + "\n\t".join(import_exceptions)
-            warnings.warn(
-                f"[WARNING] Not all pims readers could be imported: {import_exception_string}\nInstall the readers you need or use 'webknossos[all]' to install all readers.",
-                category=UserWarning,
-            )
-
         if self._use_bioformats:
             return None
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -52,7 +52,6 @@ from ..geometry.mag import MagLike
 from ..geometry.nd_bounding_box import derive_nd_bounding_box_from_shape
 from ._array import ArrayException, ArrayInfo, BaseArray
 from ._metadata import DatasetMetadata
-from ._utils import pims_images
 from .defaults import (
     DEFAULT_BIT_DEPTH,
     DEFAULT_CHUNK_SHAPE,
@@ -251,6 +250,7 @@ class Dataset:
             use_bioformats: Optional[bool],
         ) -> Callable[[Path], str]:
             ConversionLayerMapping = Dataset.ConversionLayerMapping
+            from ._utils import pims_images
 
             if self == ConversionLayerMapping.ENFORCE_LAYER_PER_FILE:
                 return lambda p: p.as_posix().replace("/", "_")
@@ -935,6 +935,7 @@ class Dataset:
             This method needs extra packages like tifffile or pylibczirw.
             Install with `pip install "webknossos[all]"` and `pip install --extra-index-url https://pypi.scm.io/simple/ "webknossos[czi]"`.
         """
+        from ._utils import pims_images
 
         input_upath = UPath(input_path)
 
@@ -1681,6 +1682,8 @@ class Dataset:
         * `truncate_rgba_to_rgb`: only applies if `allow_multiple_layers=True`, set to `False` to write four channels into layers instead of an RGB channel
         * `executor`: pass a `ClusterExecutor` instance to parallelize the conversion jobs across the batches
         """
+        from ._utils import pims_images
+
         if category is None:
             image_path_for_category_guess: Path
             if isinstance(images, str) or isinstance(images, PathLike):


### PR DESCRIPTION
### Description:
- This PR moves the import of different pims_readers, to avoid warnings for every pims image reader

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
