### PR TITLE
Add RunLLM AI assistant to documentation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -57,6 +57,9 @@ extra:
       link: https://medium.com/webknossos
   generator: false
 
+extra_javascript:
+  - javascripts/runllm-widget.js
+
 plugins:
   # - gen-files:
   #     scripts:
@@ -172,7 +175,7 @@ nav:
         - Import Through Python: webknossos/data/upload_python.md
         - Streaming from Cloud Storage: webknossos/data/streaming.md
         - Export Through UI : webknossos/data/export_ui.md
-        - Export Through Python: webknossos/data/export_python.md
+        - Export Through Python:  webknossos/data/export_python.md
         - Export as Zarr Stream: webknossos/data/zarr_stream.md
       - Datasets:
         - webknossos/datasets/index.md

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -175,7 +175,7 @@ nav:
         - Import Through Python: webknossos/data/upload_python.md
         - Streaming from Cloud Storage: webknossos/data/streaming.md
         - Export Through UI : webknossos/data/export_ui.md
-        - Export Through Python:  webknossos/data/export_python.md
+        - Export Through Python: webknossos/data/export_python.md
         - Export as Zarr Stream: webknossos/data/zarr_stream.md
       - Datasets:
         - webknossos/datasets/index.md

--- a/docs/src/javascripts/runllm-widget.js
+++ b/docs/src/javascripts/runllm-widget.js
@@ -1,0 +1,17 @@
+document.addEventListener("DOMContentLoaded", function () {
+    var script = document.createElement("script");
+    script.type = "module";
+    script.id = "runllm-widget-script"
+  
+    script.src = "https://widget.runllm.com";
+  
+    script.setAttribute("version", "stable");
+    script.setAttribute("crossorigin", "true");
+    script.setAttribute("runllm-keyboard-shortcut", "Mod+j");
+    script.setAttribute("runllm-name", "WEBKNOSSOS Assistant");
+    script.setAttribute("runllm-position", "BOTTOM_RIGHT");
+    script.setAttribute("runllm-assistant-id", "635");
+  
+    script.async = true;
+    document.head.appendChild(script);
+});


### PR DESCRIPTION
### Description:
- This PR adds the [RunLLM](https://runllm.com/) AI assistant to WK documentation. 
  - Once, the widget is deployed on https://docs.webknossos.org, we can start the whitelisting process for that URL in the RunLLM settings.


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
