### PR TITLE
switch to ported slurm docker cluster

### DIFF
--- a/cluster_tools/dockered-slurm/docker-compose.yml
+++ b/cluster_tools/dockered-slurm/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - ..:/cluster_tools
 
   slurmdbd:
-    image: scalableminds/slurm-docker-cluster:master__11274637426
+    image: scalableminds/slurm-docker-cluster:port_slurm_in_docker_to_debian__14751549755
     command: [ "slurmdbd" ]
     container_name: slurmdbd
     hostname: slurmdbd
@@ -29,7 +29,7 @@ services:
       - mysql
 
   slurmctld:
-    image: scalableminds/slurm-docker-cluster:master__11274637426
+    image: scalableminds/slurm-docker-cluster:port_slurm_in_docker_to_debian__14751549755
     command: [ "slurmctld" ]
     container_name: slurmctld
     environment:
@@ -50,7 +50,7 @@ services:
       - "slurmdbd"
 
   c1:
-    image: scalableminds/slurm-docker-cluster:master__11274637426
+    image: scalableminds/slurm-docker-cluster:port_slurm_in_docker_to_debian__14751549755
     command: [ "slurmd" ]
     hostname: c1
     container_name: c1
@@ -68,7 +68,7 @@ services:
       - "slurmctld"
 
   c2:
-    image: scalableminds/slurm-docker-cluster:master__11274637426
+    image: scalableminds/slurm-docker-cluster:port_slurm_in_docker_to_debian__14751549755
     command: [ "slurmd" ]
     hostname: c2
     container_name: c2


### PR DESCRIPTION
### Description:
- The old Docker Slurm Cluster image (see: https://github.com/scalableminds/dockerfiles/tree/master/slurm-docker-cluster) sporadically fails to build. Because of that we switch to the latest Debian version and our custom Slurm packages.

### Issues:
- fixes CI build failures for Docker Slurm Cluster image
