### PR TITLE
Fix OME metadata

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,8 +17,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+- For Zarr3 datasets, the OME-Zarr 0.5 metadata is now written. [#1272](https://github.com/scalableminds/webknossos-libs/pull/1272)
 
 ### Fixed
+- Fixed an issue where it was attempted to overwrite the OME-Zarr metadata for symlinked layers. [#1272](https://github.com/scalableminds/webknossos-libs/pull/1272) 
 
 
 ## [2.0.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.0.3) - 2025-03-18

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -66,7 +66,7 @@ from .defaults import (
     ZATTRS_FILE_NAME,
     ZGROUP_FILE_NAME,
 )
-from .ome_metadata import write_ome_0_4_metadata
+from .ome_metadata import write_ome_metadata
 from .remote_dataset_registry import RemoteDatasetRegistry
 from .remote_folder import RemoteFolder
 from .sampling_modes import SamplingModes
@@ -2794,7 +2794,9 @@ class Dataset:
                 json.dump({"zarr_format": 3, "node_type": "group"}, outfile, indent=4)
 
         for layer in self.layers.values():
-            write_ome_0_4_metadata(self, layer)
+            # Only write out OME metadata if the layer is a child of the dataset
+            if not is_fs_path(layer.path) or layer.path.resolve().parent == self.path:
+                write_ome_metadata(self, layer)
 
     def _initialize_layer_from_properties(self, properties: LayerProperties) -> Layer:
         if properties.category == COLOR_CATEGORY:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -329,6 +329,7 @@ class Dataset:
 
         """
         self._read_only = read_only
+        self._resolved_path: Optional[Path] = None
         self.path: Path = strip_trailing_slash(UPath(dataset_path))
 
         if count_defined_values((voxel_size, voxel_size_with_unit)) > 1:
@@ -472,7 +473,14 @@ class Dataset:
         dataset = cls.__new__(cls)
         dataset.path = dataset_path
         dataset._read_only = read_only
+        dataset._resolved_path = None
         return dataset._init_from_properties(dataset_properties)
+
+    @property
+    def resolved_path(self) -> Path:
+        if self._resolved_path is None:
+            self._resolved_path = self.path.resolve()
+        return self._resolved_path
 
     @classmethod
     def announce_manual_upload(
@@ -2795,7 +2803,7 @@ class Dataset:
 
         for layer in self.layers.values():
             # Only write out OME metadata if the layer is a child of the dataset
-            if layer.path.resolve().parent == self.path:
+            if layer.resolved_path.parent == self.resolved_path:
                 write_ome_metadata(self, layer)
 
     def _initialize_layer_from_properties(self, properties: LayerProperties) -> Layer:

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -2407,12 +2407,12 @@ class Dataset:
             mag.path = str(foreign_layer.mags[mag.mag].path)
         layer_properties.name = new_layer_name
         self._properties.data_layers += [layer_properties]
-        self._layers[new_layer_name] = self._initialize_layer_from_properties(
-            layer_properties
-        )
+        new_layer = self._initialize_layer_from_properties(layer_properties)
+        new_layer._resolved_path = foreign_layer_path
+        self._layers[new_layer_name] = new_layer
 
         self._export_as_json()
-        return self.layers[new_layer_name]
+        return new_layer
 
     def add_fs_copy_layer(
         self,

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -2795,7 +2795,7 @@ class Dataset:
 
         for layer in self.layers.values():
             # Only write out OME metadata if the layer is a child of the dataset
-            if not is_fs_path(layer.path) or layer.path.resolve().parent == self.path:
+            if layer.path.resolve().parent == self.path:
                 write_ome_metadata(self, layer)
 
     def _initialize_layer_from_properties(self, properties: LayerProperties) -> Layer:

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -216,6 +216,7 @@ class Layer:
             properties.element_class, properties.num_channels
         )
         self._mags: Dict[Mag, MagView] = {}
+        self._resolved_path: Optional[Path] = None
 
         for mag in properties.mags:
             self._setup_mag(Mag(mag.mag), mag.path)
@@ -259,6 +260,12 @@ class Layer:
             if maybe_layer_path and is_remote
             else self.dataset.path / self.name
         )
+
+    @property
+    def resolved_path(self) -> Path:
+        if self._resolved_path is None:
+            self._resolved_path = self.path.resolve()
+        return self._resolved_path
 
     @property
     def is_remote_to_dataset(self) -> bool:

--- a/webknossos/webknossos/dataset/ome_metadata.py
+++ b/webknossos/webknossos/dataset/ome_metadata.py
@@ -12,6 +12,53 @@ if TYPE_CHECKING:
     from .layer import Layer
 
 
+def get_ome_0_5_multiscale_metadata(
+    dataset: "Dataset", layer: "Layer"
+) -> Dict[str, Any]:
+    return {
+        "ome": {
+            "version": "0.5",
+            "multiscales": [
+                {
+                    "axes": [
+                        {"name": "c", "type": "channel"},
+                        {
+                            "name": "x",
+                            "type": "space",
+                            "unit": "nanometer",
+                        },
+                        {
+                            "name": "y",
+                            "type": "space",
+                            "unit": "nanometer",
+                        },
+                        {
+                            "name": "z",
+                            "type": "space",
+                            "unit": "nanometer",
+                        },
+                    ],
+                    "datasets": [
+                        {
+                            "path": mag.path.name,
+                            "coordinateTransformations": [
+                                {
+                                    "type": "scale",
+                                    "scale": [1.0]
+                                    + (
+                                        np.array(dataset.voxel_size) * mag.mag.to_np()
+                                    ).tolist(),
+                                }
+                            ],
+                        }
+                        for mag in layer.mags.values()
+                    ],
+                }
+            ],
+        }
+    }
+
+
 def get_ome_0_4_multiscale_metadata(
     dataset: "Dataset", layer: "Layer"
 ) -> Dict[str, Any]:
@@ -57,7 +104,7 @@ def get_ome_0_4_multiscale_metadata(
     }
 
 
-def write_ome_0_4_metadata(dataset: "Dataset", layer: "Layer") -> None:
+def write_ome_metadata(dataset: "Dataset", layer: "Layer") -> None:
     if not is_writable_path(layer.path):
         return
     if layer.data_format == DataFormat.Zarr3:
@@ -66,7 +113,7 @@ def write_ome_0_4_metadata(dataset: "Dataset", layer: "Layer") -> None:
                 {
                     "zarr_format": 3,
                     "node_type": "group",
-                    "attributes": get_ome_0_4_multiscale_metadata(dataset, layer),
+                    "attributes": get_ome_0_5_multiscale_metadata(dataset, layer),
                 },
                 outfile,
                 indent=4,


### PR DESCRIPTION
### Description:
- Use OME-Zarr 0.5 metadata for Zarr3 datasets
- Only write OME-Zarr metadata for layers that are child directories of the dataset (not symlinks)

### Issues:
- see https://scm.slack.com/archives/C02Q35Q28P5/p1741598485944569

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
