### PR TITLE
Add warning for outdated libs versions

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective *Breaking Changes* sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.6...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.7...HEAD)
 
 ### Breaking Changes
 
@@ -16,6 +16,10 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+
+
+## [2.0.7](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.0.7) - 2025-03-26
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.6...v2.0.7)
 
 
 ## [2.0.6](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.0.6) - 2025-03-25

--- a/webknossos/.gitignore
+++ b/webknossos/.gitignore
@@ -104,7 +104,6 @@ ENV/
 # MyPy
 .mypy_cache/
 
-/webknossos/version.py
 testoutput
 # Unpacked version of WT1_wkw.tar.gz
 testdata/WT1_wkw

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -10,16 +10,22 @@ and this project adheres to [Semantic Versioning](http://semver.org/) `MAJOR.MIN
 For upgrade instructions, please check the respective _Breaking Changes_ sections.
 
 ## Unreleased
-[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.6...HEAD)
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.7...HEAD)
 
 ### Breaking Changes
 
 ### Added
 
 ### Changed
-- Pinned `tensorstore` to `<=0.1.71`. [#1276](https://github.com/scalableminds/webknossos-libs/pull/1276)
 
 ### Fixed
+
+
+## [2.0.7](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.0.7) - 2025-03-26
+[Commits](https://github.com/scalableminds/webknossos-libs/compare/v2.0.6...v2.0.7)
+
+### Changed
+- Pinned `tensorstore` to `<=0.1.71`. [#1276](https://github.com/scalableminds/webknossos-libs/pull/1276)
 
 
 ## [2.0.6](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.0.6) - 2025-03-25

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Add a warning on import if a newer version of the wk-libs is available from PyPi. [#1280](https://github.com/scalableminds/webknossos-libs/pull/1280)
 
 ### Changed
 

--- a/webknossos/webknossos/__init__.py
+++ b/webknossos/webknossos/__init__.py
@@ -24,9 +24,23 @@ Server interactions may require [authentication](webknossos/client/context.html)
 
 # The table above contains zero-width spaces in the code examples after each dot to enforce correct line-breaks.
 # ruff: noqa: F403
+import logging
+
+from packaging.version import Version
+
 from .administration import *
 from .annotation import *
 from .client import *
 from .dataset import *
 from .geometry import *
 from .skeleton import *
+from .utils import get_latest_version_from_pypi
+from .version import __version__ as current_version
+
+if not current_version == "0.0.0":
+    latest_version = get_latest_version_from_pypi()
+    if Version(current_version) < latest_version:
+        logger = logging.getLogger(__name__)
+        logger.warn(
+            f"Your current version {current_version} of the webknossos-libs is outdated. The latest version available on PyPI is {latest_version}. Consider upgrading to the latest version to avoid being out-of-sync with the latest WEBKNOSSOS features. See GitHub for full changelog of all releases (https://github.com/scalableminds/webknossos-libs/releases)."
+        )

--- a/webknossos/webknossos/__init__.py
+++ b/webknossos/webknossos/__init__.py
@@ -24,23 +24,15 @@ Server interactions may require [authentication](webknossos/client/context.html)
 
 # The table above contains zero-width spaces in the code examples after each dot to enforce correct line-breaks.
 # ruff: noqa: F403
-import logging
-
-from packaging.version import Version
-
 from .administration import *
 from .annotation import *
 from .client import *
 from .dataset import *
 from .geometry import *
 from .skeleton import *
-from .utils import get_latest_version_from_pypi
+from .utils import check_version_in_background
 from .version import __version__ as current_version
 
 if not current_version == "0.0.0":
-    latest_version = get_latest_version_from_pypi()
-    if Version(current_version) < latest_version:
-        logger = logging.getLogger(__name__)
-        logger.warn(
-            f"Your current version {current_version} of the webknossos-libs is outdated. The latest version available on PyPI is {latest_version}. Consider upgrading to the latest version to avoid being out-of-sync with the latest WEBKNOSSOS features. See GitHub for full changelog of all releases (https://github.com/scalableminds/webknossos-libs/releases)."
-        )
+    # Schedule the version check to run non-blocking in a background thread
+    check_version_in_background(current_version)

--- a/webknossos/webknossos/cli/main.py
+++ b/webknossos/webknossos/cli/main.py
@@ -19,7 +19,7 @@ from . import (
 )
 
 
-def version_callback(value: bool):
+def version_callback(value: bool) -> None:
     if value:
         from ..version import __version__
 
@@ -40,7 +40,7 @@ def main(
         help="Show the version and exit.",
         is_flag=True,
     ),
-):
+) -> None:
     """WEBKNOSSOS CLI tool."""
     pass
 

--- a/webknossos/webknossos/cli/main.py
+++ b/webknossos/webknossos/cli/main.py
@@ -18,7 +18,32 @@ from . import (
     upsample,
 )
 
+
+def version_callback(value: bool):
+    if value:
+        from ..version import __version__
+
+        typer.echo(__version__)
+        raise typer.Exit()
+
+
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_short=False)
+
+
+@app.callback()
+def main(
+    version: bool = typer.Option(
+        None,
+        "--version",
+        callback=version_callback,
+        is_eager=True,
+        help="Show the version and exit.",
+        is_flag=True,
+    ),
+):
+    """WEBKNOSSOS CLI tool."""
+    pass
+
 
 app.command("check-equality")(check_equality.main)
 app.command("compress")(compress.main)

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -32,8 +32,10 @@ from typing import (
 )
 
 import numpy as np
+import requests
 import rich
 from cluster_tools import Executor, get_executor
+from packaging.version import InvalidVersion, Version
 from rich.progress import Progress
 from upath import UPath
 
@@ -421,3 +423,26 @@ class NDArrayLike(Protocol):
 
     @property
     def dtype(self) -> np.dtype: ...
+
+
+def get_latest_version_from_pypi() -> Version:
+    """Get the latest version of the Webknossos package from PyPI."""
+
+    try:
+        response = requests.get("https://pypi.org/pypi/webknossos/json")
+        response.raise_for_status()
+        data = response.json()
+        releases = data["releases"]
+        versions = [Version(v) for v in releases.keys()]
+        latest_version = max(versions)
+
+        return latest_version
+
+    except requests.exceptions.HTTPError:
+        # Failed to get latest version from PyPI: {e}") from e
+        pass
+    except InvalidVersion:
+        # "Failed to parse latest version from PyPI: {e}") from e
+        pass
+
+    return Version("0.0.0")

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -14,6 +14,7 @@ from multiprocessing import cpu_count
 from os.path import relpath
 from pathlib import Path, PosixPath, WindowsPath
 from shutil import copyfileobj, move
+from threading import Thread
 from typing import (
     Any,
     Callable,
@@ -31,8 +32,8 @@ from typing import (
     Union,
 )
 
+import httpx
 import numpy as np
-import requests
 import rich
 from cluster_tools import Executor, get_executor
 from packaging.version import InvalidVersion, Version
@@ -429,20 +430,46 @@ def get_latest_version_from_pypi() -> Version:
     """Get the latest version of the Webknossos package from PyPI."""
 
     try:
-        response = requests.get("https://pypi.org/pypi/webknossos/json")
+        response = httpx.get("https://pypi.org/pypi/webknossos/json")
         response.raise_for_status()
         data = response.json()
         releases = data["releases"]
         versions = [Version(v) for v in releases.keys()]
         latest_version = max(versions)
-
         return latest_version
 
-    except requests.exceptions.HTTPError:
-        # Failed to get latest version from PyPI: {e}") from e
-        pass
-    except InvalidVersion:
-        # "Failed to parse latest version from PyPI: {e}") from e
+    except (httpx.HTTPError, InvalidVersion):
+        # Failed to get latest version from PyPI
         pass
 
     return Version("0.0.0")
+
+
+def check_version_in_background(current_version: str) -> None:
+    """
+    Schedule a non-blocking version check that will log a warning if the current version is outdated.
+    This function runs the check in a separate thread to avoid blocking the main application.
+    """
+
+    def check_version_in_thread() -> None:
+        try:
+            # Get the latest version
+            latest_version = get_latest_version_from_pypi()
+
+            # Compare versions and log warning if needed
+            if Version(current_version) < latest_version:
+                logger = logging.getLogger(__name__)
+                logger.warning(
+                    f"Your current version {current_version} of the webknossos-libs is outdated. "
+                    f"The latest version available on PyPI is {latest_version}. "
+                    f"Consider upgrading to the latest version to avoid being out-of-sync with "
+                    f"the latest WEBKNOSSOS features. See GitHub for full changelog of all "
+                    f"releases (https://github.com/scalableminds/webknossos-libs/releases)."
+                )
+        except Exception:
+            # Silently ignore any errors in version checking
+            pass
+
+    # Start the check in a daemon thread so it won't block program exit
+    t = Thread(target=check_version_in_thread, daemon=True)
+    t.start()

--- a/webknossos/webknossos/version.py
+++ b/webknossos/webknossos/version.py
@@ -1,0 +1,2 @@
+# This is dynamically set while building and publishing the the package in the CI
+__version__ = "0.0.0"


### PR DESCRIPTION
### Description:
- PR adds a version check when importing the wk-libs. It will provide a warning to users when the installed wk libs package is outdated compared to the latest available version on PyPi.
- PR adds a `--version` CLI option to print the current version.


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
