### PR TITLE
Enable image captions for docs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -126,6 +126,7 @@ markdown_extensions:
   - pymdownx.keys
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.blocks.caption
   - toc:
       title: ON THIS PAGE
       permalink: true  

--- a/docs/src/webknossos-py/examples/learned_segmenter.md
+++ b/docs/src/webknossos-py/examples/learned_segmenter.md
@@ -2,14 +2,15 @@
 
 This example trains a segmenter from a volume annotation and applies it to the whole dataset.
 
-<figure markdown>
-  ![Volume annotation used for training](./learned_segmenter_annotation.png)
-  <figcaption>Volume annotation used for training</figcaption>
-</figure>
-<figure markdown>
-  ![Result of the trained segmenter on the full dataset](./learned_segmenter_result.png)
-  <figcaption>Result of the trained segmenter on the full dataset</figcaption>
-</figure>
+![Volume annotation used for training](./learned_segmenter_annotation.png)
+/// caption
+Volume annotation used for training
+///
+
+![Result of the trained segmenter on the full dataset](./learned_segmenter_result.png)
+/// caption
+Result of the trained segmenter on the full dataset
+///
 
 It builds upon the two previous examples using the [Dataset API](dataset_usage.md) and [dataset upload](upload_image_data.md).
 Additionally, it downloads [this manual volume annotation of a subset of the skin example dataset](https://webknossos.org/annotations/Explorational/616457c2010000870032ced4) which is used for training.

--- a/docs/src/webknossos-py/examples/upload_image_data.md
+++ b/docs/src/webknossos-py/examples/upload_image_data.md
@@ -9,3 +9,6 @@ webknossos/examples/upload_image_data.py
 ```
 
 ![Cell Dataset uploaded to WEBKNOSSOS](./upload_image_data_dataset.jpg)
+/// caption
+Cell Dataset uploaded to WEBKNOSSOS
+///

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -1152,15 +1152,15 @@ wheels = [
 
 [[package]]
 name = "pymdown-extensions"
-version = "10.4"
+version = "10.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markdown" },
     { name = "pyyaml" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/71/5f48080bde77b07ca1eba6d7cb5c5598ac6c8f2a399846159b3c8b45e171/pymdown_extensions-10.4.tar.gz", hash = "sha256:bc46f11749ecd4d6b71cf62396104b4a200bad3498cb0f5dad1b8502fe461a35", size = 785151, upload-time = "2023-11-10T23:40:31.345Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/b3/6d2b3f149bc5413b0a29761c2c5832d8ce904a1d7f621e86616d96f505cc/pymdown_extensions-10.16.1.tar.gz", hash = "sha256:aace82bcccba3efc03e25d584e6a22d27a8e17caa3f4dd9f207e49b787aa9a91", size = 853277, upload-time = "2025-07-28T16:19:34.167Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/2d/2929de81618c7213176899dd6372d6ec9c8f24337841dd74634fb69864ae/pymdown_extensions-10.4-py3-none-any.whl", hash = "sha256:cfc28d6a09d19448bcbf8eee3ce098c7d17ff99f7bd3069db4819af181212037", size = 240838, upload-time = "2023-11-10T23:40:29.166Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/06/43084e6cbd4b3bc0e80f6be743b2e79fbc6eed8de9ad8c629939fa55d972/pymdown_extensions-10.16.1-py3-none-any.whl", hash = "sha256:d6ba157a6c03146a7fb122b2b9a121300056384eafeec9c9f9e584adfdb2a32d", size = 266178, upload-time = "2025-07-28T16:19:31.401Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
### Description:
- This PR enables image captions for our docs. 
  - See [MkDocs Documentation](https://squidfunk.github.io/mkdocs-material/setup/extensions/python-markdown-extensions/#caption)
- Updated the `pymdown-extensions` lib used by `mkdocs` to v10.12 to enable the [captions]( https://facelessuser.github.io/pymdown-extensions/extensions/blocks/plugins/caption/).
- Updated the few wk-libs pages, that contain images


### Example
<img width="1344" height="833" alt="Screenshot 2025-09-22 at 10 55 36" src="https://github.com/user-attachments/assets/1f9f8338-8ac8-429b-bbbb-9917d92dd7eb" />


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
