### PR TITLE
Only Retry Certain Errors

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+- Limit custom retries (e.g. additional to tensorstore internal retries) to certain network errors ("Too Many Requests", "GatewayTimeout"). [#1330](https://github.com/scalableminds/webknossos-libs/pull/1330)
 
 ### Fixed
 

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -12,7 +12,7 @@ def test_call_with_retries_success() -> None:
     result = call_with_retries(mock_fn)
 
     assert result == "success"
-    mock_fn.assert_called_once()
+    mock_fn.call_count == 1  # Function called only once (direct success)
 
 
 @patch("time.sleep")
@@ -29,7 +29,7 @@ def test_call_with_retries_sucess_with_retry(mock_sleep: Mock) -> None:
     result = call_with_retries(mock_fn, num_retries=3, backoff_factor=2.0)
 
     assert result == "success"
-    assert mock_fn.call_count == 3  # Called once for each retry
+    assert mock_fn.call_count == 3  # Called once for each try
     assert mock_sleep.call_count == 2  # Sleep called twice for retries
 
 
@@ -48,7 +48,9 @@ def test_call_with_retries_failure_after_retry(mock_sleep: Mock) -> None:
         call_with_retries(mock_fn, num_retries=2, backoff_factor=2.0)
 
     assert mock_fn.call_count == 2
-    assert mock_sleep.call_count == 2  # Sleep called twice for retries
+    assert (
+        mock_sleep.call_count == 1
+    )  # Sleep called once after the first failure but not after the second/last failure
 
 
 @patch("time.sleep")
@@ -65,4 +67,4 @@ def test_call_with_retries_direct_failure(mock_sleep: Mock) -> None:
         call_with_retries(mock_fn, num_retries=5, backoff_factor=2.0)
 
     assert mock_fn.call_count == 1  # Only called once, no retries
-    assert mock_sleep.call_count == 0  # Sleep called twice for retries
+    assert mock_sleep.call_count == 0  # Sleep not called since it failed immediately

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -1,0 +1,68 @@
+from unittest.mock import Mock, patch
+
+import pytest
+
+from webknossos.utils import call_with_retries
+
+
+def test_call_with_retries_success() -> None:
+    """Test that a successful function call returns immediately."""
+    mock_fn = Mock(return_value="success")
+
+    result = call_with_retries(mock_fn)
+
+    assert result == "success"
+    mock_fn.assert_called_once()
+
+
+@patch("time.sleep")
+def test_call_with_retries_sucess_with_retry(mock_sleep: Mock) -> None:
+    """Test retry behavior when function succeeds after retryable failures."""
+    mock_fn = Mock(
+        side_effect=[
+            Exception("Too Many Requests"),
+            Exception("GatewayTimeout"),
+            "success",
+        ]
+    )
+
+    result = call_with_retries(mock_fn, num_retries=3, backoff_factor=2.0)
+
+    assert result == "success"
+    assert mock_fn.call_count == 3  # Called once for each retry
+    assert mock_sleep.call_count == 2  # Sleep called twice for retries
+
+
+@patch("time.sleep")
+def test_call_with_retries_failure_after_retry(mock_sleep: Mock) -> None:
+    """Test retry behavior when function succeeds after retryable failures."""
+    mock_fn = Mock(
+        side_effect=[
+            Exception("Too Many Requests"),
+            Exception("GatewayTimeout"),
+            "success",
+        ]
+    )
+
+    with pytest.raises(Exception):
+        call_with_retries(mock_fn, num_retries=2, backoff_factor=2.0)
+
+    assert mock_fn.call_count == 2
+    assert mock_sleep.call_count == 2  # Sleep called twice for retries
+
+
+@patch("time.sleep")
+def test_call_with_retries_direct_failure(mock_sleep: Mock) -> None:
+    """Test retry behavior when function succeeds after retryable failures."""
+    mock_fn = Mock(
+        side_effect=[
+            RuntimeError("Non Retryable Runtime Error"),
+            "success",
+        ]
+    )
+
+    with pytest.raises(RuntimeError):
+        call_with_retries(mock_fn, num_retries=5, backoff_factor=2.0)
+
+    assert mock_fn.call_count == 1  # Only called once, no retries
+    assert mock_sleep.call_count == 0  # Sleep called twice for retries

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -61,7 +61,8 @@ def call_with_retries(
             return fn()
         except Exception as e:  # noqa: PERF203 # allow try except in loop
             last_exception = e
-            if _is_exception_retryable(e):
+            # We only sleep and retry if it was not the last attempt and the exception is retryable and.
+            if current_retry_number < num_retries - 1 and _is_exception_retryable(e):
                 logger.warning(
                     f"{description} attempt {current_retry_number + 1}/{num_retries} failed, retrying..."
                     f"Error was: {e}"

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -43,10 +43,7 @@ ReturnType = TypeVar("ReturnType")
 
 def _is_exception_retryable(exception: Exception) -> bool:
     exception_str_lower = str(exception).lower()
-    if (
-        "too many requests" in exception_str_lower
-        or "gatewaytimeout" in exception_str_lower
-    ):
+    if "too many requests" in exception_str_lower or "gateway" in exception_str_lower:
         return True
     return False
 


### PR DESCRIPTION
### Description:
- Limit the retry only to certain (network) errors which we found with some S3 compatible providers
- Add unit tests for the retry wrapper function

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
