### PR TITLE
Make folder id parameter of announce upload route optional according to beackend route

### DIFF
--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -131,7 +131,7 @@ class ApiDatasetAnnounceUpload:
     dataset_name: str
     organization: str
     initial_team_ids: list[str]
-    folder_id: str
+    folder_id: str | None
     require_unique_name: bool
 
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -465,7 +465,7 @@ class Dataset:
         dataset_name: str,
         organization: str,
         initial_team_ids: list[str],
-        folder_id: str | RemoteFolder,
+        folder_id: str | RemoteFolder | None,
         require_unique_name: bool = False,
         token: str | None = None,
     ) -> tuple[str, str]:
@@ -478,7 +478,8 @@ class Dataset:
             dataset_name: Name for the new dataset
             organization: Organization ID to upload to
             initial_team_ids: List of team IDs to grant initial access
-            folder_id: ID of folder where dataset should be placed
+            folder_id: Optional ID of folder where dataset should be placed
+            require_unique_name: Whether to make request fail in case a dataset with the name already exists
             token: Optional authentication token
 
         Note:


### PR DESCRIPTION
### Description:

@MatthisCl noticed that the folderId parameter of the announce upload function is required although it is optional. This PR aims to make this parameter optional.

See https://github.com/scalableminds/webknossos/blob/da0d52d80a69427cc1b840723eff96f22904b6e7/webknossos-datastore/app/com/scalableminds/webknossos/datastore/services/uploading/UploadService.scala#L51 to compare with the backend route properties. There folderId is listed as optional.

### Issues:
- No issue exists for this

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [ ] Added / Updated Tests
