### PR TITLE
Adapt NML parsing to convert Scale to nanometers.

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed an issue where the unit of the scale (voxel_size) was not considered when reading the NML. [#1339](https://github.com/scalableminds/webknossos-libs/pull/1339)
 
 
 ## [2.4.4](https://github.com/scalableminds/webknossos-libs/releases/tag/v2.4.4) - 2025-07-14

--- a/webknossos/testdata/nmls/generated_skeleton_snapshot.nml
+++ b/webknossos/testdata/nmls/generated_skeleton_snapshot.nml
@@ -2,7 +2,7 @@
 <things>
   <parameters>
     <experiment name="My Dataset" />
-    <scale x="11.0" y="11.0" z="25.0" />
+    <scale unit="nanometer" x="11.0" y="11.0" z="25.0" />
   </parameters>
   <thing color.a="1.0" color.b="0.13373766240135082" color.g="0.09300433970039235" color.r="0.9988844805996959" id="1" name="A WkTree">
     <nodes>

--- a/webknossos/testdata/nmls/test_a.nml
+++ b/webknossos/testdata/nmls/test_a.nml
@@ -1,7 +1,7 @@
 <things>
   <parameters>
     <experiment name="ds_name" organization="orga" description="" />
-    <scale x="4.0" y="4.0" z="35.0" />
+    <scale x="4.0" y="4.0" z="35.0" unit="micrometer" />
     <offset x="0" y="0" z="0" />
     <time ms="1644425515615" />
     <editPosition x="199480" y="199906" z="3593" />

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -375,6 +375,12 @@ def test_load_nml(tmp_path: Path) -> None:
     assert skeleton_a == wk.Skeleton.load(output_path)
 
 
+def test_load_nml_with_scale_unit() -> None:
+    input_path = TESTDATA_DIR / "nmls" / "test_a.nml"
+    skeleton_a = wk.Skeleton.load(input_path)
+    assert skeleton_a.voxel_size == (4000.0, 4000.0, 35000.0)
+
+
 def test_remove_tree(tmp_path: Path) -> None:
     input_path = TESTDATA_DIR / "nmls" / "test_a.nml"
     output_path = tmp_path / "test_a.nml"

--- a/webknossos/tests/test_skeleton.py
+++ b/webknossos/tests/test_skeleton.py
@@ -251,7 +251,7 @@ def test_simple_initialization_and_representations(tmp_path: Path) -> None:
 <things>
   <parameters>
     <experiment name="ds_name" />
-    <scale x="0.5" y="0.5" z="0.5" />
+    <scale unit="nanometer" x="0.5" y="0.5" z="0.5" />
   </parameters>
   <branchpoints />
   <comments />
@@ -266,7 +266,7 @@ def test_simple_initialization_and_representations(tmp_path: Path) -> None:
         )
     assert nml == wk.Skeleton.load(nml_path)
     assert str(nml) == (
-        "Skeleton(_child_groups=<No child groups>, _child_trees=<No child trees>, voxel_size=(0.5, 0.5, 0.5), dataset_name='ds_name', dataset_id=None, organization_id=None, description=None)"
+        "Skeleton(_child_groups=<No child groups>, _child_trees=<No child trees>, _voxel_size=VoxelSize(factor=(0.5, 0.5, 0.5), unit=<LengthUnit.NANOMETER: 'nanometer'>), dataset_name='ds_name', dataset_id=None, organization_id=None, description=None)"
     )
 
     my_group = nml.add_group("my_group")
@@ -280,7 +280,7 @@ def test_simple_initialization_and_representations(tmp_path: Path) -> None:
 <things>
   <parameters>
     <experiment name="ds_name" />
-    <scale x="0.5" y="0.5" z="0.5" />
+    <scale unit="nanometer" x="0.5" y="0.5" z="0.5" />
   </parameters>
   <thing color.a="1.0" color.b="0.3" color.g="0.2" color.r="0.1" groupId="1" id="3" name="my_other_tree">
     <nodes />
@@ -316,7 +316,7 @@ def test_simple_initialization_and_representations(tmp_path: Path) -> None:
         )
     assert nml == wk.Skeleton.load(nml_path)
     assert str(nml) == (
-        "Skeleton(_child_groups=<1 child group>, _child_trees=<1 child tree>, voxel_size=(0.5, 0.5, 0.5), dataset_name='ds_name', dataset_id=None, organization_id=None, description=None)"
+        "Skeleton(_child_groups=<1 child group>, _child_trees=<1 child tree>, _voxel_size=VoxelSize(factor=(0.5, 0.5, 0.5), unit=<LengthUnit.NANOMETER: 'nanometer'>), dataset_name='ds_name', dataset_id=None, organization_id=None, description=None)"
     )
     assert (
         str(my_group)

--- a/webknossos/webknossos/_nml/parameters.py
+++ b/webknossos/webknossos/_nml/parameters.py
@@ -101,7 +101,7 @@ class Parameters(NamedTuple):
                 "x": str(float(self.scale.factor[0])),
                 "y": str(float(self.scale.factor[1])),
                 "z": str(float(self.scale.factor[2])),
-                "unit":  self.scale.unit.value
+                "unit": self.scale.unit.value,
             },
         )
 

