### PR TITLE
Fix upsampled Mag-1 bounding box in BufferedSliceWriter

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed a bug in the `BufferedSliceWriter`, where Mag-1 bounding boxes were upscaled when writing to a non-Mag-1 view. [#1451](https://github.com/scalableminds/webknossos-libs/pull/1451)
 
 
 ## [3.3.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.3.0) - 2026-03-31

--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -379,9 +379,13 @@ def test_buffered_slice_writer_resize_error(tmp_upath: UPath) -> None:
 
 
 def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
-    target_mag = Mag("2-2-1")  # write to a non mag1 mag using an absolute bbox with offset
+    target_mag = Mag(
+        "2-2-1"
+    )  # write to a non mag1 mag using an absolute bbox with offset
 
-    mag1_bbox = BoundingBox((128, 128, 0), (32, 32, 8))  # intentionally start at some offset
+    mag1_bbox = BoundingBox(
+        (128, 128, 0), (32, 32, 8)
+    )  # intentionally start at some offset
     mag2_bbox = mag1_bbox.align_with_mag(target_mag).in_mag(target_mag)
 
     # Allocate some data

--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -376,3 +376,34 @@ def test_buffered_slice_writer_resize_error(tmp_upath: UPath) -> None:
             for z in range(0, shape[2]):
                 section = data[:, :, z]
                 writer.send(section)
+
+
+def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
+    target_mag = Mag("2-2-1")  # write to a non mag1 mag using an absolute bbox with offset
+
+    mag1_bbox = BoundingBox((128, 128, 0), (32, 32, 8))  # intentionally start at some offset
+    mag2_bbox = mag1_bbox.align_with_mag(target_mag).in_mag(target_mag)
+
+    # Allocate some data
+    data = np.random.randint(0, 255, mag2_bbox.size, dtype=np.uint8)
+
+    # Create DS
+    dataset = Dataset(tmp_upath, voxel_size=(1, 1, 1))
+    layer = dataset.add_layer(
+        layer_name="color",
+        category="color",
+        dtype="uint8",
+        num_channels=1,
+        bounding_box=mag1_bbox,
+    )
+    mag2 = layer.add_mag("2-2-1")
+
+    # Write some slices
+    with mag2.get_buffered_slice_writer(absolute_bounding_box=mag1_bbox) as writer:
+        for z in range(0, mag2_bbox.size[2]):
+            section = data[:, :, z]
+            writer.send(section)
+
+    written_data = mag2.read(absolute_bounding_box=mag1_bbox)
+
+    assert np.all(data == written_data)

--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -379,13 +379,11 @@ def test_buffered_slice_writer_resize_error(tmp_upath: UPath) -> None:
 
 
 def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
-    target_mag = Mag(
-        "2-2-1"
-    )  # write to a non mag1 mag using an absolute bbox with offset
+    # write to a non mag1 mag using an absolute bbox with offset
+    target_mag = Mag("2-2-1")
 
-    mag1_bbox = BoundingBox(
-        (128, 128, 0), (32, 32, 8)
-    )  # intentionally start at some offset
+    # intentionally start at some odd offset
+    mag1_bbox = BoundingBox((128, 128, 0), (32, 32, 8))
     mag2_bbox = mag1_bbox.align_with_mag(target_mag).in_mag(target_mag)
 
     # Allocate some data
@@ -399,6 +397,7 @@ def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
         dtype="uint8",
         num_channels=1,
         bounding_box=mag1_bbox,
+        chunk_shape=mag1_bbox.size,
     )
     mag2 = layer.add_mag("2-2-1")
 
@@ -409,5 +408,4 @@ def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
             writer.send(section)
 
     written_data = mag2.read(absolute_bounding_box=mag1_bbox)
-
-    assert np.all(data == written_data)
+    np.testing.assert_array_equal(data, written_data.squeeze())

--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -382,9 +382,9 @@ def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
     # write to a non mag1 mag using an absolute bbox with offset
     target_mag = Mag("2-2-1")
 
