### PR TITLE
Shallow copy for RemoteDatasets

### DIFF
--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -2597,9 +2597,6 @@ class Dataset:
             copies of remote datasets or create shallow copies in remote locations.
         """
 
-        assert is_fs_path(self.path), (
-            f"Cannot create symlinks to remote dataset {self.path}"
-        )
         new_dataset_path = UPath(new_dataset_path)
         assert is_fs_path(new_dataset_path), (
             f"Cannot create symlink in remote path {new_dataset_path}"


### PR DESCRIPTION
### Description:
- Removes an assertion from shallow copy that disables shallow copy of remote datasets.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
