### PR TITLE
Link API page for Annotation in nav structure

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -288,7 +288,7 @@ nav:
         - DataFormat: api/webknossos/dataset_properties/data_format.md
         - LengthUnit: api/webknossos/dataset_properties/length_unit.md
         - LayerToLink: api/webknossos/dataset/layer/layer_to_link.md
-      - Annotations:
+      - Annotation:
         - Annotation: api/webknossos/annotation/annotation.md
         - AnnotationInfo: api/webknossos/annotation/annotation_info.md
       - Skeleton:

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -288,6 +288,9 @@ nav:
         - DataFormat: api/webknossos/dataset_properties/data_format.md
         - LengthUnit: api/webknossos/dataset_properties/length_unit.md
         - LayerToLink: api/webknossos/dataset/layer/layer_to_link.md
+      - Annotations:
+        - Annotation: api/webknossos/annotation/annotation.md
+        - AnnotationInfo: api/webknossos/annotation/annotation_info.md
       - Skeleton:
         - Skeleton: api/webknossos/skeleton/skeleton.md
         - Group: api/webknossos/skeleton/group.md


### PR DESCRIPTION
### Description:
- Extend the docs to link API page for Annotation in nav structure. Seem like a pretty serious omission.

<img width="405" height="402" alt="Screenshot 2026-04-09 at 20 45 26" src="https://github.com/user-attachments/assets/a880e535-5924-49a2-8a85-eb39d1a6ec4a" />


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [ ] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
