### PR TITLE
Fix downsampling memory consumption

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed excessive RAM consumption during downsampling by chunking the computation. [#1325](https://github.com/scalableminds/webknossos-libs/pull/1325)
 
 
 ## [2.3.9](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.3.9) - 2025-06-13

--- a/webknossos/webknossos/dataset/_downsampling_utils.py
+++ b/webknossos/webknossos/dataset/_downsampling_utils.py
@@ -29,7 +29,16 @@ class InterpolationModes(Enum):
     MIN = 6
 
 
-def determine_buffer_shape(array_info: ArrayInfo) -> Vec3Int:
+def determine_downsample_buffer_shape(array_info: ArrayInfo) -> Vec3Int:
+    # This is the shape of the data in the downsampling target magnification, so the
+    # data that is read is up to 512³ vx in the source magnification. Using larger
+    # shapes uses a lot of RAM, especially for segmentation layers which use the mode filter.
+    # See https://scm.slack.com/archives/CMBMU5684/p1749771929954699 for more context.
+    return Vec3Int.full(256).pairmin(array_info.shard_shape)
+
+
+def determine_upsample_buffer_shape(array_info: ArrayInfo) -> Vec3Int:
+    # This is the shape of the data in the upsampling target magnification.
     return array_info.shard_shape
 
 

--- a/webknossos/webknossos/dataset/_downsampling_utils.py
+++ b/webknossos/webknossos/dataset/_downsampling_utils.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING, Optional
 
 import numpy as np
 from scipy.ndimage import zoom
-from scipy.stats import mode
 
 if TYPE_CHECKING:
     from .dataset import Dataset
@@ -215,7 +214,50 @@ def _median(x: np.ndarray) -> np.ndarray:
 
 
 def _mode(x: np.ndarray) -> np.ndarray:
-    return mode(x).mode
+    """
+    Fast mode implementation from: https://stackoverflow.com/a/35674754
+    """
+    # Check inputs
+    ndim = x.ndim
+    axis = 0
+    # Sort array
+    sort = np.sort(x, axis=axis)
+    # Create array to transpose along the axis and get padding shape
+    transpose = np.roll(np.arange(ndim)[::-1], axis)
+    shape = list(sort.shape)
+    shape[axis] = 1
+    # Create a boolean array along strides of unique values
+    strides = (
+        np.concatenate(
+            [
+                np.zeros(shape=shape, dtype="bool"),
+                np.diff(sort, axis=axis) == 0,
+                np.zeros(shape=shape, dtype="bool"),
+            ],
+            axis=axis,
+        )
+        .transpose(transpose)
+        .ravel()
+    )
+    # Count the stride lengths
+    counts = np.cumsum(strides)
+    counts[~strides] = np.concatenate([[0], np.diff(counts[~strides])])
+    counts[strides] = 0
+    # Get shape of padded counts and slice to return to the original shape
+    shape_array = np.array(sort.shape)
+    shape_array[axis] += 1
+    shape_array = shape_array[transpose]
+    slices = [slice(None)] * ndim
+    slices[axis] = slice(1, None)
+    # Reshape and compute final counts
+    counts = counts.reshape(shape_array).transpose(transpose)[tuple(slices)] + 1
+
+    # Find maximum counts and return modals/counts
+    slices = [slice(None, i) for i in sort.shape]
+    del slices[axis]
+    index = list(np.ogrid[slices])
+    index.insert(axis, np.argmax(counts, axis=axis))
+    return sort[tuple(index)]
 
 
 def downsample_unpadded_data(

--- a/webknossos/webknossos/dataset/layer.py
+++ b/webknossos/webknossos/dataset/layer.py
@@ -19,7 +19,8 @@ from ._downsampling_utils import (
     calculate_default_coarsest_mag,
     calculate_mags_to_downsample,
     calculate_mags_to_upsample,
-    determine_buffer_shape,
+    determine_downsample_buffer_shape,
+    determine_upsample_buffer_shape,
     downsample_cube_job,
     parse_interpolation_mode,
 )
@@ -1301,7 +1302,7 @@ class Layer:
         # perform downsampling
         with get_executor_for_args(None, executor) as executor:
             if buffer_shape is None:
-                buffer_shape = determine_buffer_shape(prev_mag_view.info)
+                buffer_shape = determine_downsample_buffer_shape(prev_mag_view.info)
             func = named_partial(
                 downsample_cube_job,
                 mag_factors=mag_factors,
@@ -1506,7 +1507,7 @@ class Layer:
             # perform upsampling
             with get_executor_for_args(None, executor) as actual_executor:
                 if buffer_shape is None:
-                    buffer_shape = determine_buffer_shape(prev_mag_view.info)
+                    buffer_shape = determine_upsample_buffer_shape(prev_mag_view.info)
                 else:
                     buffer_shape = Vec3Int.from_vec_or_int(buffer_shape)
                 func = named_partial(


### PR DESCRIPTION
### Description:
- Do not downsample to 1024³ chunks all at once (input is up to 2048³ vx), but instead chunk the downsample computation to target blocks of 256³ vx (input is up to 512³ vx) 
- This is a regression from an [upsampling fix PR](https://github.com/scalableminds/webknossos-libs/pull/1287/files#diff-bb56a3928082f3652fecbe683735bdd2b041bdb0b5353098b8f06808b2e0121aL35)
- See https://scm.slack.com/archives/CMBMU5684/p1749771929954699 for more context

### Issues:
- fixes downsampling memory consumption

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog