### PR TITLE
Add support for in-memory datasets (e.g. useful for testing)

### DIFF
--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -1,0 +1,26 @@
+
+import numpy as np
+
+import webknossos as wk
+from tests.utils import TestTemporaryDirectoryNonLocal
+
+
+def test_create_dataset_remote_storage()->None:
+    """Test creating a dataset with remote storage."""
+    # Create a temporary directory for the dataset
+    # with tempfile.TemporaryDirectory() as temp_dir:
+    with TestTemporaryDirectoryNonLocal() as temp_dir:
+        dataset = wk.Dataset(temp_dir / "ds", voxel_size=(10, 10, 10), exist_ok=True)
+        layer = dataset.add_layer(
+            "color",
+            wk.COLOR_CATEGORY,
+            data_format="zarr3",
+            bounding_box=wk.BoundingBox((0, 0, 0), (16, 16, 16)),
+        )
+        mag1 = layer.add_mag(1)
+        mag1.write(np.ones((16, 16, 16), dtype="uint8"))
+        ds = wk.Dataset.open(temp_dir / "ds")
+        read_data = ds.get_layer("color").get_mag(1).read()
+        assert read_data.shape == (1, 16, 16, 16)
+        assert read_data.dtype == np.uint8
+        assert np.all(read_data == 1)

--- a/webknossos/tests/utils.py
+++ b/webknossos/tests/utils.py
@@ -1,0 +1,16 @@
+import uuid
+from collections.abc import Generator
+from contextlib import contextmanager
+
+from upath import UPath
+
+
+@contextmanager
+def TestTemporaryDirectoryNonLocal() -> Generator[UPath, None, None]:
+    """Gives a temporary directory as UPath which does not use the "local" protocol (local file system).
+    Useful for testing functionality that uses non-local UPaths.
+    Currently implemented to use an in-memory file system. (no persistence across lifetime of the process)."""
+    random_prefix = str(uuid.uuid4())
+    temp_dir = UPath(f"memory:///{random_prefix}")
+    temp_dir.mkdir(parents=True, exist_ok=True)
+    yield temp_dir

--- a/webknossos/webknossos/dataset/_array.py
+++ b/webknossos/webknossos/dataset/_array.py
@@ -22,6 +22,8 @@ from ..geometry import BoundingBox, NDBoundingBox, Vec3Int, VecInt
 from ..utils import is_fs_path
 from .data_format import DataFormat
 
+TS_CONTEXT = tensorstore.Context()
+
 
 def _is_power_of_two(num: int) -> bool:
     return num & (num - 1) == 0
@@ -442,6 +444,14 @@ class TensorStoreArray(BaseArray):
             else:
                 kvstore_spec["aws_credentials"] = {"type": "default"}
             return kvstore_spec
+        elif isinstance(path, UPath) and path.protocol == "memory":
+            # use memory driver (in-memory file systems), e.g. useful for testing
+            # attention: this is not a persistent storage and it does not support
+            # multiprocessing since memory is not shared between processes
+            return {
+                "driver": "memory",
+                "path": path.path,
+            }
         else:
             return {
                 "driver": "file",
@@ -470,9 +480,13 @@ class TensorStoreArray(BaseArray):
                 },
                 open=True,
                 create=False,
+                context=TS_CONTEXT,
             ).result()  # check that everything exists
             return cls(path, _array)
         except Exception as exc:
+            import pdb
+
+            pdb.set_trace()
             raise ArrayException(f"Could not open array at {uri}.") from exc
 
     def read(self, bbox: NDBoundingBox) -> np.ndarray:
@@ -532,7 +546,8 @@ class TensorStoreArray(BaseArray):
                 {
                     "driver": str(self.data_format),
                     "kvstore": self._make_kvstore(self._path),
-                }
+                },
+                context=TS_CONTEXT,
             ).result()
             if array.domain != current_array.domain:
                 raise RuntimeError(
@@ -632,7 +647,8 @@ class TensorStoreArray(BaseArray):
                     {
                         "driver": str(self.data_format),
                         "kvstore": self._make_kvstore(self._path),
-                    }
+                    },
+                    context=TS_CONTEXT,
                 ).result()
             except Exception as e:
                 raise ArrayException(
@@ -780,7 +796,8 @@ class Zarr3Array(TensorStoreArray):
                     ],
                 },
                 "create": True,
-            }
+            },
+            context=TS_CONTEXT,
         ).result()
         return cls(path, _array)
 
@@ -856,7 +873,8 @@ class Zarr2Array(TensorStoreArray):
                     "dimension_separator": "/",
                 },
                 "create": True,
-            }
+            },
+            context=TS_CONTEXT,
         ).result()
         return cls(path, _array)
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -358,10 +358,9 @@ class Dataset:
                 dataset_path_is_empty = next(self.path.iterdir(), None) is None
                 dataset_path_exists = True
             except NotADirectoryError:
-                dataset_path_exists = True
+                dataset_path_is_empty = True
             except FileNotFoundError:
                 dataset_path_exists = False
-
             if dataset_path_exists and not dataset_path_is_empty:
                 raise RuntimeError(
                     f"Creation of Dataset at {self.path} failed, because a file or folder already exists at this path."


### PR DESCRIPTION
### Description:
- add support for tensorstore in-memory driver to support in-memory datasets for zarr3 format
- add tensorstore context to allow re-opening of in-memory datasets
- add simple test to test a fully remote dataset by using using the in-memory file system as "remote" file system

### Todos:
 - [ ] Updated Changelog
 - [x] Added / Updated Tests