--- a/webknossos/webknossos/_nml/parameters.py
+++ b/webknossos/webknossos/_nml/parameters.py
@@ -15,7 +15,7 @@ DEFAULT_BOUNDING_BOX_COLOR = [0.2, 0.5, 0.1, 1]
 
 class Parameters(NamedTuple):
     name: str  # dataset name
-    scale: Vector3  # dataset voxel_size
+    scale: VoxelSize  # dataset voxel_size
     description: str | None = None
     organization: str | None = None
     dataset_id: str | None = None
@@ -98,9 +98,10 @@ class Parameters(NamedTuple):
         xf.tag(
             "scale",
             {
-                "x": str(float(self.scale[0])),
-                "y": str(float(self.scale[1])),
-                "z": str(float(self.scale[2])),
+                "x": str(float(self.scale.factor[0])),
+                "y": str(float(self.scale.factor[1])),
+                "z": str(float(self.scale.factor[2])),
+                "unit":  self.scale.unit.value
             },
         )
 
@@ -251,7 +252,7 @@ class Parameters(NamedTuple):
                     float(scale_element.get("z", 0)),
                 ),
                 unit=length_unit_from_str(scale_element.get("unit", "nm")),
-            ).to_nanometer(),
+            ),
             offset=offset,
             time=time,
             editPosition=editPosition,

--- a/webknossos/webknossos/_nml/parameters.py
+++ b/webknossos/webknossos/_nml/parameters.py
@@ -3,6 +3,9 @@ from xml.etree.ElementTree import Element
 
 from loxun import XmlWriter
 
+from webknossos.dataset.length_unit import length_unit_from_str
+from webknossos.dataset.properties import VoxelSize
+
 from ..geometry import BoundingBox, NDBoundingBox
 from ..geometry.bounding_box import _DEFAULT_BBOX_NAME
 from .utils import Vector3, enforce_not_null, filter_none_values
@@ -241,11 +244,14 @@ class Parameters(NamedTuple):
             description=experiment_element.get("description"),
             organization=experiment_element.get("organization"),
             dataset_id=experiment_element.get("datasetId"),
-            scale=(
-                float(scale_element.get("x", 0)),
-                float(scale_element.get("y", 0)),
-                float(scale_element.get("z", 0)),
-            ),
+            scale=VoxelSize(
+                factor=(
+                    float(scale_element.get("x", 0)),
+                    float(scale_element.get("y", 0)),
+                    float(scale_element.get("z", 0)),
+                ),
+                unit=length_unit_from_str(scale_element.get("unit", "nm")),
+            ).to_nanometer(),
             offset=offset,
             time=time,
             editPosition=editPosition,