-    # intentionally start at some odd offset
+    # intentionally start at some offset
     mag1_bbox = BoundingBox((128, 128, 0), (32, 32, 8))
-    mag2_bbox = mag1_bbox.align_with_mag(target_mag).in_mag(target_mag)
+    mag2_bbox = mag1_bbox.in_mag(target_mag)
 
     # Allocate some data
     data = np.random.randint(0, 255, tuple(mag2_bbox.size), dtype=np.uint8)

--- a/webknossos/tests/dataset/test_buffered_slice_utils.py
+++ b/webknossos/tests/dataset/test_buffered_slice_utils.py
@@ -389,7 +389,7 @@ def test_buffered_slice_writer_mag2_absolute_bbox(tmp_upath: UPath) -> None:
     mag2_bbox = mag1_bbox.align_with_mag(target_mag).in_mag(target_mag)
 
     # Allocate some data
-    data = np.random.randint(0, 255, mag2_bbox.size, dtype=np.uint8)
+    data = np.random.randint(0, 255, tuple(mag2_bbox.size), dtype=np.uint8)
 
     # Create DS
     dataset = Dataset(tmp_upath, voxel_size=(1, 1, 1))

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -162,10 +162,14 @@ class BufferedSliceWriter:
             )
             buffer_depth = min(self._buffer_size, len(self._slices_to_write))
 
+            # downsample bbox to the mag of the view,
+            # so that the topleft is in the mags coordinate system
+            mag = self._view._mag
+            downsampled_bbox = self._bbox.align_with_mag(mag).in_mag(mag)
             bbox = (
-                self._bbox.with_bounds(
+                downsampled_bbox.with_bounds(
                     self.dimension,
-                    new_topleft=self._bbox.topleft.get(self.dimension)
+                    new_topleft=downsampled_bbox.topleft.get(self.dimension)
                     + self._buffer_start_slice,
                     new_size=buffer_depth,
                 )
@@ -235,7 +239,7 @@ class BufferedSliceWriter:
 
                 self._view.write(
                     data,
-                    absolute_bounding_box=chunk_bbox.from_mag_to_mag1(self._view._mag),
+                    absolute_bounding_box=chunk_bbox.from_mag_to_mag1(mag),
                     allow_unaligned=self._allow_unaligned,
                 )
                 del data

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -83,6 +83,9 @@ class BufferedSliceWriter:
             absolute_bounding_box,
         )
 
+        # assert that self.bbox is aligned with the mag of the view
+        self._bbox.in_mag(self._view.mag)  # will throw error if not aligned
+
         view_shard_depth = self._view.info.chunk_shape.get(self.dimension)
         if (
             self._bbox is not None

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -164,7 +164,7 @@ class BufferedSliceWriter:
 
             # downsample bbox to the mag of the view,
             # so that the topleft is in the mags coordinate system
-            mag = self._view._mag
+            mag = self._view.mag
             downsampled_bbox = self._bbox.align_with_mag(mag).in_mag(mag)
             bbox = (
                 downsampled_bbox.with_bounds(

--- a/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
+++ b/webknossos/webknossos/dataset/_utils/buffered_slice_writer.py
@@ -165,7 +165,8 @@ class BufferedSliceWriter:
             # downsample bbox to the mag of the view,
             # so that the topleft is in the mags coordinate system
             mag = self._view.mag
-            downsampled_bbox = self._bbox.align_with_mag(mag).in_mag(mag)
+            # this will throw if the bbox is not already mag aligned
+            downsampled_bbox = self._bbox.in_mag(mag)
             bbox = (
                 downsampled_bbox.with_bounds(
                     self.dimension,


### PR DESCRIPTION
### Description:
- fix BufferedSliceWriter upsampled mag1 bbox

### Issues:
- fixes #1449
- see [CI log](https://github.com/scalableminds/webknossos-libs/actions/runs/24132374093/job/70411917733?pr=1451) for error message using newly created test

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [x] Added / Updated Tests
 - [ ] Considered adding this to the Examples
