### PR TITLE
Change default dimension_separator for Zarr2

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+- Changed the default dimension separator for Zarr 2 arrays from `.` to `/`. [#1274](https://github.com/scalableminds/webknossos-libs/pull/1274)
 
 ### Fixed
 

--- a/webknossos/webknossos/dataset/_array.py
+++ b/webknossos/webknossos/dataset/_array.py
@@ -842,7 +842,7 @@ class Zarr2Array(TensorStoreArray):
                         else None
                     ),
                     "filters": None,
-                    "dimension_separator": ".",
+                    "dimension_separator": "/",
                 },
                 "create": True,
             }

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -324,7 +324,11 @@ def rmtree(path: Path) -> None:
 
 def copytree(in_path: Path, out_path: Path) -> None:
     def _walk(path: Path, base_path: Path) -> Iterator[Tuple[Path, Tuple[str, ...]]]:
-        yield (path, tuple(p for p in path.parts if p not in base_path.parts))
+        # base_path.parts is a prefix of path.parts; strip it
+        assert len(path.parts) >= len(base_path.parts)
+        assert path.parts[: len(base_path.parts)] == base_path.parts
+        yield (path, path.parts[len(base_path.parts) :])
+
         if path.is_dir():
             for p in path.iterdir():
                 yield from _walk(p, base_path)


### PR DESCRIPTION
### Description:
- Changes the default dimension separator for new Zarr2 arrays to `/`. 

### Issues:
- see https://forum.image.sc/t/webknossos-uses-as-a-dimension-separator/110373

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