--- a/webknossos/webknossos/annotation/_nml_conversion.py
+++ b/webknossos/webknossos/annotation/_nml_conversion.py
@@ -154,7 +154,7 @@ def annotation_to_nml(
     nml_parameters = wknml.Parameters(
         dataset_id=annotation.dataset_id,
         name=annotation.dataset_name,
-        scale=annotation.voxel_size,
+        scale=annotation.voxel_size_with_unit,
         description=annotation.description,
         organization=annotation.organization_id,
         time=annotation.time,

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -72,7 +72,7 @@ from ..dataset import (
     SegmentationLayer,
 )
 from ..dataset.defaults import PROPERTIES_FILE_NAME, SSL_CONTEXT
-from ..dataset.properties import DatasetProperties, dataset_converter
+from ..dataset.properties import DatasetProperties, VoxelSize, dataset_converter
 from ..geometry import NDBoundingBox, Vec3Int
 from ..skeleton import Skeleton
 from ..utils import get_executor_for_args, time_since_epoch_in_ms
@@ -300,6 +300,14 @@ class Annotation:
     @voxel_size.setter
     def voxel_size(self, voxel_size: tuple[float, float, float]) -> None:
         self.skeleton.voxel_size = voxel_size
+
+    @property
+    def voxel_size_with_unit(self) -> VoxelSize:
+        return self.skeleton.voxel_size_with_unit
+
+    @voxel_size_with_unit.setter
+    def voxel_size_with_unit(self, voxel_size: VoxelSize) -> None:
+        self.skeleton.voxel_size_with_unit = voxel_size
 
     @property
     def organization_id(self) -> str | None:

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -82,7 +82,7 @@ class Skeleton(Group):
         - Annotation: Container class for working with WEBKNOSSOS
     """
 
-    _voxel_size: VoxelSize
+    _voxel_size: VoxelSize | Vector3
     dataset_name: str
     dataset_id: str | None = None
     organization_id: str | None = None
@@ -99,6 +99,8 @@ class Skeleton(Group):
     _skeleton: "Skeleton" = attr.field(init=False, eq=False, repr=False)
 
     def __attrs_post_init__(self) -> None:
+        if not isinstance(self._voxel_size, VoxelSize):
+            self._voxel_size = VoxelSize(self._voxel_size)
         self._element_id_generator = itertools.count()
         self._skeleton = self
         super().__attrs_post_init__()  # sets self._id
@@ -110,6 +112,7 @@ class Skeleton(Group):
         Returns:
             Vector3: A tuple (x, y, z) representing the voxel size in nanometers.
         """
+        assert isinstance(self._voxel_size, VoxelSize)
         return self._voxel_size.to_nanometer()
 
     @voxel_size.setter
@@ -119,6 +122,7 @@ class Skeleton(Group):
         Args:
             voxel_size (Vector3): A tuple (x, y, z) representing the new voxel size in nanometers.
         """
+        assert isinstance(self._voxel_size, VoxelSize)
         conversion_factor = _LENGTH_UNIT_TO_NANOMETER[self._voxel_size.unit]
         new_factor = (
             voxel_size[0] / conversion_factor,
@@ -137,6 +141,7 @@ class Skeleton(Group):
         Returns:
             VoxelSize: An instance of VoxelSize containing the scale factor and unit.
         """
+        assert isinstance(self._voxel_size, VoxelSize)
         return self._voxel_size
 
     @voxel_size_with_unit.setter

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -120,7 +120,11 @@ class Skeleton(Group):
             voxel_size (Vector3): A tuple (x, y, z) representing the new voxel size in nanometers.
         """
         conversion_factor = _LENGTH_UNIT_TO_NANOMETER[self._voxel_size.unit]
-        new_factor = voxel_size[0] / conversion_factor, voxel_size[1] / conversion_factor, voxel_size[2] / conversion_factor
+        new_factor = (
+            voxel_size[0] / conversion_factor,
+            voxel_size[1] / conversion_factor,
+            voxel_size[2] / conversion_factor,
+        )
         self._voxel_size = VoxelSize(
             factor=new_factor,
             unit=self._voxel_size.unit,

--- a/webknossos/webknossos/skeleton/skeleton.py
+++ b/webknossos/webknossos/skeleton/skeleton.py
@@ -6,6 +6,9 @@ from pathlib import Path
 import attr
 import networkx as nx
 
+from webknossos.dataset.length_unit import _LENGTH_UNIT_TO_NANOMETER
+from webknossos.dataset.properties import VoxelSize
+
 from .group import Group
 
 Vector3 = tuple[float, float, float]
@@ -79,7 +82,7 @@ class Skeleton(Group):
         - Annotation: Container class for working with WEBKNOSSOS
     """
 
-    voxel_size: Vector3
+    _voxel_size: VoxelSize
     dataset_name: str
     dataset_id: str | None = None
     organization_id: str | None = None
@@ -99,6 +102,47 @@ class Skeleton(Group):
         self._element_id_generator = itertools.count()
         self._skeleton = self
         super().__attrs_post_init__()  # sets self._id
+
+    @property
+    def voxel_size(self) -> Vector3:
+        """Get the voxel size of the skeleton in nanometers.
+
+        Returns:
+            Vector3: A tuple (x, y, z) representing the voxel size in nanometers.
+        """
+        return self._voxel_size.to_nanometer()
+
+    @voxel_size.setter
+    def voxel_size(self, voxel_size: Vector3) -> None:
+        """Set the voxel size of the skeleton in nanometers.
+
+        Args:
+            voxel_size (Vector3): A tuple (x, y, z) representing the new voxel size in nanometers.
+        """
+        conversion_factor = _LENGTH_UNIT_TO_NANOMETER[self._voxel_size.unit]
+        new_factor = voxel_size[0] / conversion_factor, voxel_size[1] / conversion_factor, voxel_size[2] / conversion_factor
+        self._voxel_size = VoxelSize(
+            factor=new_factor,
+            unit=self._voxel_size.unit,
+        )
+
+    @property
+    def voxel_size_with_unit(self) -> VoxelSize:
+        """Get the voxel size of the skeleton with unit.
+
+        Returns:
+            VoxelSize: An instance of VoxelSize containing the scale factor and unit.
+        """
+        return self._voxel_size
+
+    @voxel_size_with_unit.setter
+    def voxel_size_with_unit(self, voxel_size: VoxelSize) -> None:
+        """Set the voxel size of the skeleton with unit.
+
+        Args:
+            voxel_size (VoxelSize): An instance of VoxelSize containing the new scale factor and unit.
+        """
+        self._voxel_size = voxel_size
 
     @staticmethod
     def load(file_path: PathLike | str) -> "Skeleton":


### PR DESCRIPTION
### Description:
- This PR changes the nml parsing to consider the unit in the scale tag. The x, y and z values of the scale are then converted to use the unit nanometers.

### Issues:
- fixes #1334 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
