### PR TITLE
adds slurm+batching option to CLI commands

### DIFF
--- a/cluster_tools/cluster_tools/executors/batching.py
+++ b/cluster_tools/cluster_tools/executors/batching.py
@@ -121,9 +121,9 @@ class BatchingExecutor:
         all_item_futures: list[Future[_T]] = []
 
         for batch in _iter_batches(items, batch_size):
-            (batch_future,) = self._executor.map_to_futures(
-                partial(_apply_fn_to_batch, fn), [batch]
-            )
+            batch_fn = partial(_apply_fn_to_batch, fn)
+            batch_fn.__name__ = f"batch_{fn.__name__}"  # type: ignore[attr-defined]
+            (batch_future,) = self._executor.map_to_futures(batch_fn, [batch])
             item_futures: list[Future[_T]] = [Future() for _ in batch]
             all_item_futures.extend(item_futures)
 
@@ -159,8 +159,10 @@ class BatchingExecutor:
         batch_size = self._resolve_batch_size(len(items))
 
         def result_generator() -> Iterator[_T]:
+            batch_fn = partial(_apply_fn_to_batch, fn)
+            batch_fn.__name__ = f"batch_{fn.__name__}"  # type: ignore[attr-defined]
             for batch_results in self._executor.map(
-                partial(_apply_fn_to_batch, fn),
+                batch_fn,
                 _iter_batches(items, batch_size),
                 timeout=timeout,
             ):

--- a/docs/src/cli/compress.md
+++ b/docs/src/cli/compress.md
@@ -31,7 +31,7 @@ webknossos compress [OPTIONS] TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 - `--job-resources`  

--- a/docs/src/cli/compress.md
+++ b/docs/src/cli/compress.md
@@ -36,7 +36,7 @@ webknossos compress [OPTIONS] TARGET
 
 - `--job-resources`  
     Specify resources for jobs when using the SLURM distribution strategy.  
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 ## Example Commands
 
@@ -60,7 +60,7 @@ This command compresses the `1` and `2` magnifications in all layers of the data
 
 ### Compress using SLURM with custom job resources:
 ```bash
-compress --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/dataset
+compress --distribution-strategy slurm --job-resources mem=10M /path/to/dataset
 ```
 This command uses the SLURM distribution strategy with custom memory allocation for each job.
 

--- a/docs/src/cli/convert.md
+++ b/docs/src/cli/convert.md
@@ -113,7 +113,7 @@ webknossos convert [OPTIONS] SOURCE [TARGET]
 
 - `--distribution-strategy`
     Strategy to distribute the task across CPUs or nodes.
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`.
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`.
     Default: `multiprocessing`.
 
 - `--job-resources`
@@ -291,7 +291,7 @@ webknossos convert-raw [OPTIONS] SOURCE TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 ### Example Commands
@@ -367,7 +367,7 @@ webknossos convert-knossos [OPTIONS] SOURCE TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 ### Example Commands
@@ -475,7 +475,7 @@ webknossos convert-zarr [OPTIONS] SOURCE TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 ### Example Commands

--- a/docs/src/cli/convert.md
+++ b/docs/src/cli/convert.md
@@ -118,7 +118,7 @@ webknossos convert [OPTIONS] SOURCE [TARGET]
 
 - `--job-resources`
     JSON string to specify resources for jobs when using the SLURM distribution strategy.
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 #### WEBKNOSSOS context
 
@@ -495,7 +495,7 @@ webknossos convert-zarr --jobs 4 /path/to/source/zarr /path/to/target/dataset
 Convert a Zarr dataset using SLURM with custom job resources:
 
 ```bash
-webknossos convert-zarr --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/source/zarr /path/to/target/dataset
+webknossos convert-zarr --distribution-strategy slurm --job-resources mem=10M /path/to/source/zarr /path/to/target/dataset
 ```
 
 ---

--- a/docs/src/cli/copy.md
+++ b/docs/src/cli/copy.md
@@ -42,7 +42,7 @@ webknossos copy-dataset [OPTIONS] SOURCE TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`.  
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`.  
     Default: `multiprocessing`.
 
 - `--job-resources`  

--- a/docs/src/cli/copy.md
+++ b/docs/src/cli/copy.md
@@ -47,7 +47,7 @@ webknossos copy-dataset [OPTIONS] SOURCE TARGET
 
 - `--job-resources`  
     Specify resources for jobs when using the SLURM distribution strategy.  
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 ### Environment Variables for Remote Paths
 
@@ -88,7 +88,7 @@ This command uses 4 parallel processes to speed up the dataset copying process.
 
 ### Copy a dataset using SLURM with custom job resources:
 ```bash
-webknossos copy-dataset --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/source/dataset /path/to/target/dataset
+webknossos copy-dataset --distribution-strategy slurm --job-resources mem=10M /path/to/source/dataset /path/to/target/dataset
 ```
 This command uses the SLURM distribution strategy with custom memory allocation for each job.
 

--- a/docs/src/cli/distribution_strategies.md
+++ b/docs/src/cli/distribution_strategies.md
@@ -29,14 +29,14 @@ Below is a list of the allowed resources and a brief explanation of each. For fu
 
 The `slurm+batching` strategy is a variant of the SLURM strategy that groups individual tasks into larger batches before submitting them to the cluster. This reduces scheduling overhead and is especially useful when the dataset produces a large number of small work items that would otherwise flood the job queue.
 
-Like the `slurm` strategy, `--job-resources` is required. The number of SLURM jobs to submit is controlled by `--jobs`. Alternatively, you can specify `batch_size` in `--job-resources` to fix the number of work items per job instead — in that case `--jobs` must not be set:
+Like the `slurm` strategy, `--job-resources` is required. The number of SLURM jobs to submit is controlled by `--jobs`. Alternatively, you can specify `batch-size` in `--job-resources` to fix the number of work items per job instead — in that case `--jobs` must not be set:
 
 ```bash
 # Use --jobs to control the total number of submitted SLURM jobs
 --jobs 100 --job-resources mem=32G
 
 # Or fix the number of work items per job via batch_size
---job-resources batch_size=50,mem=32G
+--job-resources batch-size=50,mem=32G
 ```
 
 All other SLURM resource keys (e.g. `mem`, `time`, `partition`) are supported just as with the plain `slurm` strategy.

--- a/docs/src/cli/distribution_strategies.md
+++ b/docs/src/cli/distribution_strategies.md
@@ -25,6 +25,22 @@ Below is a list of the allowed resources and a brief explanation of each. For fu
 - **reservation**: Indicates a reservation name if specific reserved resources need to be used.
 - **time**: Sets the time limit for the job execution, as defined by SLURM.
 
+## SLURM+BATCHING
+
+The `slurm+batching` strategy is a variant of the SLURM strategy that groups individual tasks into larger batches before submitting them to the cluster. This reduces scheduling overhead and is especially useful when the dataset produces a large number of small work items that would otherwise flood the job queue.
+
+Like the `slurm` strategy, `--job-resources` is required. In addition, you must specify either `target_job_count` (the desired total number of SLURM jobs) or `batch_size` (the number of work items per job) — but not both:
+
+```bash
+# Limit the total number of submitted jobs
+--job-resources '{"target_job_count": 100, "mem": "32G"}'
+
+# Or set an explicit batch size
+--job-resources '{"batch_size": 50, "mem": "32G"}'
+```
+
+All other SLURM resource keys (e.g. `mem`, `time`, `partition`) are supported just as with the plain `slurm` strategy.
+
 ## KUBERNETES
 
 The `kubernetes` strategy allows tasks to execute within a Kubernetes cluster. It is ideal for containerized workflows and scalable orchestration. This strategy handles job creation and resource allocation automatically based on your Kubernetes configuration.

--- a/docs/src/cli/distribution_strategies.md
+++ b/docs/src/cli/distribution_strategies.md
@@ -27,7 +27,7 @@ Below is a list of the allowed resources and a brief explanation of each. For fu
 
 ## SLURM+BATCHING
 
-The `slurm+batching` strategy is a variant of the SLURM strategy that groups individual tasks into larger batches before submitting them to the cluster. This reduces scheduling overhead and is especially useful when the dataset produces a large number of small work items that would otherwise flood the job queue.
+The `slurm+batching` strategy is a variant of the SLURM strategy that groups individual tasks into larger batches before submitting them to the cluster. This reduces scheduling overhead and is especially useful when the dataset produces a large number of small work items that would otherwise flood the job queue. Within each batch the tasks are executed sequentially. 
 
 Like the `slurm` strategy, `--job-resources` is required. The number of SLURM jobs to submit is controlled by `--jobs`. Alternatively, you can specify `batch-size` in `--job-resources` to fix the number of work items per job instead — in that case `--jobs` must not be set:
 
@@ -39,7 +39,7 @@ Like the `slurm` strategy, `--job-resources` is required. The number of SLURM jo
 --job-resources batch-size=50,mem=32G
 ```
 
-All other SLURM resource keys (e.g. `mem`, `time`, `partition`) are supported just as with the plain `slurm` strategy.
+All other SLURM resource keys (e.g. `mem`, `time`, `partition`) are supported just as with the plain `slurm` strategy. The job resources are applied to each batch. 
 
 ## KUBERNETES
 

--- a/docs/src/cli/distribution_strategies.md
+++ b/docs/src/cli/distribution_strategies.md
@@ -7,7 +7,7 @@ The CLI offers several distribution strategies to execute tasks, each designed f
 Deploy tasks on a SLURM cluster to leverage distributed computing resources. When using the `slurm` strategy, you can configure SLURM-specific options to fine-tune your job scheduling and resource allocation. For example, you may supply job resources via parameters like:
 
 ```bash
---job-resources '{"mem": "10M", "time": "00:05:00", "partition": "cpu"}'
+--job-resources mem=10M,time=00:05:00,partition=cpu
 ```
 
 Below is a list of the allowed resources and a brief explanation of each. For further details on their meanings, please refer to the [SLURM sbatch documentation](https://slurm.schedmd.com/sbatch.html):
@@ -29,14 +29,14 @@ Below is a list of the allowed resources and a brief explanation of each. For fu
 
 The `slurm+batching` strategy is a variant of the SLURM strategy that groups individual tasks into larger batches before submitting them to the cluster. This reduces scheduling overhead and is especially useful when the dataset produces a large number of small work items that would otherwise flood the job queue.
 
-Like the `slurm` strategy, `--job-resources` is required. In addition, you must specify either `target_job_count` (the desired total number of SLURM jobs) or `batch_size` (the number of work items per job) — but not both:
+Like the `slurm` strategy, `--job-resources` is required. The number of SLURM jobs to submit is controlled by `--jobs`. Alternatively, you can specify `batch_size` in `--job-resources` to fix the number of work items per job instead — in that case `--jobs` must not be set:
 
 ```bash
-# Limit the total number of submitted jobs
---job-resources '{"target_job_count": 100, "mem": "32G"}'
+# Use --jobs to control the total number of submitted SLURM jobs
+--jobs 100 --job-resources mem=32G
 
-# Or set an explicit batch size
---job-resources '{"batch_size": 50, "mem": "32G"}'
+# Or fix the number of work items per job via batch_size
+--job-resources batch_size=50,mem=32G
 ```
 
 All other SLURM resource keys (e.g. `mem`, `time`, `partition`) are supported just as with the plain `slurm` strategy.

--- a/docs/src/cli/downsample.md
+++ b/docs/src/cli/downsample.md
@@ -68,7 +68,7 @@ webknossos downsample [OPTIONS] TARGET
 
 - `--job-resources`
     JSON string to specify resources for jobs when using the SLURM distribution strategy.
-    Example: `--job-resources '{"mem": "10M"}'`
+    Example: `--job-resources mem=10M`
 
 ## Example Commands
 
@@ -89,7 +89,7 @@ webknossos downsample --coarsest-mag 2 /path/to/dataset
 
 ### Downsample with parallel execution and custom job settings:
 ```bash
-webknossos downsample --jobs 4 --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/dataset
+webknossos downsample --jobs 4 --distribution-strategy slurm --job-resources mem=10M /path/to/dataset
 ```
 
 ### Downsample a dataset on a WEBKNOSSOS server:

--- a/docs/src/cli/downsample.md
+++ b/docs/src/cli/downsample.md
@@ -62,7 +62,7 @@ webknossos downsample [OPTIONS] TARGET
 
 - `--distribution-strategy`
     Strategy to distribute the task across CPUs or nodes.
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`.
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`.
     Default: `multiprocessing`
     Example: `--distribution-strategy sequential`
 

--- a/docs/src/cli/export-as-tiff.md
+++ b/docs/src/cli/export-as-tiff.md
@@ -64,7 +64,7 @@ webknossos export-as-tiff [OPTIONS] SOURCE TARGET
 
 - `--job-resources`  
     Resources specification for jobs when using the SLURM strategy.  
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 ## Example Commands
 
@@ -86,7 +86,7 @@ webknossos export-as-tiff --bbox 0,0,0,512,512,100 --tiles-per-dimension 4,4 /pa
 
 ### Export using parallel processing with SLURM:
 ```bash
-webknossos export-as-tiff --jobs 8 --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/source/dataset /path/to/target/tiff_folder
+webknossos export-as-tiff --jobs 8 --distribution-strategy slurm --job-resources mem=10M /path/to/source/dataset /path/to/target/tiff_folder
 ```
 
 ## Notes

--- a/docs/src/cli/export-as-tiff.md
+++ b/docs/src/cli/export-as-tiff.md
@@ -66,6 +66,16 @@ webknossos export-as-tiff [OPTIONS] SOURCE TARGET
     Resources specification for jobs when using the SLURM strategy.  
     Example: `--job-resources '{"mem": "10M"}'`.
 
+#### WEBKNOSSOS context
+
+- `--token`  
+    Authentication token for the WEBKNOSSOS instance (see https://webknossos.org/auth/token).  
+    Can also be provided via the `WK_TOKEN` environment variable.  
+    Required when SOURCE is a WEBKNOSSOS server URL pointing to a non-public dataset.
+
+- `--access-mode`  
+    How to access the remote dataset's data. Available options are `direct_path`, `zarr_streaming`, `proxy_path`.
+
 ## Example Commands
 
 ### Export a dataset to TIFF images locally:

--- a/docs/src/cli/export-as-tiff.md
+++ b/docs/src/cli/export-as-tiff.md
@@ -41,6 +41,12 @@ webknossos export-as-tiff [OPTIONS] SOURCE TARGET
     Downsample factor for each TIFF image.  
     Default: `1`.
 
+- `--apply-mapping`  
+    Name of an agglomerate attachment on the segmentation layer. When provided,
+    segment IDs are replaced with their agglomerate IDs before writing each TIFF.
+    Requires `--layer-name` to point to a segmentation layer that has a Zarr3-format
+    agglomerate attachment with the given name.
+
 - `--tiles-per-dimension`  
     Define tiling by specifying the number of tiles per dimension in the form `x,y`.  
     When set, each slice is exported as multiple tiled images.

--- a/docs/src/cli/export-as-tiff.md
+++ b/docs/src/cli/export-as-tiff.md
@@ -59,7 +59,7 @@ webknossos export-as-tiff [OPTIONS] SOURCE TARGET
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 - `--job-resources`  

--- a/docs/src/cli/merge-fallback.md
+++ b/docs/src/cli/merge-fallback.md
@@ -39,7 +39,7 @@ webknossos merge-fallback [OPTIONS] TARGET SOURCE_ANNOTATION DATASET_DIRECTORY
 
 - `--job-resources`  
     Specify resources for jobs when using the SLURM distribution strategy.  
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 ## Example Commands
 
@@ -56,7 +56,7 @@ webknossos merge-fallback --volume-layer-name my_volume /path/to/output/dataset 
 
 ### Merge fallback layer with parallel execution and custom job settings:
 ```bash
-webknossos merge-fallback --jobs 4 --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/output/dataset /path/to/source/annotation.zip /path/to/dataset/folder
+webknossos merge-fallback --jobs 4 --distribution-strategy slurm --job-resources mem=10M /path/to/output/dataset /path/to/source/annotation.zip /path/to/dataset/folder
 ```
 Uses 4 parallel processes with SLURM to merge the fallback layer, allocating custom memory to each job.
 

--- a/docs/src/cli/merge-fallback.md
+++ b/docs/src/cli/merge-fallback.md
@@ -34,7 +34,7 @@ webknossos merge-fallback [OPTIONS] TARGET SOURCE_ANNOTATION DATASET_DIRECTORY
 
 - `--distribution-strategy`  
     Strategy to distribute the task across CPUs or nodes.  
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`. 
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`. 
     Default: `multiprocessing`.
 
 - `--job-resources`  

--- a/docs/src/cli/upsample.md
+++ b/docs/src/cli/upsample.md
@@ -57,7 +57,7 @@ webknossos upsample [OPTIONS] SOURCE
 
 - `--distribution-strategy`
     Strategy to distribute the task across CPUs or nodes.
-    Options: `multiprocessing`, `slurm`, `kubernetes`, `sequential`.
+    Options: `multiprocessing`, `slurm`, `slurm+batching`, `kubernetes`, `sequential`.
     Default: `multiprocessing`.
 
 - `--job-resources`

--- a/docs/src/cli/upsample.md
+++ b/docs/src/cli/upsample.md
@@ -63,7 +63,7 @@ webknossos upsample [OPTIONS] SOURCE
 - `--job-resources`
     Specify resources for jobs when using the SLURM distribution strategy.
     Should be a JSON string.
-    Example: `--job-resources '{"mem": "10M"}'`.
+    Example: `--job-resources mem=10M`.
 
 ## Example Commands
 
@@ -79,7 +79,7 @@ webknossos upsample --from-mag 2 --layer-name gray_matter /path/to/dataset
 
 ### Upsample with parallel execution using SLURM:
 ```bash
-webknossos upsample --from-mag 2 --distribution-strategy slurm --job-resources '{"mem": "10M"}' /path/to/dataset
+webknossos upsample --from-mag 2 --distribution-strategy slurm --job-resources mem=10M /path/to/dataset
 ```
 
 ### Upsample a dataset on a WEBKNOSSOS server:

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,12 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added `slurm+batching` distribution strategy for CLI commands. `--jobs` can be used to specify the target number of jobs and the `batch-size` key can be specified in the `--job-resources`. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
 
 ### Changed
+- The job resources for `slurm`, `slurm+batching` and `kubernetes` in the CLI commands are now specified as comma-separated key-value pairs instead of JSON, e.g. `--job-resources mem=10G,time=02:00:00`. The JSON syntax is still available for backwards compatibility. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
+- The `export-as-tiff` CLI command now compressed exported segmentation layers. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
+- S3 retry settings are eagerly applied for all CLI commands. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
 
 ### Fixed
 - Fixed a bug in the `BufferedSliceWriter`, where Mag-1 bounding boxes were upscaled when writing to a non-Mag-1 view. [#1451](https://github.com/scalableminds/webknossos-libs/pull/1451)

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added `slurm+batching` distribution strategy for CLI commands. `--jobs` can be used to specify the target number of jobs and the `batch-size` key can be specified in the `--job-resources`. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
+- Added the `--apply-mapping` option to the `export-as-tiff` CLI command. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)
 
 ### Changed
 - The job resources for `slurm`, `slurm+batching` and `kubernetes` in the CLI commands are now specified as comma-separated key-value pairs instead of JSON, e.g. `--job-resources mem=10G,time=02:00:00`. The JSON syntax is still available for backwards compatibility. [#1455](https://github.com/scalableminds/webknossos-libs/pull/1455)

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -323,7 +323,7 @@ def _test_bioformats(
     unzip_path = tmp_upath / "unzip"
     download_and_unpack(url, unzip_path, filename)
     ds = wk.Dataset(tmp_upath / "ds", (1, 1, 1))
-    with wk.utils.get_executor_for_args(None) as executor:
+    with wk.utils.wrap_executor() as executor:
         layer = ds.add_layer_from_images(
             str(unzip_path / filename),
             layer_name="color",
@@ -472,7 +472,7 @@ def _test_test_images(
         layer_name = filename
         path = unzip_path / filename
     ds = wk.Dataset(tmp_upath / "ds", (1, 1, 1))
-    with wk.utils.get_executor_for_args(None) as executor:
+    with wk.utils.wrap_executor() as executor:
         l_bio: wk.Layer | None
         try:
             l_bio = ds.add_layer_from_images(

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -323,7 +323,7 @@ def _test_bioformats(
     unzip_path = tmp_upath / "unzip"
     download_and_unpack(url, unzip_path, filename)
     ds = wk.Dataset(tmp_upath / "ds", (1, 1, 1))
-    with wk.utils.wrap_executor() as executor:
+    with SequentialExecutor() as executor:
         layer = ds.add_layer_from_images(
             str(unzip_path / filename),
             layer_name="color",
@@ -472,7 +472,7 @@ def _test_test_images(
         layer_name = filename
         path = unzip_path / filename
     ds = wk.Dataset(tmp_upath / "ds", (1, 1, 1))
-    with wk.utils.wrap_executor() as executor:
+    with SequentialExecutor() as executor:
         l_bio: wk.Layer | None
         try:
             l_bio = ds.add_layer_from_images(

--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -321,7 +321,7 @@ def test_url_download(url: str, tmp_upath: UPath) -> None:
     assert set(ds.layers.keys()) == {"color", "segmentation"}
     data = ds.get_color_layers()[0].get_finest_mag().read()
     assert data.sum() == 120697
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         data,
         sample_dataset.get_color_layers()[0].get_finest_mag().read(),
     )
@@ -351,7 +351,7 @@ def test_url_open_remote(
         .read(absolute_bounding_box=SAMPLE_BBOX)
     )
     assert data.sum() == 120697
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         data,
         sample_dataset.get_color_layers()[0].get_finest_mag().read(),
     )
@@ -370,7 +370,7 @@ def test_upload_dataset(tmp_upath: UPath, transfer_mode: TransferMode) -> None:
         new_dataset_name="test_remote_symlink",
         transfer_mode=transfer_mode,
     )
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         remote_ds.get_color_layers()[0].get_finest_mag().read(),
         sample_dataset.get_color_layers()[0].get_finest_mag().read(),
     )
@@ -379,7 +379,7 @@ def test_upload_dataset(tmp_upath: UPath, transfer_mode: TransferMode) -> None:
 def test_remote_dataset(tmp_upath: UPath) -> None:
     sample_dataset = get_sample_dataset(tmp_upath)
     remote_ds = sample_dataset.upload(new_dataset_name="test_remote_metadata")
-    assert np.array_equal(
+    np.testing.assert_array_equal(
         remote_ds.get_color_layers()[0].get_finest_mag().read(),
         sample_dataset.get_color_layers()[0].get_finest_mag().read(),
     )
@@ -458,7 +458,7 @@ def test_upload_download_roundtrip(tmp_upath: UPath) -> None:
 
     data_original = ds_original.get_segmentation_layers()[0].get_finest_mag().read()
     data_roundtrip = ds_roundtrip.get_segmentation_layers()[0].get_finest_mag().read()
-    assert np.array_equal(data_original, data_roundtrip)
+    np.testing.assert_array_equal(data_original, data_roundtrip)
 
 
 def test_upload_twice(tmp_upath: UPath) -> None:

--- a/webknossos/tests/dataset/test_upsampling.py
+++ b/webknossos/tests/dataset/test_upsampling.py
@@ -3,6 +3,7 @@ from collections.abc import Iterator
 
 import numpy as np
 import pytest
+from cluster_tools import SequentialExecutor
 from upath import UPath
 
 from webknossos import (
@@ -15,7 +16,6 @@ from webknossos import (
 )
 from webknossos.dataset.layer._upsampling_utils import upsample_cube, upsample_cube_job
 from webknossos.dataset.sampling_modes import SamplingModes
-from webknossos.utils import wrap_executor
 
 WKW_CUBE_SIZE = 1024
 BUFFER_SHAPE = Vec3Int.full(256)
@@ -241,7 +241,7 @@ def test_upsample_nd_dataset(tmp_upath: UPath) -> None:
     )
 
     source_mag = source_layer.get_mag("2")
-    with wrap_executor() as executor:
+    with SequentialExecutor() as executor:
         target_layer.add_mag_as_copy(source_mag, executor=executor)
         target_layer.upsample(
             from_mag=Mag(2),

--- a/webknossos/tests/dataset/test_upsampling.py
+++ b/webknossos/tests/dataset/test_upsampling.py
@@ -15,7 +15,7 @@ from webknossos import (
 )
 from webknossos.dataset.layer._upsampling_utils import upsample_cube, upsample_cube_job
 from webknossos.dataset.sampling_modes import SamplingModes
-from webknossos.utils import get_executor_for_args
+from webknossos.utils import wrap_executor
 
 WKW_CUBE_SIZE = 1024
 BUFFER_SHAPE = Vec3Int.full(256)
@@ -241,7 +241,7 @@ def test_upsample_nd_dataset(tmp_upath: UPath) -> None:
     )
 
     source_mag = source_layer.get_mag("2")
-    with get_executor_for_args(None) as executor:
+    with wrap_executor() as executor:
         target_layer.add_mag_as_copy(source_mag, executor=executor)
         target_layer.upsample(
             from_mag=Mag(2),

--- a/webknossos/tests/geometry/test_normalized_bounding_box.py
+++ b/webknossos/tests/geometry/test_normalized_bounding_box.py
@@ -37,7 +37,7 @@ def test_from_wkw_dict_with_axis_order() -> None:
     assert result.size.c == 1
 
 
-def test_from_wkw_dict_with_axis_order_missing_c() -> None:
+def test_from_wkw_dict_with_axis_order_implicit_c() -> None:
     result = NormalizedBoundingBox.from_wkw_dict(
         {
             "topLeft": [1, 2, 3],
@@ -52,6 +52,24 @@ def test_from_wkw_dict_with_axis_order_missing_c() -> None:
     assert result.topleft_xyz.to_list() == [1, 2, 3]
     assert result.size_xyz.to_list() == [4, 5, 6]
     assert result.size.c == 1
+
+
+def test_from_wkw_dict_with_axis_order_missing_c() -> None:
+    result = NormalizedBoundingBox.from_wkw_dict(
+        {
+            "topLeft": [1, 2, 3],
+            "width": 4,
+            "height": 5,
+            "depth": 6,
+            "axisOrder": {"x": 2, "y": 1, "z": 0},
+        }
+    )
+    assert isinstance(result, NormalizedBoundingBox)
+    assert result.axes == ("z", "y", "x")
+    assert result.topleft_xyz.to_list() == [1, 2, 3]
+    assert result.size_xyz.to_list() == [4, 5, 6]
+    with pytest.raises(KeyError):
+        assert result.size.c == 0
 
 
 def test_from_wkw_dict_with_num_channels() -> None:

--- a/webknossos/tests/geometry/test_vec3_int.py
+++ b/webknossos/tests/geometry/test_vec3_int.py
@@ -25,7 +25,7 @@ def test_export() -> None:
     assert Vec3Int(1, 2, 3)[0] == 1
     assert Vec3Int(1, 2, 3)[1] == 2
     assert Vec3Int(1, 2, 3)[2] == 3
-    assert np.array_equal(Vec3Int(1, 2, 3).to_np(), np.array([1, 2, 3]))
+    np.testing.assert_array_equal(Vec3Int(1, 2, 3).to_np(), np.array([1, 2, 3]))
     assert Vec3Int(1, 2, 3).to_list() == [1, 2, 3]
     assert Vec3Int(1, 2, 3).to_tuple() == (1, 2, 3)
 

--- a/webknossos/tests/geometry/test_vec_int.py
+++ b/webknossos/tests/geometry/test_vec_int.py
@@ -31,7 +31,9 @@ def test_export() -> None:
     assert VecInt(x=1, y=2, z=3, t=4)[0] == 1
     assert VecInt(x=1, y=2, z=3, t=4)[1] == 2
     assert VecInt(x=1, y=2, z=3, t=4)[2] == 3
-    assert np.array_equal(VecInt(x=1, y=2, z=3, t=4).to_np(), np.array([1, 2, 3, 4]))
+    np.testing.assert_array_equal(
+        VecInt(x=1, y=2, z=3, t=4).to_np(), np.array([1, 2, 3, 4])
+    )
     assert VecInt(x=1, y=2, z=3, t=4).to_list() == [1, 2, 3, 4]
     assert VecInt(x=1, y=2, z=3, t=4).to_tuple() == (1, 2, 3, 4)
 

--- a/webknossos/tests/test_annotation.py
+++ b/webknossos/tests/test_annotation.py
@@ -410,7 +410,7 @@ def test_edit_volume_annotation(edit_mode: VolumeLayerEditMode, executor: str) -
             assert len(seg_layer.mags) == 1
             mag = seg_layer.get_mag(1)
             read_data = mag.read(absolute_offset=(0, 0, 0), size=(10, 10, 10))
-            assert np.array_equal(data, read_data)
+            np.testing.assert_array_equal(data, read_data)
 
 
 def test_edited_volume_annotation_format() -> None:
@@ -463,7 +463,7 @@ def test_edited_volume_annotation_format() -> None:
         codec["name"] for codec in metadata["codecs"]
     ]
     data_read = ts.read().result()[0, :10, :10, :10]
-    assert np.array_equal(data, data_read)
+    np.testing.assert_array_equal(data, data_read)
 
 
 @pytest.mark.parametrize(
@@ -493,7 +493,7 @@ def test_edited_volume_annotation_save_load(edit_mode: VolumeLayerEditMode) -> N
         assert len(seg_layer.mags) == 1
         mag = seg_layer.get_mag(1)
         read_data = mag.read(absolute_offset=(0, 0, 0), size=(10, 10, 10))
-        assert np.array_equal(data, read_data)
+        np.testing.assert_array_equal(data, read_data)
 
 
 @pytest.mark.skip_on_windows
@@ -529,4 +529,4 @@ def test_edited_volume_annotation_upload_download() -> None:
         assert len(seg_layer.mags) == 1
         mag = seg_layer.get_mag(1)
         read_data = mag.read(absolute_offset=(0, 0, 0), size=(10, 10, 10))
-        assert np.array_equal(data, read_data)
+        np.testing.assert_array_equal(data, read_data)

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -591,9 +591,12 @@ def test_export_tiff_stack(tmp_upath: UPath) -> None:
         )
         correct_image = np.squeeze(correct_image)
 
-        assert np.array_equal(correct_image, test_image), (
-            f"The tiff file {tiff_path} that was written is not "
-            f"equal to the original wkw_file."
+        (
+            np.testing.assert_array_equal(correct_image, test_image),
+            (
+                f"The tiff file {tiff_path} that was written is not "
+                f"equal to the original wkw_file."
+            ),
         )
 
 
@@ -656,9 +659,12 @@ def test_export_tiff_stack_tile_size(tmp_upath: UPath) -> None:
 
                 correct_image = np.squeeze(correct_image)
 
-                assert np.array_equal(correct_image, test_image), (
-                    f"The tiff file {tiff_path} that was written "
-                    f"is not equal to the original wkw_file."
+                (
+                    np.testing.assert_array_equal(correct_image, test_image),
+                    (
+                        f"The tiff file {tiff_path} that was written "
+                        f"is not equal to the original wkw_file."
+                    ),
                 )
 
 
@@ -721,9 +727,12 @@ def test_export_tiff_stack_tiles_per_dimension(tmp_upath: UPath) -> None:
 
                 correct_image = np.squeeze(correct_image)
 
-                assert np.array_equal(correct_image, test_image), (
-                    f"The tiff file {tiff_path} that was written "
-                    f"is not equal to the original wkw_file."
+                (
+                    np.testing.assert_array_equal(correct_image, test_image),
+                    (
+                        f"The tiff file {tiff_path} that was written "
+                        f"is not equal to the original wkw_file."
+                    ),
                 )
 
 

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -26,8 +26,12 @@ from tests.constants import (
     use_minio,
 )
 from webknossos import BoundingBox, DataFormat, Dataset, Mag
-from webknossos.cli.export_as_tiff import _make_tiff_name
+from webknossos.cli.export_as_tiff import _apply_mapping, _make_tiff_name
 from webknossos.cli.main import app
+from webknossos.dataset._utils.tensorstore_helpers import (
+    open_zarr3_array,
+    write_zarr3_array,
+)
 from webknossos.dataset.dataset import PROPERTIES_FILE_NAME
 from webknossos.dataset.defaults import DEFAULT_CHUNK_SHAPE
 from webknossos.utils import copytree
@@ -546,6 +550,36 @@ def test_convert_upload_downsample() -> None:
     assert result.exit_code == 0, result.stdout
 
 
+def test_apply_mapping(tmp_path: UPath) -> None:
+    """Tests the segment-to-agglomerate mapping helper."""
+    # mapping[0] = 0 (background), mapping[1..4] → agglomerate IDs
+    mapping_data = np.array([0, 10, 10, 20, 20], dtype=np.uint32)
+    mapping_path = UPath(tmp_path) / "segment_to_agglomerate"
+    write_zarr3_array(
+        mapping_path,
+        mapping_data,
+        target_chunk_size_bytes=1024,
+        target_shard_size_bytes=1024 * 1024,
+    )
+    mapping_array = open_zarr3_array(mapping_path).result()
+
+    # normal segment IDs: 1→10, 2→10, 3→20, 4→20
+    data = np.array([[[[1, 2], [3, 4]]]], dtype=np.uint32)
+    result = _apply_mapping(data, mapping_array)
+    np.testing.assert_array_equal(result, [[[[10, 10], [20, 20]]]])
+    assert result.dtype == np.uint32
+
+    # background (0) stays 0
+    data_bg = np.array([[[[0, 1]]]], dtype=np.uint32)
+    result_bg = _apply_mapping(data_bg, mapping_array)
+    np.testing.assert_array_equal(result_bg, [[[[0, 10]]]])
+
+    # out-of-bounds segment IDs map to 0
+    data_oob = np.array([[[[5, 99]]]], dtype=np.uint32)
+    result_oob = _apply_mapping(data_oob, mapping_array)
+    np.testing.assert_array_equal(result_oob, [[[[0, 0]]]])
+
+
 def test_export_tiff_stack(tmp_upath: UPath) -> None:
     """Tests export of a tiff stack."""
 
@@ -591,12 +625,10 @@ def test_export_tiff_stack(tmp_upath: UPath) -> None:
         )
         correct_image = np.squeeze(correct_image)
 
-        (
-            np.testing.assert_array_equal(correct_image, test_image),
-            (
-                f"The tiff file {tiff_path} that was written is not "
-                f"equal to the original wkw_file."
-            ),
+        np.testing.assert_array_equal(
+            correct_image,
+            test_image,
+            f"The tiff file {tiff_path} that was written is not equal to the original wkw_file.",
         )
 
 
@@ -659,12 +691,11 @@ def test_export_tiff_stack_tile_size(tmp_upath: UPath) -> None:
 
                 correct_image = np.squeeze(correct_image)
 
-                (
-                    np.testing.assert_array_equal(correct_image, test_image),
-                    (
-                        f"The tiff file {tiff_path} that was written "
-                        f"is not equal to the original wkw_file."
-                    ),
+                np.testing.assert_array_equal(
+                    correct_image,
+                    test_image,
+                    f"The tiff file {tiff_path} that was written "
+                    f"is not equal to the original wkw_file.",
                 )
 
 
@@ -727,12 +758,10 @@ def test_export_tiff_stack_tiles_per_dimension(tmp_upath: UPath) -> None:
 
                 correct_image = np.squeeze(correct_image)
 
-                (
-                    np.testing.assert_array_equal(correct_image, test_image),
-                    (
-                        f"The tiff file {tiff_path} that was written "
-                        f"is not equal to the original wkw_file."
-                    ),
+                np.testing.assert_array_equal(
+                    correct_image,
+                    test_image,
+                    f"The tiff file {tiff_path} that was written is not equal to the original wkw_file.",
                 )
 
 

--- a/webknossos/tests/test_cli_utils.py
+++ b/webknossos/tests/test_cli_utils.py
@@ -18,7 +18,8 @@ from webknossos.cli._utils import (
 
 
 def test_parse_job_resources_key_value_format() -> None:
-    assert parse_job_resources("mem=32G,time=02:00:00") == {
+    assert parse_job_resources("batch-size=10,mem=32G,time=02:00:00") == {
+        "batch_size": 10,
         "mem": "32G",
         "time": "02:00:00",
     }
@@ -200,6 +201,7 @@ def test_slurm_batching_uses_jobs_as_target_job_count() -> None:
             job_resources={"mem": "1G"},
         )
     assert isinstance(result, BatchingExecutor)
+    assert result.target_job_count == 10
     mock_get.assert_called_once_with(
         "slurm",
         debug=True,
@@ -219,6 +221,7 @@ def test_slurm_batching_with_batch_size() -> None:
             job_resources={"batch_size": 5, "mem": "1G"},
         )
     assert isinstance(result, BatchingExecutor)
+    assert result.batch_size == 5
     # batch_size is popped before passing resources to get_executor
     mock_get.assert_called_once_with(
         "slurm",

--- a/webknossos/tests/test_cli_utils.py
+++ b/webknossos/tests/test_cli_utils.py
@@ -1,0 +1,228 @@
+"""Unit tests for webknossos.cli._utils.get_executor_for_args and parse_job_resources."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+import typer
+from cluster_tools import BatchingExecutor
+
+from webknossos.cli._utils import (
+    DistributionStrategy,
+    get_executor_for_args,
+    parse_job_resources,
+)
+
+# ---------------------------------------------------------------------------
+# parse_job_resources
+# ---------------------------------------------------------------------------
+
+
+def test_parse_job_resources_key_value_format() -> None:
+    assert parse_job_resources("mem=32G,time=02:00:00") == {
+        "mem": "32G",
+        "time": "02:00:00",
+    }
+
+
+def test_parse_job_resources_single_pair() -> None:
+    assert parse_job_resources("mem=32G") == {"mem": "32G"}
+
+
+def test_parse_job_resources_int_conversion() -> None:
+    # dashes in keys are converted to underscores
+    assert parse_job_resources("nice=10,mem=32G") == {
+        "nice": 10,
+        "mem": "32G",
+    }
+
+
+def test_parse_job_resources_json_backward_compat() -> None:
+    assert parse_job_resources('{"mem": "32G"}') == {"mem": "32G"}
+
+
+def test_parse_job_resources_json_with_int_backward_compat() -> None:
+    assert parse_job_resources('{"batch_size": 100, "mem": "32G"}') == {
+        "batch_size": 100,
+        "mem": "32G",
+    }
+
+
+def test_parse_job_resources_invalid_no_equals() -> None:
+    with pytest.raises(ValueError):
+        parse_job_resources("badformat")
+
+
+def test_parse_job_resources_invalid_json() -> None:
+    with pytest.raises(ValueError):
+        parse_job_resources("{bad json}")
+
+
+# ---------------------------------------------------------------------------
+# get_executor_for_args — error cases
+# ---------------------------------------------------------------------------
+
+
+def test_slurm_requires_job_resources() -> None:
+    with pytest.raises(typer.BadParameter, match="--job-resources"):
+        get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.SLURM,
+            job_resources=None,
+        )
+
+
+def test_kubernetes_requires_job_resources() -> None:
+    with pytest.raises(typer.BadParameter, match="--job-resources"):
+        get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.KUBERNETES,
+            job_resources=None,
+        )
+
+
+def test_slurm_batching_requires_job_resources() -> None:
+    with pytest.raises(typer.BadParameter, match="--job-resources"):
+        get_executor_for_args(
+            jobs=10,
+            distribution_strategy=DistributionStrategy.SLURM_BATCHING,
+            job_resources=None,
+        )
+
+
+def test_slurm_batching_requires_jobs_when_no_batch_size() -> None:
+    with pytest.raises(typer.BadParameter, match="--jobs"):
+        get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.SLURM_BATCHING,
+            job_resources={"mem": "1G"},
+        )
+
+
+def test_slurm_batching_rejects_jobs_with_batch_size() -> None:
+    with pytest.raises(typer.BadParameter, match="--jobs"):
+        get_executor_for_args(
+            jobs=4,
+            distribution_strategy=DistributionStrategy.SLURM_BATCHING,
+            job_resources={"batch_size": 5, "mem": "1G"},
+        )
+
+
+# ---------------------------------------------------------------------------
+# get_executor_for_args — happy paths, local executors (no mocking)
+# ---------------------------------------------------------------------------
+
+
+def test_multiprocessing_returns_executor_with_explicit_jobs() -> None:
+    with get_executor_for_args(
+        jobs=2,
+        distribution_strategy=DistributionStrategy.MULTIPROCESSING,
+        job_resources=None,
+    ):
+        pass
+
+
+def test_multiprocessing_returns_executor_with_default_jobs() -> None:
+    with get_executor_for_args(
+        jobs=None,
+        distribution_strategy=DistributionStrategy.MULTIPROCESSING,
+        job_resources=None,
+    ):
+        pass
+
+
+def test_sequential_returns_executor() -> None:
+    with get_executor_for_args(
+        jobs=None,
+        distribution_strategy=DistributionStrategy.SEQUENTIAL,
+        job_resources=None,
+    ):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# get_executor_for_args — happy paths, cluster executors (mock get_executor)
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_executor() -> MagicMock:
+    mock = MagicMock()
+    mock.__enter__ = MagicMock(return_value=mock)
+    mock.__exit__ = MagicMock(return_value=False)
+    return mock
+
+
+def test_slurm_calls_get_executor_with_correct_args() -> None:
+    mock_executor = _make_mock_executor()
+    with patch(
+        "webknossos.cli._utils.get_executor", return_value=mock_executor
+    ) as mock_get:
+        with get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.SLURM,
+            job_resources={"mem": "1G"},
+        ):
+            pass
+    mock_get.assert_called_once_with(
+        "slurm",
+        debug=True,
+        keep_logs=True,
+        job_resources={"mem": "1G"},
+    )
+
+
+def test_kubernetes_calls_get_executor_with_correct_args() -> None:
+    mock_executor = _make_mock_executor()
+    with patch(
+        "webknossos.cli._utils.get_executor", return_value=mock_executor
+    ) as mock_get:
+        with get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.KUBERNETES,
+            job_resources={"memory": "1G"},
+        ):
+            pass
+    mock_get.assert_called_once_with(
+        "kubernetes",
+        debug=True,
+        keep_logs=True,
+        job_resources={"memory": "1G"},
+    )
+
+
+def test_slurm_batching_uses_jobs_as_target_job_count() -> None:
+    mock_executor = _make_mock_executor()
+    with patch(
+        "webknossos.cli._utils.get_executor", return_value=mock_executor
+    ) as mock_get:
+        result = get_executor_for_args(
+            jobs=10,
+            distribution_strategy=DistributionStrategy.SLURM_BATCHING,
+            job_resources={"mem": "1G"},
+        )
+    assert isinstance(result, BatchingExecutor)
+    mock_get.assert_called_once_with(
+        "slurm",
+        debug=True,
+        keep_logs=True,
+        job_resources={"mem": "1G"},
+    )
+
+
+def test_slurm_batching_with_batch_size() -> None:
+    mock_executor = _make_mock_executor()
+    with patch(
+        "webknossos.cli._utils.get_executor", return_value=mock_executor
+    ) as mock_get:
+        result = get_executor_for_args(
+            jobs=None,
+            distribution_strategy=DistributionStrategy.SLURM_BATCHING,
+            job_resources={"batch_size": 5, "mem": "1G"},
+        )
+    assert isinstance(result, BatchingExecutor)
+    # batch_size is popped before passing resources to get_executor
+    mock_get.assert_called_once_with(
+        "slurm",
+        debug=True,
+        keep_logs=True,
+        job_resources={"mem": "1G"},
+    )

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -81,10 +81,10 @@ from ..geometry import NDBoundingBox, Vec3Int, Vec3IntLike
 from ..proofreading.agglomerate_graph_data import AgglomerateGraphData
 from ..skeleton import Skeleton
 from ..utils import (
-    get_executor_for_args,
     is_fs_path,
     time_since_epoch_in_ms,
     warn_deprecated,
+    wrap_executor,
 )
 from ._nml_conversion import annotation_to_nml, nml_to_skeleton
 from .volume_layer import SegmentInformation, VolumeLayer
@@ -808,7 +808,7 @@ class Annotation:
 
             if volume_layer.zip is None:
                 logger.info("No volume annotation found. Copy fallback layer.")
-                with get_executor_for_args(args=None, executor=executor) as executor:
+                with wrap_executor(executor) as executor:
                     output_dataset.add_layer_as_copy(
                         fallback_layer, compress=True, executor=executor
                     )
@@ -841,7 +841,7 @@ class Annotation:
                     fallback_layer, fallback_layer.name
                 )
 
-                with get_executor_for_args(args=None, executor=executor) as executor:
+                with wrap_executor(executor) as executor:
                     logger.info(
                         "Copy Mag %s from %s to %s",
                         fallback_mag.mag,

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -6,7 +6,6 @@ import re
 from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from enum import Enum
-from functools import lru_cache
 from multiprocessing import cpu_count
 from os import environ
 from typing import Annotated, NamedTuple
@@ -26,7 +25,7 @@ from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_DATA_FORMAT
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..dataset_properties import DataFormat
 from ..geometry import BoundingBox, Mag, Vec3Int
-from ..utils import is_fs_path, set_s3fs_retry_settings
+from ..utils import is_fs_path
 
 logger = logging.getLogger(__name__)
 
@@ -243,11 +242,6 @@ AccessModeOption = Annotated[
 ]
 
 
-@lru_cache(maxsize=1)
-def _set_s3fs_retry_settings() -> None:
-    set_s3fs_retry_settings()
-
-
 def parse_mag(mag_str: str) -> Mag:
     """Parses str input to Mag"""
 
@@ -412,8 +406,6 @@ def parse_path(value: str) -> UPath:
             auth=(environ["HTTP_BASIC_USER"], environ["HTTP_BASIC_PASSWORD"]),
         )
     if value.startswith("s3://"):
-        _set_s3fs_retry_settings()
-
         if "S3_ENDPOINT_URL" in environ:
             return UPath(
                 value,

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -6,10 +6,11 @@ from contextlib import contextmanager
 from enum import Enum
 from functools import lru_cache
 from os import environ
-from typing import NamedTuple
+from typing import Annotated, NamedTuple
 from urllib.parse import urlparse
 
 import numpy as np
+import typer
 from upath import UPath
 
 from ..annotation.annotation import _ANNOTATION_URL_REGEX, Annotation
@@ -80,6 +81,16 @@ class Order(str, Enum):
 
     C = "C"
     F = "F"
+
+
+AccessModeOption = Annotated[
+    RemoteAccessMode | None,
+    typer.Option(
+        help="How to access the remote dataset's data. "
+        "Defaults to 'direct_path' when --transfer-mode is not 'http', otherwise 'proxy_path'.",
+        rich_help_panel="WEBKNOSSOS context",
+    ),
+]
 
 
 @lru_cache(maxsize=1)

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -57,12 +57,10 @@ class DistributionStrategy(str, Enum):
     SEQUENTIAL = "sequential"
 
 
-DEFAULT_JOBS: int = cpu_count()
-
 JobsOption = Annotated[
-    int,
+    int | None,
     typer.Option(
-        help="Number of processes to be spawned.",
+        help="Number of processes to be spawned. By default the number of CPUs is used.",
         rich_help_panel="Executor options",
     ),
 ]
@@ -75,25 +73,70 @@ DistributionStrategyOption = Annotated[
     ),
 ]
 
+
+def _try_parse_number(value: str) -> str | int | float:
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return value
+
+
+def parse_job_resources(value: str) -> dict:
+    """Parses --job-resources in 'key=value,key=value' or JSON format.
+
+    key=value format: dashes in keys are converted to underscores (e.g. cpus-per-task=4).
+    JSON format: keys are used as-is and must already use underscores (e.g. {"cpus_per_task": 4}).
+    """
+    value = value.strip()
+    if value.startswith("{"):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            raise ValueError(f"Invalid JSON for --job-resources: {e}") from e
+    try:
+        result = {}
+        for pair in value.split(","):
+            key, val = pair.split("=", 1)
+            result[key.strip().replace("-", "_")] = _try_parse_number(val.strip())
+        return result
+    except ValueError as e:
+        raise ValueError(
+            f"Invalid --job-resources format. Expected 'key=value,key=value' or JSON. Got: {value!r}"
+        ) from e
+
+
 JobResourcesOption = Annotated[
-    str | None,
+    dict | None,
     typer.Option(
-        help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-        '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
+        help="Resources for cluster jobs (slurm, slurm+batching, kubernetes). "
+        "Format: key=value pairs separated by commas (e.g. mem=32G,time=02:00:00).",
         rich_help_panel="Executor options",
+        parser=parse_job_resources,
+        metavar="KEY=VALUE,...",
     ),
 ]
 
 
 def get_executor_for_args(
     *,
-    jobs: int,
+    jobs: int | None,
     distribution_strategy: DistributionStrategy,
-    job_resources: str | None,
+    job_resources: dict | None,
 ) -> AbstractContextManager[Executor]:
     if distribution_strategy == DistributionStrategy.MULTIPROCESSING:
-        logger.info(f"Using pool of {jobs} workers.")
-        return get_executor("multiprocessing", max_workers=jobs)
+        if job_resources is not None:
+            raise typer.BadParameter(
+                "Job resources are not supported for multiprocessing execution.",
+                param_hint="--job-resources",
+            )
+        resolved_jobs = jobs if jobs is not None else cpu_count()
+        logger.info(f"Using pool of {resolved_jobs} workers.")
+        return get_executor("multiprocessing", max_workers=resolved_jobs)
     if distribution_strategy in (
         DistributionStrategy.SLURM,
         DistributionStrategy.SLURM_BATCHING,
@@ -101,31 +144,28 @@ def get_executor_for_args(
     ):
         if job_resources is None:
             resources_example = (
-                '{"mem": "32G"}'
+                "mem=32G"
                 if distribution_strategy != DistributionStrategy.KUBERNETES
-                else '{"memory": "32G"}'
+                else "memory=32G"
             )
             raise typer.BadParameter(
                 f"Job resources has to be provided when using {distribution_strategy.value} as distribution strategy. "
-                f"Example: --job-resources='{resources_example}'",
+                f"Example: --job-resources={resources_example}",
                 param_hint="--job-resources",
             )
-        job_resources_parsed = json.loads(job_resources)
+        job_resources_parsed = dict(job_resources)
 
         if distribution_strategy == DistributionStrategy.SLURM_BATCHING:
-            target_job_count = job_resources_parsed.get("target_job_count")
-            batch_size = job_resources_parsed.get("batch_size")
-            if target_job_count is None and batch_size is None:
-                resources_example = '{"target_job_count": 100, "mem": "32G"}'
+            batch_size = job_resources_parsed.pop("batch_size", None)
+            if batch_size is not None and jobs is not None:
                 raise typer.BadParameter(
-                    f"target_job_count or batch_size have to be provided when using {distribution_strategy.value} as distribution strategy. "
-                    f"Example: --job-resources='{resources_example}'",
-                    param_hint="--job-resources",
+                    "--jobs and batch-size in --job-resources are mutually exclusive for slurm+batching.",
+                    param_hint="--jobs",
                 )
-            if target_job_count is not None and batch_size is not None:
+            if batch_size is None and jobs is None:
                 raise typer.BadParameter(
-                    f"target_job_count and batch_size can not be provided at the same time when using {distribution_strategy.value} as distribution strategy.",
-                    param_hint="--job-resources",
+                    "--jobs is required for slurm+batching when batch-size is not set in --job-resources.",
+                    param_hint="--jobs",
                 )
             distribution_strategy = DistributionStrategy.SLURM
             logger.info(f"Using {distribution_strategy.value} cluster with batching.")
@@ -136,7 +176,7 @@ def get_executor_for_args(
                     keep_logs=True,
                     job_resources=job_resources_parsed,
                 ),
-                target_job_count=target_job_count,
+                target_job_count=jobs,
                 batch_size=batch_size,
             )
 
@@ -149,6 +189,16 @@ def get_executor_for_args(
         )
 
     if distribution_strategy == DistributionStrategy.SEQUENTIAL:
+        if job_resources is not None:
+            raise typer.BadParameter(
+                "Job resources are not supported for sequential execution.",
+                param_hint="--job-resources",
+            )
+        if jobs is not None:
+            raise typer.BadParameter(
+                "Number of jobs is not supported for sequential execution.",
+                param_hint="--jobs",
+            )
         return get_executor(
             distribution_strategy.value,
             debug=True,

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -1,15 +1,20 @@
 """Utilities to work with the CLI of webknossos."""
 
+import json
+import logging
 import re
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import AbstractContextManager, contextmanager
 from enum import Enum
 from functools import lru_cache
+from multiprocessing import cpu_count
 from os import environ
-from typing import NamedTuple
+from typing import Annotated, NamedTuple
 from urllib.parse import urlparse
 
 import numpy as np
+import typer
+from cluster_tools import BatchingExecutor, Executor, get_executor
 from upath import UPath
 
 from ..annotation.annotation import _ANNOTATION_URL_REGEX, Annotation
@@ -17,10 +22,13 @@ from ..client import webknossos_context
 from ..client._resolve_short_link import resolve_short_link
 from ..dataset import Dataset, RemoteDataset
 from ..dataset.abstract_dataset import _DATASET_DEPRECATED_URL_REGEX, _DATASET_URL_REGEX
-from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
+from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_DATA_FORMAT
 from ..dataset.remote_dataset import RemoteAccessMode
+from ..dataset_properties import DataFormat
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import is_fs_path, set_s3fs_retry_settings
+
+logger = logging.getLogger(__name__)
 
 
 class VoxelSizeTuple(NamedTuple):
@@ -40,28 +48,121 @@ class Vec2Int(NamedTuple):
 
 
 class DistributionStrategy(str, Enum):
-    """Enum of available distribution strategies.
-
-    TODO
-    - As soon as supported by typer this enum should be
-    replaced with typing.Literal in type hint.
-    https://github.com/tiangolo/typer/pull/669
-    """
+    """Enum of available distribution strategies."""
 
     SLURM = "slurm"
+    SLURM_BATCHING = "slurm+batching"
     KUBERNETES = "kubernetes"
     MULTIPROCESSING = "multiprocessing"
     SEQUENTIAL = "sequential"
 
 
-class LayerCategory(str, Enum):
-    """Enum of available layer categories.
+DEFAULT_JOBS: int = cpu_count()
 
-    TODO
-    - As soon as supported by typer this enum should be
-    replaced with typing.Literal in type hint.
-    https://github.com/tiangolo/typer/pull/669
-    """
+JobsOption = Annotated[
+    int,
+    typer.Option(
+        help="Number of processes to be spawned.",
+        rich_help_panel="Executor options",
+    ),
+]
+
+DistributionStrategyOption = Annotated[
+    DistributionStrategy,
+    typer.Option(
+        help="Strategy to distribute the task across CPUs or nodes.",
+        rich_help_panel="Executor options",
+    ),
+]
+
+JobResourcesOption = Annotated[
+    str | None,
+    typer.Option(
+        help="Necessary when using slurm as distribution strategy. Should be a JSON string "
+        '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
+        rich_help_panel="Executor options",
+    ),
+]
+
+
+def get_executor_for_args(
+    *,
+    jobs: int,
+    distribution_strategy: DistributionStrategy,
+    job_resources: str | None,
+) -> AbstractContextManager[Executor]:
+    if distribution_strategy == DistributionStrategy.MULTIPROCESSING:
+        logger.info(f"Using pool of {jobs} workers.")
+        return get_executor("multiprocessing", max_workers=jobs)
+    if distribution_strategy in (
+        DistributionStrategy.SLURM,
+        DistributionStrategy.SLURM_BATCHING,
+        DistributionStrategy.KUBERNETES,
+    ):
+        if job_resources is None:
+            resources_example = (
+                '{"mem": "32G"}'
+                if distribution_strategy != DistributionStrategy.KUBERNETES
+                else '{"memory": "32G"}'
+            )
+            raise typer.BadParameter(
+                f"Job resources has to be provided when using {distribution_strategy.value} as distribution strategy. "
+                f"Example: --job-resources='{resources_example}'",
+                param_hint="--job-resources",
+            )
+        job_resources_parsed = json.loads(job_resources)
+
+        if distribution_strategy == DistributionStrategy.SLURM_BATCHING:
+            target_job_count = job_resources_parsed.get("target_job_count")
+            batch_size = job_resources_parsed.get("batch_size")
+            if target_job_count is None and batch_size is None:
+                resources_example = '{"target_job_count": 100, "mem": "32G"}'
+                raise typer.BadParameter(
+                    f"target_job_count or batch_size have to be provided when using {distribution_strategy.value} as distribution strategy. "
+                    f"Example: --job-resources='{resources_example}'",
+                    param_hint="--job-resources",
+                )
+            if target_job_count is not None and batch_size is not None:
+                raise typer.BadParameter(
+                    f"target_job_count and batch_size can not be provided at the same time when using {distribution_strategy.value} as distribution strategy.",
+                    param_hint="--job-resources",
+                )
+            distribution_strategy = DistributionStrategy.SLURM
+            logger.info(f"Using {distribution_strategy.value} cluster with batching.")
+            return BatchingExecutor(
+                get_executor(
+                    distribution_strategy.value,
+                    debug=True,
+                    keep_logs=True,
+                    job_resources=job_resources_parsed,
+                ),
+                target_job_count=target_job_count,
+                batch_size=batch_size,
+            )
+
+        logger.info(f"Using {distribution_strategy.value} cluster.")
+        return get_executor(
+            distribution_strategy.value,
+            debug=True,
+            keep_logs=True,
+            job_resources=job_resources_parsed,
+        )
+
+    if distribution_strategy == DistributionStrategy.SEQUENTIAL:
+        return get_executor(
+            distribution_strategy.value,
+            debug=True,
+            keep_logs=True,
+        )
+
+    raise typer.BadParameter(
+        f"Unknown distribution strategy: {distribution_strategy.value}",
+        param_hint="--distribution-strategy",
+    )
+
+
+class LayerCategory(str, Enum):
+    """Enum of available layer categories."""
 
     COLOR = "color"
     SEGMENTATION = "segmentation"
@@ -143,6 +244,49 @@ def parse_vec3int(vec3int_like: str | Vec3Int) -> Vec3Int:
             "The value could not be parsed to VoxelSize. "
             "Please format the voxel size like 1,1,2 ."
         ) from err
+
+
+DEFAULT_DATA_FORMAT_STR: str = str(DEFAULT_DATA_FORMAT)
+
+DataFormatOption = Annotated[
+    DataFormat,
+    typer.Option(help="Data format to store the target dataset in."),
+]
+
+ChunkShapeOption = Annotated[
+    Vec3Int,
+    typer.Option(
+        help="Number of voxels to be stored as a chunk in the output format "
+        "(e.g. `32` or `32,32,32`).",
+        parser=parse_vec3int,
+        metavar="Vec3Int",
+    ),
+]
+
+ShardShapeOption = Annotated[
+    Vec3Int | None,
+    typer.Option(
+        help="Number of voxels to be stored as a shard in the output format "
+        "(e.g. `1024` or `1024,1024,1024`).",
+        parser=parse_vec3int,
+        metavar="Vec3Int",
+    ),
+]
+
+ChunksPerShardOption = Annotated[
+    Vec3Int | None,
+    typer.Option(
+        help="Deprecated, use --shard-shape. Number of chunks to be stored as a shard in the output format "
+        "(e.g. `32` or `32,32,32`).",
+        parser=parse_vec3int,
+        metavar="Vec3Int",
+    ),
+]
+
+ExistsOkOption = Annotated[
+    bool,
+    typer.Option(help="Whether it should overwrite an existing dataset."),
+]
 
 
 def parse_vec2int(vec2int_str: str) -> Vec2Int:

--- a/webknossos/webknossos/cli/_utils.py
+++ b/webknossos/webknossos/cli/_utils.py
@@ -137,6 +137,7 @@ def get_executor_for_args(
         resolved_jobs = jobs if jobs is not None else cpu_count()
         logger.info(f"Using pool of {resolved_jobs} workers.")
         return get_executor("multiprocessing", max_workers=resolved_jobs)
+
     if distribution_strategy in (
         DistributionStrategy.SLURM,
         DistributionStrategy.SLURM_BATCHING,

--- a/webknossos/webknossos/cli/check_equality.py
+++ b/webknossos/webknossos/cli/check_equality.py
@@ -8,7 +8,6 @@ from cluster_tools import Executor
 
 from ..dataset import Dataset, Layer
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -44,7 +43,7 @@ def main(
             help="Name of the layer to compare (if not provided, all layers are compared)."
         ),
     ] = None,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/check_equality.py
+++ b/webknossos/webknossos/cli/check_equality.py
@@ -1,15 +1,21 @@
 """This module checks equality of two different WEBKNOSSOS datasets."""
 
 import logging
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import typer
+from cluster_tools import Executor
 
 from ..dataset import Dataset, Layer
-from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, parse_path
+from ._utils import (
+    DEFAULT_JOBS,
+    DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
+    get_executor_for_args,
+    parse_path,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,36 +44,11 @@ def main(
             help="Name of the layer to compare (if not provided, all layers are compared)."
         ),
     ] = None,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Check equality of two WEBKNOSSOS datasets."""
-
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
 
     source_dataset = Dataset.open(source)
     target_dataset = Dataset.open(target)
@@ -76,42 +57,47 @@ def main(
 
     layer_names = list(source_layer_names)
 
-    try:
-        if layer_name is not None:
-            assert layer_name in source_layer_names, (
-                f"Provided layer {layer_name} does not exist in source dataset."
-            )
-            assert layer_name in target_layer_names, (
-                f"Provided layer {layer_name} does not exist in target dataset."
-            )
-            layer_names = [layer_name]
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
+        try:
+            if layer_name is not None:
+                assert layer_name in source_layer_names, (
+                    f"Provided layer {layer_name} does not exist in source dataset."
+                )
+                assert layer_name in target_layer_names, (
+                    f"Provided layer {layer_name} does not exist in target dataset."
+                )
+                layer_names = [layer_name]
 
-        else:
-            assert source_layer_names == target_layer_names, (
-                f"The provided input datasets have different \
+            else:
+                assert source_layer_names == target_layer_names, (
+                    f"The provided input datasets have different \
     layers: {source_layer_names} != {target_layer_names}"
-            )
+                )
 
-        for name in layer_names:
-            compare_layers(
-                source_dataset.get_layer(name),
-                target_dataset.get_layer(name),
-                executor_args,
-            )
+            for name in layer_names:
+                compare_layers(
+                    source_dataset.get_layer(name),
+                    target_dataset.get_layer(name),
+                    executor,
+                )
 
-        print(
-            f"The datasets {source} and {target} are equal \
+            print(
+                f"The datasets {source} and {target} are equal \
     (with regard to the layers: {layer_names})"
-        )
-    except RuntimeError as err:
-        print(f"The datasets are not equal: {err}")
-        exit(1)
+            )
+        except RuntimeError as err:
+            print(f"The datasets are not equal: {err}")
+            exit(1)
 
 
 def compare_layers(
     source_layer: Layer,
     target_layer: Layer,
-    executor_args: Namespace,
+    executor: Executor,
 ) -> None:
     """Compares one layer with another layer"""
 
@@ -138,12 +124,9 @@ are not equal: {source_layer.bounding_box} != {target_layer.bounding_box}"
         target_mag = target_layer.mags[mag]
 
         logger.info("Start verification of %s in mag %s", layer_name, mag)
-        with get_executor_for_args(args=executor_args) as executor:
-            if not source_mag.content_is_equal(
-                target_mag,
-                executor=executor,
-                progress_desc=f"Comparing {layer_name}/{mag}",
-            ):
-                raise RuntimeError(
-                    f"The contents of {source_mag} and {target_mag} differ."
-                )
+        if not source_mag.content_is_equal(
+            target_mag,
+            executor=executor,
+            progress_desc=f"Comparing {layer_name}/{mag}",
+        ):
+            raise RuntimeError(f"The contents of {source_mag} and {target_mag} differ.")

--- a/webknossos/webknossos/cli/compress.py
+++ b/webknossos/webknossos/cli/compress.py
@@ -1,15 +1,21 @@
 """This module takes care of compressing WEBKNOSSOS datasets."""
 
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import typer
 
 from ..dataset import Dataset
 from ..geometry.mag import Mag
-from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, parse_mag, parse_path
+from ._utils import (
+    DEFAULT_JOBS,
+    DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
+    get_executor_for_args,
+    parse_mag,
+    parse_path,
+)
 
 
 def main(
@@ -38,36 +44,11 @@ def main(
             metavar="MAG",
         ),
     ] = None,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Compress a given WEBKNOSSOS dataset."""
-
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
 
     ds = Dataset.open(target)
     if layer_name is None:
@@ -75,7 +56,11 @@ def main(
     else:
         layers = [ds.get_layer(layer_name)]
 
-    with get_executor_for_args(args=executor_args) as executor:
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
         for layer in layers:
             if mag is None:
                 mags = list(layer.mags.values())

--- a/webknossos/webknossos/cli/compress.py
+++ b/webknossos/webknossos/cli/compress.py
@@ -7,7 +7,6 @@ import typer
 from ..dataset import Dataset
 from ..geometry.mag import Mag
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -44,7 +43,7 @@ def main(
             metavar="MAG",
         ),
     ] = None,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/convert.py
+++ b/webknossos/webknossos/cli/convert.py
@@ -16,7 +16,6 @@ from ..geometry import Mag
 from ..utils import rmtree
 from ._utils import (
     DEFAULT_DATA_FORMAT_STR,
-    DEFAULT_JOBS,
     ChunkShapeOption,
     ChunksPerShardOption,
     DataFormatOption,
@@ -178,7 +177,7 @@ def main(
             rich_help_panel="WEBKNOSSOS context",
         ),
     ] = TransferMode.HTTP,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/convert.py
+++ b/webknossos/webknossos/cli/convert.py
@@ -1,8 +1,6 @@
 """This module converts an image stack to a WEBKNOSSOS dataset."""
 
 import tempfile
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import typer
@@ -11,19 +9,28 @@ from upath import UPath
 from ..client._defaults import DEFAULT_WEBKNOSSOS_URL
 from ..client.context import webknossos_context
 from ..dataset import Dataset, RemoteFolder, SamplingModes, TransferMode
-from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_DATA_FORMAT
-from ..dataset_properties import DataFormat, LengthUnit, VoxelSize
+from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
+from ..dataset_properties import LengthUnit, VoxelSize
 from ..dataset_properties.structuring import DEFAULT_LENGTH_UNIT_STR
-from ..geometry import Mag, Vec3Int
-from ..utils import get_executor_for_args, rmtree
+from ..geometry import Mag
+from ..utils import rmtree
 from ._utils import (
+    DEFAULT_DATA_FORMAT_STR,
+    DEFAULT_JOBS,
+    ChunkShapeOption,
+    ChunksPerShardOption,
+    DataFormatOption,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
     LayerCategory,
     SamplingMode,
+    ShardShapeOption,
     VoxelSizeTuple,
+    get_executor_for_args,
     parse_mag,
     parse_path,
-    parse_vec3int,
     parse_voxel_size,
     prepare_shard_shape,
 )
@@ -75,12 +82,7 @@ def main(
             help="The category of the layer that should be created.",
         ),
     ] = None,
-    data_format: Annotated[
-        DataFormat,
-        typer.Option(
-            help="Data format to store the target dataset in.",
-        ),
-    ] = str(DEFAULT_DATA_FORMAT),  # type:ignore
+    data_format: DataFormatOption = DEFAULT_DATA_FORMAT_STR,  # type: ignore
     name: Annotated[
         str | None,
         typer.Option(
@@ -89,33 +91,9 @@ def main(
             "or the source directory name (upload)."
         ),
     ] = None,
-    chunk_shape: Annotated[
-        Vec3Int,
-        typer.Option(
-            help="Number of voxels to be stored as a chunk in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = DEFAULT_CHUNK_SHAPE,
-    shard_shape: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Number of voxels to be stored as a shard in the output format "
-            "(e.g. `1024` or `1024,1024,1024`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
-    chunks_per_shard: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Deprecated, use --shard-shape. Number of chunks to be stored as a shard in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
+    chunk_shape: ChunkShapeOption = DEFAULT_CHUNK_SHAPE,
+    shard_shape: ShardShapeOption = None,
+    chunks_per_shard: ChunksPerShardOption = None,
     compress: Annotated[
         bool, typer.Option(help="Enable compression of the target dataset.")
     ] = True,
@@ -200,28 +178,9 @@ def main(
             rich_help_panel="WEBKNOSSOS context",
         ),
     ] = TransferMode.HTTP,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Automatic detection of an image stack and conversion to a WEBKNOSSOS dataset."""
 
@@ -236,16 +195,15 @@ def main(
         chunks_per_shard=chunks_per_shard,
     )
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     voxel_size_with_unit = VoxelSize(voxel_size, unit)
     mode = SamplingModes.parse(sampling_mode.value)
 
     def _convert_and_downsample(target_path: UPath) -> Dataset:
-        with get_executor_for_args(args=executor_args) as executor:
+        with get_executor_for_args(
+            jobs=jobs,
+            distribution_strategy=distribution_strategy,
+            job_resources=job_resources,
+        ) as executor:
             dataset = Dataset.from_images(
                 source,
                 target_path,
@@ -261,7 +219,11 @@ def main(
                 layer_category=category.value if category else None,
             )
         if downsample:
-            with get_executor_for_args(args=executor_args) as executor:
+            with get_executor_for_args(
+                jobs=jobs,
+                distribution_strategy=distribution_strategy,
+                job_resources=job_resources,
+            ) as executor:
                 dataset.downsample(
                     coarsest_mag=max_mag,
                     interpolation_mode=interpolation_mode,

--- a/webknossos/webknossos/cli/convert_knossos.py
+++ b/webknossos/webknossos/cli/convert_knossos.py
@@ -22,7 +22,6 @@ from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import time_start, time_stop, wrap_executor
 from ._utils import (
     DEFAULT_DATA_FORMAT_STR,
-    DEFAULT_JOBS,
     ChunkShapeOption,
     ChunksPerShardOption,
     DataFormatOption,
@@ -287,7 +286,7 @@ def main(
             metavar="MAG",
         ),
     ] = 1,  # type: ignore
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/convert_knossos.py
+++ b/webknossos/webknossos/cli/convert_knossos.py
@@ -2,35 +2,39 @@
 
 import logging
 import re
-from argparse import Namespace
 from collections import namedtuple
 from collections.abc import Generator, Iterator
 from functools import partial
-from multiprocessing import cpu_count
 from os import PathLike, sep
 from types import TracebackType
 from typing import Annotated, Any, cast
 
 import numpy as np
 import typer
+from cluster_tools import Executor
 from upath import UPath
 
 from ..dataset import Dataset, View
-from ..dataset.defaults import (
-    DEFAULT_CHUNK_SHAPE,
-    DEFAULT_DATA_FORMAT,
-    DEFAULT_SHARD_SHAPE,
-)
+from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_SHARD_SHAPE
 from ..dataset_properties import COLOR_CATEGORY, DataFormat, LengthUnit, VoxelSize
 from ..dataset_properties.structuring import DEFAULT_LENGTH_UNIT_STR
 from ..geometry import BoundingBox, Mag, Vec3Int
-from ..utils import get_executor_for_args, time_start, time_stop
+from ..utils import time_start, time_stop, wrap_executor
 from ._utils import (
+    DEFAULT_DATA_FORMAT_STR,
+    DEFAULT_JOBS,
+    ChunkShapeOption,
+    ChunksPerShardOption,
+    DataFormatOption,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
+    ShardShapeOption,
     VoxelSizeTuple,
+    get_executor_for_args,
     parse_mag,
     parse_path,
-    parse_vec3int,
     parse_voxel_size,
     prepare_shard_shape,
 )
@@ -185,7 +189,7 @@ def convert_knossos(
     chunk_shape: Vec3Int,  # in target-mag
     shard_shape: Vec3Int,
     mag: Mag = Mag(1),
-    args: Namespace | None = None,
+    executor: Executor | None = None,
 ) -> None:
     """Performs the conversion of a KNOSSOS dataset to a WEBKNOSSOS dataset."""
 
@@ -220,7 +224,7 @@ def convert_knossos(
         mag, chunk_shape=chunk_shape, shard_shape=shard_shape
     )
 
-    with get_executor_for_args(args) as executor:
+    with wrap_executor(executor) as executor:
         target_mag.for_each_chunk(
             partial(convert_cube_job, source_knossos_info),
             chunk_shape=shard_shape * mag,
@@ -270,39 +274,10 @@ def main(
     dtype: Annotated[
         str, typer.Option(help="Target datatype (e.g. uint8, uint16, uint32)")
     ] = "uint8",
-    data_format: Annotated[
-        DataFormat,
-        typer.Option(
-            help="Data format to store the target dataset in.",
-        ),
-    ] = str(DEFAULT_DATA_FORMAT),  # type:ignore
-    chunk_shape: Annotated[
-        Vec3Int,
-        typer.Option(
-            help="Number of voxels to be stored as a chunk in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = DEFAULT_CHUNK_SHAPE,
-    shard_shape: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Number of voxels to be stored as a shard in the output format "
-            "(e.g. `1024` or `1024,1024,1024`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
-    chunks_per_shard: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Deprecated, use --shard-shape. Number of chunks to be stored as a shard in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
+    data_format: DataFormatOption = DEFAULT_DATA_FORMAT_STR,  # type: ignore
+    chunk_shape: ChunkShapeOption = DEFAULT_CHUNK_SHAPE,
+    shard_shape: ShardShapeOption = None,
+    chunks_per_shard: ChunksPerShardOption = None,
     mag: Annotated[
         Mag,
         typer.Option(
@@ -312,28 +287,9 @@ def main(
             metavar="MAG",
         ),
     ] = 1,  # type: ignore
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Convert your KNOSSOS dataset to a WEBKNOSOOS dataset."""
 
@@ -343,22 +299,22 @@ def main(
         chunks_per_shard=chunks_per_shard,
     )
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     voxel_size_with_unit = VoxelSize(voxel_size, unit)
 
-    convert_knossos(
-        source,
-        target,
-        layer_name,
-        dtype,
-        voxel_size_with_unit,
-        data_format,
-        chunk_shape,
-        shard_shape or DEFAULT_SHARD_SHAPE,
-        mag,
-        executor_args,
-    )
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
+        convert_knossos(
+            source,
+            target,
+            layer_name,
+            dtype,
+            voxel_size_with_unit,
+            data_format,
+            chunk_shape,
+            shard_shape or DEFAULT_SHARD_SHAPE,
+            mag,
+            executor,
+        )

--- a/webknossos/webknossos/cli/convert_raw.py
+++ b/webknossos/webknossos/cli/convert_raw.py
@@ -1,38 +1,43 @@
 """This module converts a RAW dataset to a WEBKNOSSOS dataset."""
 
 import logging
-from argparse import Namespace
 from functools import partial
-from multiprocessing import cpu_count
 from typing import Annotated, Any, Literal
 
 import numpy as np
 import typer
+from cluster_tools import Executor
 from upath import UPath
 
 from ..dataset import Dataset, MagView, SamplingModes
-from ..dataset.defaults import (
-    DEFAULT_CHUNK_SHAPE,
-    DEFAULT_DATA_FORMAT,
-    DEFAULT_SHARD_SHAPE,
-)
+from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_SHARD_SHAPE
 from ..dataset_properties import DataFormat, LengthUnit, VoxelSize
 from ..dataset_properties.structuring import DEFAULT_LENGTH_UNIT_STR
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import (
-    get_executor_for_args,
     is_fs_path,
     rmtree,
     time_start,
     time_stop,
     wait_and_ensure_success,
+    wrap_executor,
 )
 from ._utils import (
+    DEFAULT_DATA_FORMAT_STR,
+    DEFAULT_JOBS,
+    ChunkShapeOption,
+    ChunksPerShardOption,
+    DataFormatOption,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
     Order,
     RescaleValues,
     SamplingMode,
+    ShardShapeOption,
     VoxelSizeTuple,
+    get_executor_for_args,
     parse_mag,
     parse_path,
     parse_rescale_values,
@@ -108,7 +113,7 @@ def convert_raw(
     flip_axes: tuple[int, ...] | None = None,
     compress: bool = True,
     rescale_min_max: RescaleValues | None = None,
-    executor_args: Namespace | None = None,
+    executor: Executor | None = None,
 ) -> MagView:
     """Performs the conversion step from RAW file to WEBKNOSSOS"""
     time_start(f"Conversion of {source_raw_path}")
@@ -132,7 +137,7 @@ def convert_raw(
     )
 
     # Parallel chunk conversion
-    with get_executor_for_args(args=executor_args) as executor:
+    with wrap_executor(executor) as executor:
         wait_and_ensure_success(
             executor.map_to_futures(
                 partial(
@@ -232,39 +237,10 @@ def main(
             show_default=False,
         ),
     ] = None,
-    data_format: Annotated[
-        DataFormat,
-        typer.Option(
-            help="Data format to store the target dataset in.",
-        ),
-    ] = str(DEFAULT_DATA_FORMAT),  # type:ignore
-    chunk_shape: Annotated[
-        Vec3Int,
-        typer.Option(
-            help="Number of voxels to be stored as a chunk in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = DEFAULT_CHUNK_SHAPE,
-    shard_shape: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Number of voxels to be stored as a shard in the output format "
-            "(e.g. `1024` or `1024,1024,1024`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
-    chunks_per_shard: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Deprecated, use --shard-shape. Number of chunks to be stored as a shard in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
+    data_format: DataFormatOption = DEFAULT_DATA_FORMAT_STR,  # type: ignore
+    chunk_shape: ChunkShapeOption = DEFAULT_CHUNK_SHAPE,
+    shard_shape: ShardShapeOption = None,
+    chunks_per_shard: ChunksPerShardOption = None,
     flip_axes: Annotated[
         Vec3Int | None,
         typer.Option(
@@ -307,28 +283,9 @@ def main(
             show_default=False,
         ),
     ] = False,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Converts a RAW file into a WEBKNOSSOS dataset."""
 
@@ -352,36 +309,35 @@ def main(
         logger.error("source_path is not a file")
         return
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     voxel_size_with_unit = VoxelSize(voxel_size, unit)
 
     if overwrite_existing and target.exists():
         rmtree(target)
 
-    mag_view = convert_raw(
-        source_raw_path=source,
-        target_path=target,
-        layer_name=layer_name,
-        source_dtype=np.dtype(source_dtype),
-        target_dtype=np.dtype(dtype),
-        shape=shape,
-        data_format=data_format,
-        chunk_shape=chunk_shape,
-        shard_shape=shard_shape or DEFAULT_SHARD_SHAPE,
-        order=order.value,
-        voxel_size_with_unit=voxel_size_with_unit,
-        flip_axes=flip_axes.to_tuple() if flip_axes else None,
-        compress=compress,
-        rescale_min_max=rescale_min_max,
-        executor_args=executor_args,
-    )
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
+        mag_view = convert_raw(
+            source_raw_path=source,
+            target_path=target,
+            layer_name=layer_name,
+            source_dtype=np.dtype(source_dtype),
+            target_dtype=np.dtype(dtype),
+            shape=shape,
+            data_format=data_format,
+            chunk_shape=chunk_shape,
+            shard_shape=shard_shape or DEFAULT_SHARD_SHAPE,
+            order=order.value,
+            voxel_size_with_unit=voxel_size_with_unit,
+            flip_axes=flip_axes.to_tuple() if flip_axes else None,
+            compress=compress,
+            rescale_min_max=rescale_min_max,
+            executor=executor,
+        )
 
-    if downsample:
-        with get_executor_for_args(executor_args) as executor:
+        if downsample:
             mag_view.layer.downsample(
                 from_mag=mag_view.mag,
                 coarsest_mag=max_mag,

--- a/webknossos/webknossos/cli/convert_raw.py
+++ b/webknossos/webknossos/cli/convert_raw.py
@@ -24,7 +24,6 @@ from ..utils import (
 )
 from ._utils import (
     DEFAULT_DATA_FORMAT_STR,
-    DEFAULT_JOBS,
     ChunkShapeOption,
     ChunksPerShardOption,
     DataFormatOption,
@@ -283,7 +282,7 @@ def main(
             show_default=False,
         ),
     ] = False,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/convert_zarr.py
+++ b/webknossos/webknossos/cli/convert_zarr.py
@@ -2,30 +2,39 @@
 
 import logging
 import time
-from argparse import Namespace
 from functools import partial
-from multiprocessing import cpu_count
 from typing import Annotated, Any, cast
 
 import numpy as np
 import tensorstore
 import typer
+from cluster_tools import Executor
 from upath import UPath
 
 from ..dataset import Dataset, MagView, SegmentationLayer
-from ..dataset.defaults import (
-    DEFAULT_CHUNK_SHAPE,
-    DEFAULT_DATA_FORMAT,
-    DEFAULT_SHARD_SHAPE,
-)
+from ..dataset.defaults import DEFAULT_CHUNK_SHAPE, DEFAULT_SHARD_SHAPE
 from ..dataset_properties import DataFormat, LengthUnit, VoxelSize
 from ..dataset_properties.structuring import DEFAULT_LENGTH_UNIT_STR
 from ..geometry import BoundingBox, Mag, Vec3Int
-from ..utils import get_executor_for_args, rmtree, wait_and_ensure_success
+from ..utils import (
+    rmtree,
+    wait_and_ensure_success,
+    wrap_executor,
+)
 from ._utils import (
+    DEFAULT_DATA_FORMAT_STR,
+    DEFAULT_JOBS,
+    ChunkShapeOption,
+    ChunksPerShardOption,
+    DataFormatOption,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
     SamplingMode,
+    ShardShapeOption,
     VoxelSizeTuple,
+    get_executor_for_args,
     parse_mag,
     parse_path,
     parse_vec3int,
@@ -78,7 +87,7 @@ def convert_zarr(
     voxel_size_with_unit: VoxelSize = VoxelSize((1.0, 1.0, 1.0)),
     flip_axes: tuple[int, ...] | None = None,
     compress: bool = True,
-    executor_args: Namespace | None = None,
+    executor: Executor | None = None,
 ) -> MagView:
     """Performs the conversation of a Zarr dataset to a WEBKNOSSOS dataset."""
     ref_time = time.time()
@@ -107,7 +116,7 @@ def convert_zarr(
     )
 
     # Parallel chunk conversion
-    with get_executor_for_args(args=executor_args) as executor:
+    with wrap_executor(executor) as executor:
         largest_segment_id_per_chunk = wait_and_ensure_success(
             executor.map_to_futures(
                 partial(
@@ -176,39 +185,10 @@ def main(
 When converting a folder, this option is ignored."
         ),
     ] = False,
-    data_format: Annotated[
-        DataFormat,
-        typer.Option(
-            help="Data format to store the target dataset in.",
-        ),
-    ] = str(DEFAULT_DATA_FORMAT),  # type:ignore
-    chunk_shape: Annotated[
-        Vec3Int,
-        typer.Option(
-            help="Number of voxels to be stored as a chunk in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = DEFAULT_CHUNK_SHAPE,
-    shard_shape: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Number of voxels to be stored as a shard in the output format "
-            "(e.g. `1024` or `1024,1024,1024`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
-    chunks_per_shard: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Deprecated, use --shard-shape. Number of chunks to be stored as a shard in the output format "
-            "(e.g. `32` or `32,32,32`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
+    data_format: DataFormatOption = DEFAULT_DATA_FORMAT_STR,  # type: ignore
+    chunk_shape: ChunkShapeOption = DEFAULT_CHUNK_SHAPE,
+    shard_shape: ShardShapeOption = None,
+    chunks_per_shard: ChunksPerShardOption = None,
     flip_axes: Annotated[
         Vec3Int | None,
         typer.Option(
@@ -251,28 +231,9 @@ When converting a folder, this option is ignored."
             show_default=False,
         ),
     ] = False,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Converts a Zarr dataset to a WEBKNOSSOS dataset."""
 
@@ -286,32 +247,31 @@ When converting a folder, this option is ignored."
         chunks_per_shard=chunks_per_shard,
     )
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     voxel_size_with_unit = VoxelSize(voxel_size, unit)
 
     if overwrite_existing and target.exists():
         rmtree(target)
 
-    mag_view = convert_zarr(
-        source_zarr_path=source,
-        target_path=target,
-        layer_name=layer_name,
-        data_format=data_format,
-        chunk_shape=chunk_shape,
-        shard_shape=shard_shape or DEFAULT_SHARD_SHAPE,
-        is_segmentation_layer=is_segmentation_layer,
-        voxel_size_with_unit=voxel_size_with_unit,
-        flip_axes=flip_axes.to_tuple() if flip_axes else None,
-        compress=compress,
-        executor_args=executor_args,
-    )
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
+        mag_view = convert_zarr(
+            source_zarr_path=source,
+            target_path=target,
+            layer_name=layer_name,
+            data_format=data_format,
+            chunk_shape=chunk_shape,
+            shard_shape=shard_shape or DEFAULT_SHARD_SHAPE,
+            is_segmentation_layer=is_segmentation_layer,
+            voxel_size_with_unit=voxel_size_with_unit,
+            flip_axes=flip_axes.to_tuple() if flip_axes else None,
+            compress=compress,
+            executor=executor,
+        )
 
-    if downsample:
-        with get_executor_for_args(executor_args) as executor:
+        if downsample:
             mag_view.layer.downsample(
                 from_mag=mag_view.mag,
                 coarsest_mag=max_mag,

--- a/webknossos/webknossos/cli/convert_zarr.py
+++ b/webknossos/webknossos/cli/convert_zarr.py
@@ -23,7 +23,6 @@ from ..utils import (
 )
 from ._utils import (
     DEFAULT_DATA_FORMAT_STR,
-    DEFAULT_JOBS,
     ChunkShapeOption,
     ChunksPerShardOption,
     DataFormatOption,
@@ -231,7 +230,7 @@ When converting a folder, this option is ignored."
             show_default=False,
         ),
     ] = False,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/copy_dataset.py
+++ b/webknossos/webknossos/cli/copy_dataset.py
@@ -1,8 +1,6 @@
 """This module copies a WEBKNOSSOS datasets."""
 
 import logging
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import typer
@@ -10,8 +8,18 @@ import typer
 from ..dataset import Dataset
 from ..dataset_properties import DataFormat
 from ..geometry import Vec3Int
-from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, parse_path, parse_vec3int
+from ._utils import (
+    DEFAULT_JOBS,
+    DistributionStrategy,
+    DistributionStrategyOption,
+    ExistsOkOption,
+    JobResourcesOption,
+    JobsOption,
+    ShardShapeOption,
+    get_executor_for_args,
+    parse_path,
+    parse_vec3int,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -49,40 +57,11 @@ def main(
             metavar="Vec3Int",
         ),
     ] = None,
-    shard_shape: Annotated[
-        Vec3Int | None,
-        typer.Option(
-            help="Number of voxels to be stored as a shard in the target dataset "
-            "(e.g. `1024` or `1024,1024,1024`).",
-            parser=parse_vec3int,
-            metavar="Vec3Int",
-        ),
-    ] = None,
-    exists_ok: Annotated[
-        bool, typer.Option(help="Whether it should overwrite an existing dataset.")
-    ] = False,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    shard_shape: ShardShapeOption = None,
+    exists_ok: ExistsOkOption = False,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Make a copy of the WEBKNOSSOS dataset.
 
@@ -95,15 +74,13 @@ def main(
     - AWS_SECRET_ACCESS_KEY
     """
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
-
     source_dataset = Dataset.open(source)
 
-    with get_executor_for_args(args=executor_args) as executor:
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
         source_dataset.copy_dataset(
             target,
             chunk_shape=chunk_shape,

--- a/webknossos/webknossos/cli/copy_dataset.py
+++ b/webknossos/webknossos/cli/copy_dataset.py
@@ -9,7 +9,6 @@ from ..dataset import Dataset
 from ..dataset_properties import DataFormat
 from ..geometry import Vec3Int
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     ExistsOkOption,
@@ -59,7 +58,7 @@ def main(
     ] = None,
     shard_shape: ShardShapeOption = None,
     exists_ok: ExistsOkOption = False,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/downsample.py
+++ b/webknossos/webknossos/cli/downsample.py
@@ -12,6 +12,7 @@ from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
 from ..utils import get_executor_for_args
 from ._utils import (
+    AccessModeOption,
     DistributionStrategy,
     SamplingMode,
     open_dataset,
@@ -84,14 +85,7 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             rich_help_panel="WEBKNOSSOS context",
         ),
     ] = None,
-    access_mode: Annotated[
-        RemoteAccessMode | None,
-        typer.Option(
-            help="How to access the remote dataset's data. "
-            "Defaults to 'direct_path' when --transfer-mode is not 'http', otherwise 'proxy_path'.",
-            rich_help_panel="WEBKNOSSOS context",
-        ),
-    ] = None,
+    access_mode: AccessModeOption = None,
 ) -> None:
     """Downsample your WEBKNOSSOS dataset."""
 

--- a/webknossos/webknossos/cli/downsample.py
+++ b/webknossos/webknossos/cli/downsample.py
@@ -9,7 +9,6 @@ from ..dataset import RemoteDataset, SamplingModes, TransferMode
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -56,7 +55,7 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             envvar="WK_TOKEN",
         ),
     ] = None,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
     transfer_mode: Annotated[

--- a/webknossos/webknossos/cli/downsample.py
+++ b/webknossos/webknossos/cli/downsample.py
@@ -1,7 +1,5 @@
 """This module takes care of downsampling WEBKNOSSOS datasets."""
 
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated
 
 import typer
@@ -10,10 +8,14 @@ from upath import UPath
 from ..dataset import RemoteDataset, SamplingModes, TransferMode
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
-from ..utils import get_executor_for_args
 from ._utils import (
+    DEFAULT_JOBS,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
     SamplingMode,
+    get_executor_for_args,
     open_dataset,
     parse_mag,
 )
@@ -54,28 +56,9 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             envvar="WK_TOKEN",
         ),
     ] = None,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
     transfer_mode: Annotated[
         TransferMode | None,
         typer.Option(
@@ -95,11 +78,6 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
 ) -> None:
     """Downsample your WEBKNOSSOS dataset."""
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     sampling_mode_parsed = SamplingModes.parse(sampling_mode.value)
 
     if access_mode is None:
@@ -111,7 +89,11 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
     with open_dataset(
         UPath(target), annotation_ok=False, token=token, access_mode=access_mode
     ) as dataset:
-        with get_executor_for_args(args=executor_args) as executor:
+        with get_executor_for_args(
+            jobs=jobs,
+            distribution_strategy=distribution_strategy,
+            job_resources=job_resources,
+        ) as executor:
             if isinstance(dataset, RemoteDataset):
                 if transfer_mode is None:
                     raise typer.BadParameter(

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -17,7 +17,6 @@ from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import wait_and_ensure_success
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -240,7 +239,7 @@ def main(
     batch_size: Annotated[
         int, typer.Option(help="Number of sections to buffer per job.")
     ] = DEFAULT_CHUNK_SHAPE.z,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
     token: Annotated[

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -8,12 +8,13 @@ from typing import Annotated, Any
 import numpy as np
 import typer
 from cluster_tools import Executor
-from PIL import Image
 from scipy.ndimage import zoom
+from tifffile import imwrite
 from upath import UPath
 
 from ..dataset import MagView, View
 from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
+from ..dataset_properties import SEGMENTATION_CATEGORY
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import wait_and_ensure_success
 from ._utils import (
@@ -41,7 +42,7 @@ def _make_tiff_name(name: str, slice_index: int) -> str:
         return f"{name}_{slice_index:06d}.tiff"
 
 
-def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> Image.Image:
+def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> np.ndarray:
     if data_slice.shape[0] == 1:
         # discard greyscale dimension
         data_slice = data_slice.squeeze(axis=0)
@@ -62,7 +63,7 @@ def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> Image.Image:
             mode="nearest",
             prefilter=True,
         )
-    return Image.fromarray(data_slice)
+    return data_slice
 
 
 def export_tiff_slice_batch(
@@ -71,10 +72,12 @@ def export_tiff_slice_batch(
     tiling_size: None | tuple[int, int],
     downsample: int,
     start_slice_z_mag1: int,
+    compress: bool,
     view: View,
 ) -> None:
     tiff_bbox_mag1 = view.bounding_box
     tiff_bbox = tiff_bbox_mag1.in_mag(view.mag)
+    compression_arg = "zlib" if compress else None
 
     if tiling_size is None:
         tiff_data = view.read()
@@ -103,7 +106,7 @@ def export_tiff_slice_batch(
 
             image = _slice_to_image(tiff_data[:, :, :, slice_index], downsample)
             with tiff_file_path.open("wb") as f:
-                image.save(f)
+                imwrite(f, data=image, compression=compression_arg)
             logger.debug("Saved slice %s", slice_name_number)
 
         else:
@@ -127,7 +130,7 @@ def export_tiff_slice_batch(
                     )
 
                     with (tile_tiff_path / tile_tiff_filename).open("wb") as f:
-                        tile_image.save(f)
+                        imwrite(f, data=tile_image, compression=compression_arg)
 
             logger.debug("Saved tiles for slice %s", slice_name_number)
 
@@ -168,6 +171,7 @@ def export_tiff_stack(
                 tiling_slice_size,
                 downsample,
                 bbox.topleft.z,
+                mag_view.layer.category == SEGMENTATION_CATEGORY,
             ),
             view_chunks,
         ),

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -64,13 +64,15 @@ def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> np.ndarray:
             mode="nearest",
             prefilter=True,
         )
+    if data_slice.ndim == 3:
+        return np.moveaxis(data_slice, 0, -1)
     return data_slice
 
 
 def _apply_mapping(data: np.ndarray, mapping: np.ndarray) -> np.ndarray:
-    clipped = np.clip(data.astype(np.int64), 0, len(mapping) - 1)
-    result = mapping[clipped]
-    result[data.astype(np.int64) >= len(mapping)] = 0
+    mask = data < len(mapping)
+    result = np.zeros_like(data, dtype=mapping.dtype)
+    result[mask] = mapping[data[mask]]
     return result
 
 

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -64,8 +64,6 @@ def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> np.ndarray:
             mode="nearest",
             prefilter=True,
         )
-    if data_slice.ndim == 3:
-        return np.moveaxis(data_slice, 0, -1)
     return data_slice
 
 

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -18,6 +18,7 @@ from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import get_executor_for_args, wait_and_ensure_success
 from ._utils import (
+    AccessModeOption,
     DistributionStrategy,
     Vec2Int,
     open_dataset,
@@ -268,12 +269,13 @@ def main(
             envvar="WK_TOKEN",
         ),
     ] = None,
+    access_mode: AccessModeOption = None,
 ) -> None:
     """Export your WEBKNOSSOS dataset to TIFF image data."""
 
     mag_view: MagView | None = None
     source_path = UPath(source)
-    with open_dataset(source_path, annotation_ok=True, token=token) as dataset:
+    with open_dataset(source_path, annotation_ok=True, token=token, access_mode=access_mode) as dataset:
         mag_view = dataset.get_layer(layer_name).get_mag(mag)
 
     if mag_view is None:

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -5,15 +5,17 @@ from functools import partial
 from math import ceil
 from typing import Annotated, Any
 
+import fastremap
 import numpy as np
 import typer
 from cluster_tools import Executor
 from scipy.ndimage import zoom
+from tensorstore import Context, TensorStore
 from tifffile import imwrite
 from upath import UPath
 
 from ..dataset import MagView, View
-from ..dataset._utils.tensorstore_helpers import read_zarr3_array
+from ..dataset._utils.tensorstore_helpers import open_zarr3_array
 from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
 from ..dataset_properties import SEGMENTATION_CATEGORY, AttachmentDataFormat
 from ..geometry import BoundingBox, Mag, Vec3Int
@@ -67,11 +69,14 @@ def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> np.ndarray:
     return data_slice
 
 
-def _apply_mapping(data: np.ndarray, mapping: np.ndarray) -> np.ndarray:
-    mask = data < len(mapping)
-    result = np.zeros_like(data, dtype=mapping.dtype)
-    result[mask] = mapping[data[mask]]
-    return result
+def _apply_mapping(data: np.ndarray, mapping_array: TensorStore) -> np.ndarray:
+    unique_ids = fastremap.unique(data)
+    in_bounds = [i for i in unique_ids if i < mapping_array.shape[0]]
+    out_of_bounds = [i for i in unique_ids if i >= mapping_array.shape[0]]
+    mapped_ids = mapping_array[in_bounds].read().result() if in_bounds else []
+    mapping = {**dict(zip(in_bounds, mapped_ids)), **{i: 0 for i in out_of_bounds}}
+    result = fastremap.remap(data, mapping, preserve_missing_labels=False)
+    return result.astype(mapping_array.dtype.numpy_dtype)
 
 
 def export_tiff_slice_batch(
@@ -87,12 +92,20 @@ def export_tiff_slice_batch(
     tiff_bbox_mag1 = view.bounding_box
     tiff_bbox = tiff_bbox_mag1.in_mag(view.mag)
     compression_arg = "zlib" if compress else None
-    mapping = read_zarr3_array(mapping_path) if mapping_path is not None else None
+
+    mapping_array = None
+    if mapping_path is not None:
+        ts_context = Context(
+            {
+                "cache_pool": {"total_bytes_limit": 10 * 1024**2},  # 10 MB
+            }
+        )
+        mapping_array = open_zarr3_array(mapping_path, context=ts_context)
 
     if tiling_size is None:
         tiff_data = view.read()
-        if mapping is not None:
-            tiff_data = _apply_mapping(tiff_data, mapping)
+        if mapping_array is not None:
+            tiff_data = _apply_mapping(tiff_data, mapping_array)
     else:
         padded_tiff_bbox_size = Vec3Int(
             tiling_size[0] * ceil(tiff_bbox.size.x / tiling_size[0]),
@@ -100,8 +113,8 @@ def export_tiff_slice_batch(
             tiff_bbox.size.z,
         )
         tiff_data = view.read()
-        if mapping is not None:
-            tiff_data = _apply_mapping(tiff_data, mapping)
+        if mapping_array is not None:
+            tiff_data = _apply_mapping(tiff_data, mapping_array)
         padded_tiff_data = np.zeros(
             (tiff_data.shape[0],) + padded_tiff_bbox_size.to_tuple(),
             dtype=tiff_data.dtype,

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -1,14 +1,13 @@
 """This module takes care of exporting tiff images."""
 
 import logging
-from argparse import Namespace
 from functools import partial
 from math import ceil
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import numpy as np
 import typer
+from cluster_tools import Executor
 from PIL import Image
 from scipy.ndimage import zoom
 from upath import UPath
@@ -16,10 +15,15 @@ from upath import UPath
 from ..dataset import MagView, View
 from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
 from ..geometry import BoundingBox, Mag, Vec3Int
-from ..utils import get_executor_for_args, wait_and_ensure_success
+from ..utils import wait_and_ensure_success
 from ._utils import (
+    DEFAULT_JOBS,
     DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
     Vec2Int,
+    get_executor_for_args,
     open_dataset,
     parse_bbox,
     parse_mag,
@@ -138,39 +142,38 @@ def export_tiff_stack(
     tiling_slice_size: None | tuple[int, int],
     batch_size: int,
     downsample: int,
-    args: Namespace,
+    executor: Executor,
 ) -> None:
     destination_path.mkdir(parents=True, exist_ok=True)
 
-    with get_executor_for_args(args) as executor:
-        view = mag_view.get_view(
-            absolute_offset=bbox.topleft, size=bbox.size, read_only=True
+    view = mag_view.get_view(
+        absolute_offset=bbox.topleft, size=bbox.size, read_only=True
+    )
+
+    view_chunks = [
+        view.get_view(
+            relative_offset=(0, 0, z),
+            size=(bbox.size.x, bbox.size.y, min(batch_size, bbox.size.z - z)),
+            read_only=True,
         )
+        for z in range(0, bbox.size.z, batch_size)
+    ]
 
-        view_chunks = [
-            view.get_view(
-                relative_offset=(0, 0, z),
-                size=(bbox.size.x, bbox.size.y, min(batch_size, bbox.size.z - z)),
-                read_only=True,
-            )
-            for z in range(0, bbox.size.z, batch_size)
-        ]
-
-        wait_and_ensure_success(
-            executor.map_to_futures(
-                partial(
-                    export_tiff_slice_batch,
-                    destination_path,
-                    name,
-                    tiling_slice_size,
-                    downsample,
-                    bbox.topleft.z,
-                ),
-                view_chunks,
+    wait_and_ensure_success(
+        executor.map_to_futures(
+            partial(
+                export_tiff_slice_batch,
+                destination_path,
+                name,
+                tiling_slice_size,
+                downsample,
+                bbox.topleft.z,
             ),
-            executor=executor,
-            progress_desc="Exporting tiff files",
-        )
+            view_chunks,
+        ),
+        executor=executor,
+        progress_desc="Exporting tiff files",
+    )
 
 
 def main(
@@ -237,28 +240,9 @@ def main(
     batch_size: Annotated[
         int, typer.Option(help="Number of sections to buffer per job.")
     ] = DEFAULT_CHUNK_SHAPE.z,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
     token: Annotated[
         str | None,
         typer.Option(
@@ -285,11 +269,6 @@ def main(
     bbox = bbox.align_with_mag(mag_view.mag)
 
     logger.info("Starting tiff export for bounding box: %s", bbox)
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     used_tile_size = None
     if tiles_per_dimension is not None:
         tile_size = tiles_per_dimension
@@ -307,13 +286,18 @@ def main(
         logger.info("Using tiling with the size of %d,%d.", tile_size[0], tile_size[1])
         used_tile_size = tile_size
 
-    export_tiff_stack(
-        mag_view=mag_view,
-        bbox=bbox,
-        destination_path=target,
-        name=name,
-        tiling_slice_size=used_tile_size,
-        batch_size=batch_size,
-        downsample=downsample,
-        args=executor_args,
-    )
+    with get_executor_for_args(
+        jobs=jobs,
+        distribution_strategy=distribution_strategy,
+        job_resources=job_resources,
+    ) as executor:
+        export_tiff_stack(
+            mag_view=mag_view,
+            bbox=bbox,
+            destination_path=target,
+            name=name,
+            tiling_slice_size=used_tile_size,
+            batch_size=batch_size,
+            downsample=downsample,
+            executor=executor,
+        )

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -13,8 +13,9 @@ from tifffile import imwrite
 from upath import UPath
 
 from ..dataset import MagView, View
+from ..dataset._utils.tensorstore_helpers import read_zarr3_array
 from ..dataset.defaults import DEFAULT_CHUNK_SHAPE
-from ..dataset_properties import SEGMENTATION_CATEGORY
+from ..dataset_properties import SEGMENTATION_CATEGORY, AttachmentDataFormat
 from ..geometry import BoundingBox, Mag, Vec3Int
 from ..utils import wait_and_ensure_success
 from ._utils import (
@@ -66,6 +67,13 @@ def _slice_to_image(data_slice: np.ndarray, downsample: int = 1) -> np.ndarray:
     return data_slice
 
 
+def _apply_mapping(data: np.ndarray, mapping: np.ndarray) -> np.ndarray:
+    clipped = np.clip(data.astype(np.int64), 0, len(mapping) - 1)
+    result = mapping[clipped]
+    result[data.astype(np.int64) >= len(mapping)] = 0
+    return result
+
+
 def export_tiff_slice_batch(
     dest_path: UPath,
     name: str,
@@ -73,14 +81,18 @@ def export_tiff_slice_batch(
     downsample: int,
     start_slice_z_mag1: int,
     compress: bool,
+    mapping_path: UPath | None,
     view: View,
 ) -> None:
     tiff_bbox_mag1 = view.bounding_box
     tiff_bbox = tiff_bbox_mag1.in_mag(view.mag)
     compression_arg = "zlib" if compress else None
+    mapping = read_zarr3_array(mapping_path) if mapping_path is not None else None
 
     if tiling_size is None:
         tiff_data = view.read()
+        if mapping is not None:
+            tiff_data = _apply_mapping(tiff_data, mapping)
     else:
         padded_tiff_bbox_size = Vec3Int(
             tiling_size[0] * ceil(tiff_bbox.size.x / tiling_size[0]),
@@ -88,6 +100,8 @@ def export_tiff_slice_batch(
             tiff_bbox.size.z,
         )
         tiff_data = view.read()
+        if mapping is not None:
+            tiff_data = _apply_mapping(tiff_data, mapping)
         padded_tiff_data = np.zeros(
             (tiff_data.shape[0],) + padded_tiff_bbox_size.to_tuple(),
             dtype=tiff_data.dtype,
@@ -146,6 +160,7 @@ def export_tiff_stack(
     batch_size: int,
     downsample: int,
     executor: Executor,
+    mapping_path: UPath | None = None,
 ) -> None:
     destination_path.mkdir(parents=True, exist_ok=True)
 
@@ -172,6 +187,7 @@ def export_tiff_stack(
                 downsample,
                 bbox.topleft.z,
                 mag_view.layer.category == SEGMENTATION_CATEGORY,
+                mapping_path,
             ),
             view_chunks,
         ),
@@ -221,6 +237,14 @@ def main(
     ] = 1,  # type: ignore
     name: Annotated[str, typer.Option(help="Name of the tiffs.")] = "",
     downsample: Annotated[int, typer.Option(help="Downsample each tiff image.")] = 1,
+    apply_mapping: Annotated[
+        str | None,
+        typer.Option(
+            help="Name of an agglomerate attachment. Segment IDs are replaced with "
+            "agglomerate IDs before export. Requires a segmentation layer with "
+            "a Zarr3-format agglomerate attachment of that name.",
+        ),
+    ] = None,
     tiles_per_dimension: Annotated[
         Vec2Int | None,
         typer.Option(
@@ -261,11 +285,41 @@ def main(
     """Export your WEBKNOSSOS dataset to TIFF image data."""
 
     mag_view: MagView | None = None
+    mapping_path: UPath | None = None
     source_path = UPath(source)
     with open_dataset(
         source_path, annotation_ok=True, token=token, access_mode=access_mode
     ) as dataset:
-        mag_view = dataset.get_layer(layer_name).get_mag(mag)
+        layer = dataset.get_layer(layer_name)
+        mag_view = layer.get_mag(mag)
+
+        if apply_mapping is not None:
+            if layer.category != SEGMENTATION_CATEGORY:
+                raise ValueError(
+                    f"--apply-mapping requires a segmentation layer, "
+                    f"but '{layer_name}' is a '{layer.category}' layer."
+                )
+            seg_layer = layer.as_segmentation_layer()
+            named = next(
+                (
+                    a
+                    for a in seg_layer.attachments.agglomerates
+                    if a.name == apply_mapping
+                ),
+                None,
+            )
+            if named is None:
+                available = [a.name for a in seg_layer.attachments.agglomerates]
+                raise ValueError(
+                    f"No agglomerate attachment named '{apply_mapping}'. "
+                    f"Available: {available}"
+                )
+            if named.data_format != AttachmentDataFormat.Zarr3:
+                raise ValueError(
+                    f"Agglomerate attachment '{apply_mapping}' is not in Zarr3 format. "
+                    "Only Zarr3 format is supported."
+                )
+            mapping_path = named.path / "segment_to_agglomerate"
 
     if mag_view is None:
         raise ValueError(
@@ -307,4 +361,5 @@ def main(
             batch_size=batch_size,
             downsample=downsample,
             executor=executor,
+            mapping_path=mapping_path,
         )

--- a/webknossos/webknossos/cli/main.py
+++ b/webknossos/webknossos/cli/main.py
@@ -2,6 +2,7 @@
 
 import typer
 
+from ..utils import set_s3fs_retry_settings
 from . import (
     check_equality,
     compress,
@@ -26,6 +27,8 @@ def version_callback(value: bool) -> None:
         typer.echo(__version__)
         raise typer.Exit()
 
+
+set_s3fs_retry_settings()
 
 app = typer.Typer(no_args_is_help=True, pretty_exceptions_short=False)
 

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -6,7 +6,6 @@ import typer
 
 from ..annotation import Annotation
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -46,7 +45,7 @@ def main(
         str | None,
         typer.Option(help="Name of the volume layer to merge with fallback layer."),
     ] = None,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
 ) -> None:

--- a/webknossos/webknossos/cli/merge_fallback.py
+++ b/webknossos/webknossos/cli/merge_fallback.py
@@ -1,14 +1,19 @@
 """This module merges a volume annotation layer with its fallback layer."""
 
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated, Any
 
 import typer
 
 from ..annotation import Annotation
-from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, parse_path
+from ._utils import (
+    DEFAULT_JOBS,
+    DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
+    get_executor_for_args,
+    parse_path,
+)
 
 
 def main(
@@ -41,38 +46,17 @@ def main(
         str | None,
         typer.Option(help="Name of the volume layer to merge with fallback layer."),
     ] = None,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help="Necessary when using slurm as distribution strategy. Should be a JSON string "
-            '(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
 ) -> None:
     """Merges a given WEBKNOSSOS annotation with a volume annotation of a fallback layer."""
 
-    executor_args = Namespace(
+    with get_executor_for_args(
         jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
+        distribution_strategy=distribution_strategy,
         job_resources=job_resources,
-    )
-
-    with get_executor_for_args(args=executor_args) as executor:
+    ) as executor:
         Annotation.load(source_annotation).merge_fallback_layer(
             target=target,
             dataset_directory=dataset_directory,

--- a/webknossos/webknossos/cli/upsample.py
+++ b/webknossos/webknossos/cli/upsample.py
@@ -9,7 +9,6 @@ from ..dataset import RemoteDataset, SamplingModes, TransferMode
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
 from ._utils import (
-    DEFAULT_JOBS,
     DistributionStrategy,
     DistributionStrategyOption,
     JobResourcesOption,
@@ -56,7 +55,7 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             envvar="WK_TOKEN",
         ),
     ] = None,
-    jobs: JobsOption = DEFAULT_JOBS,
+    jobs: JobsOption = None,
     distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
     job_resources: JobResourcesOption = None,
     transfer_mode: Annotated[

--- a/webknossos/webknossos/cli/upsample.py
+++ b/webknossos/webknossos/cli/upsample.py
@@ -1,7 +1,5 @@
 """This module takes care of upsampling WEBKNOSSOS datasets."""
 
-from argparse import Namespace
-from multiprocessing import cpu_count
 from typing import Annotated
 
 import typer
@@ -10,8 +8,17 @@ from upath import UPath
 from ..dataset import RemoteDataset, SamplingModes, TransferMode
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
-from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, SamplingMode, open_dataset, parse_mag
+from ._utils import (
+    DEFAULT_JOBS,
+    DistributionStrategy,
+    DistributionStrategyOption,
+    JobResourcesOption,
+    JobsOption,
+    SamplingMode,
+    get_executor_for_args,
+    open_dataset,
+    parse_mag,
+)
 
 
 def main(
@@ -49,28 +56,9 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             envvar="WK_TOKEN",
         ),
     ] = None,
-    jobs: Annotated[
-        int,
-        typer.Option(
-            help="Number of processes to be spawned.",
-            rich_help_panel="Executor options",
-        ),
-    ] = cpu_count(),
-    distribution_strategy: Annotated[
-        DistributionStrategy,
-        typer.Option(
-            help="Strategy to distribute the task across CPUs or nodes.",
-            rich_help_panel="Executor options",
-        ),
-    ] = DistributionStrategy.MULTIPROCESSING,
-    job_resources: Annotated[
-        str | None,
-        typer.Option(
-            help='Necessary when using slurm as distribution strategy. Should be a JSON string \
-(e.g., --job-resources=\'{"mem": "10M"}\')\'',
-            rich_help_panel="Executor options",
-        ),
-    ] = None,
+    jobs: JobsOption = DEFAULT_JOBS,
+    distribution_strategy: DistributionStrategyOption = DistributionStrategy.MULTIPROCESSING,
+    job_resources: JobResourcesOption = None,
     transfer_mode: Annotated[
         TransferMode | None,
         typer.Option(
@@ -90,11 +78,6 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
 ) -> None:
     """Upsample your WEBKNOSSOS dataset."""
 
-    executor_args = Namespace(
-        jobs=jobs,
-        distribution_strategy=distribution_strategy.value,
-        job_resources=job_resources,
-    )
     mode = SamplingModes.parse(sampling_mode.value)
 
     if access_mode is None:
@@ -117,7 +100,11 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             extra_kwargs = {}
         if layer_name is None:
             for layer in dataset.layers.values():
-                with get_executor_for_args(args=executor_args) as executor:
+                with get_executor_for_args(
+                    jobs=jobs,
+                    distribution_strategy=distribution_strategy,
+                    job_resources=job_resources,
+                ) as executor:
                     layer.upsample(
                         from_mag=from_mag,
                         sampling_mode=mode,
@@ -125,7 +112,11 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
                         **extra_kwargs,
                     )
         else:
-            with get_executor_for_args(args=executor_args) as executor:
+            with get_executor_for_args(
+                jobs=jobs,
+                distribution_strategy=distribution_strategy,
+                job_resources=job_resources,
+            ) as executor:
                 dataset.get_layer(layer_name).upsample(
                     from_mag=from_mag,
                     sampling_mode=mode,

--- a/webknossos/webknossos/cli/upsample.py
+++ b/webknossos/webknossos/cli/upsample.py
@@ -11,7 +11,7 @@ from ..dataset import RemoteDataset, SamplingModes, TransferMode
 from ..dataset.remote_dataset import RemoteAccessMode
 from ..geometry import Mag
 from ..utils import get_executor_for_args
-from ._utils import DistributionStrategy, SamplingMode, open_dataset, parse_mag
+from ._utils import AccessModeOption, DistributionStrategy, SamplingMode, open_dataset, parse_mag
 
 
 def main(
@@ -79,14 +79,7 @@ Should be number or hyphen-separated string (e.g. 2 or 2-2-2).",
             rich_help_panel="WEBKNOSSOS context",
         ),
     ] = None,
-    access_mode: Annotated[
-        RemoteAccessMode | None,
-        typer.Option(
-            help="How to access the remote dataset's data. "
-            "Defaults to 'direct_path' when --transfer-mode is not 'http', otherwise 'proxy_path'.",
-            rich_help_panel="WEBKNOSSOS context",
-        ),
-    ] = None,
+    access_mode: AccessModeOption = None,
 ) -> None:
     """Upsample your WEBKNOSSOS dataset."""
 

--- a/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
+++ b/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
@@ -8,7 +8,7 @@ import numpy as np
 import tensorstore as ts
 from upath import UPath
 
-from ..utils import is_fs_path
+from ...utils import is_fs_path
 
 TS_CONTEXT = ts.Context()
 

--- a/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
+++ b/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
@@ -110,7 +110,7 @@ def _make_kvstore(path: UPath) -> str | dict[str, str | list[str]]:
         }
 
 
-def read_zarr3_array(path: UPath) -> np.ndarray:  # type: ignore[type-arg]
+def read_zarr3_array(path: UPath) -> np.ndarray:
     """Read a Zarr v3 array from disk into a numpy array."""
 
     arr = ts.open(
@@ -121,12 +121,12 @@ def read_zarr3_array(path: UPath) -> np.ndarray:  # type: ignore[type-arg]
         open=True,
         context=TS_CONTEXT,
     ).result()
-    return arr[:].read().result()  # type: ignore[no-any-return]
+    return arr[:].read().result()
 
 
 def write_zarr3_array(
     path: UPath,
-    data: np.ndarray,  # type: ignore[type-arg]
+    data: np.ndarray,
     *,
     target_chunk_size_bytes: int,
     target_shard_size_bytes: int,

--- a/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
+++ b/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
@@ -1,11 +1,113 @@
 import math
+from functools import lru_cache
+from tempfile import mkdtemp
 from typing import Any
+from urllib.parse import urlparse
 
 import numpy as np
 import tensorstore as ts
 from upath import UPath
 
+from ..utils import is_fs_path
+
 TS_CONTEXT = ts.Context()
+
+
+class AWSCredentialManager:
+    entries: dict[int, tuple[str, str]]
+    folder_path: UPath
+
+    def __init__(self, folder_path: UPath) -> None:
+        self.entries = {}
+        self.folder_path = folder_path
+
+        self.credentials_file_path.touch()
+        self.config_file_path.write_text("[default]\n")
+
+    @property
+    def credentials_file_path(self) -> UPath:
+        return self.folder_path / "credentials"
+
+    @property
+    def config_file_path(self) -> UPath:
+        return self.folder_path / "config"
+
+    def _dump_credentials(self) -> None:
+        self.credentials_file_path.write_text(
+            "\n".join(
+                [
+                    f"[profile-{key_hash}]\naws_access_key_id = {access_key_id}\naws_secret_access_key = {secret_access_key}\n"
+                    for key_hash, (
+                        access_key_id,
+                        secret_access_key,
+                    ) in self.entries.items()
+                ]
+            )
+        )
+
+    def add(self, access_key_id: str, secret_access_key: str) -> dict[str, str]:
+        key_tuple = (access_key_id, secret_access_key)
+        key_hash = hash(key_tuple)
+        self.entries[key_hash] = key_tuple
+        self._dump_credentials()
+        return {
+            "type": "profile",
+            "profile": f"profile-{key_hash}",
+            "config_file": str(self.config_file_path),
+            "credentials_file": str(self.credentials_file_path),
+        }
+
+
+@lru_cache
+def _aws_credential_folder() -> UPath:
+    return UPath(mkdtemp())
+
+
+_aws_credential_manager = AWSCredentialManager(_aws_credential_folder())
+
+
+def _make_kvstore(path: UPath) -> str | dict[str, str | list[str]]:
+    if is_fs_path(path):
+        return {"driver": "file", "path": str(path)}
+    elif path.protocol in ("http", "https"):
+        return {
+            "driver": "http",
+            "base_url": str(path),
+            "headers": [
+                f"{key}: {value}"
+                for key, value in path.storage_options.get("headers", {}).items()
+            ],
+        }
+    elif path.protocol in ("s3"):
+        parsed_url = urlparse(str(path))
+        kvstore_spec: dict[str, Any] = {
+            "driver": "s3",
+            "path": parsed_url.path.lstrip("/"),
+            "bucket": parsed_url.netloc,
+            "use_conditional_write": False,
+        }
+        if endpoint_url := path.storage_options.get("endpoint_url", None):
+            kvstore_spec["endpoint"] = endpoint_url
+        if "key" in path.storage_options and "secret" in path.storage_options:
+            kvstore_spec["aws_credentials"] = _aws_credential_manager.add(
+                path.storage_options["key"], path.storage_options["secret"]
+            )
+        else:
+            kvstore_spec["aws_credentials"] = {"type": "default"}
+        return kvstore_spec
+    elif path.protocol == "memory":
+        # use memory driver (in-memory file systems), e.g. useful for testing
+        # attention: this is not a persistent storage and it does not support
+        # multiprocessing since memory is not shared between processes
+        return {
+            "driver": "memory",
+            "path": path.path,
+        }
+    else:
+        return {
+            "driver": "file",
+            "path": str(path),
+        }
 
 
 def read_zarr3_array(path: UPath) -> np.ndarray:  # type: ignore[type-arg]
@@ -14,7 +116,7 @@ def read_zarr3_array(path: UPath) -> np.ndarray:  # type: ignore[type-arg]
     arr = ts.open(
         {
             "driver": "zarr3",
-            "kvstore": {"driver": "file", "path": str(path)},
+            "kvstore": _make_kvstore(path),
         },
         open=True,
         context=TS_CONTEXT,
@@ -88,7 +190,7 @@ def write_zarr3_array(
     arr = ts.open(
         {
             "driver": "zarr3",
-            "kvstore": {"driver": "file", "path": str(path)},
+            "kvstore": _make_kvstore(path),
             "metadata": metadata,
         },
         create=True,

--- a/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
+++ b/webknossos/webknossos/dataset/_utils/tensorstore_helpers.py
@@ -110,6 +110,19 @@ def _make_kvstore(path: UPath) -> str | dict[str, str | list[str]]:
         }
 
 
+def open_zarr3_array(path: UPath, context: ts.Context = TS_CONTEXT) -> "ts.TensorStore":
+    """Open a Zarr v3 array from disk into a tensorstore array."""
+
+    return ts.open(
+        {
+            "driver": "zarr3",
+            "kvstore": _make_kvstore(path),
+        },
+        open=True,
+        context=context,
+    )
+
+
 def read_zarr3_array(path: UPath) -> np.ndarray:
     """Read a Zarr v3 array from disk into a numpy array."""
 

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -93,13 +93,13 @@ from ..utils import (
     count_defined_values,
     dump_path,
     enrich_path,
-    get_executor_for_args,
     is_fs_path,
     named_partial,
     rmtree,
     strip_trailing_slash,
     wait_and_ensure_success,
     warn_deprecated,
+    wrap_executor,
 )
 from ._utils.infer_bounding_box_existing_files import infer_bounding_box_existing_files
 from ._utils.segmentation_recognition import (
@@ -976,7 +976,7 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
                 filepaths_per_layer = {
                     f"{layer_name}_{k}": v for k, v in filepaths_per_layer.items()
                 }
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             with warnings.catch_warnings():
                 warnings.filterwarnings(
                     "ignore",
@@ -1620,7 +1620,7 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
                     category=UserWarning,
                     module="webknossos",
                 )
-                with get_executor_for_args(None, executor) as executor:
+                with wrap_executor(executor) as executor:
                     shapes_and_max_ids = wait_and_ensure_success(
                         executor.map_to_futures(func_per_chunk, args),
                         executor=executor,
@@ -2281,7 +2281,7 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
         )
         new_dataset.default_view_configuration = self.default_view_configuration
 
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             for layer in self.layers.values():
                 if layers_to_ignore is not None and layer.name in layers_to_ignore:
                     continue

--- a/webknossos/webknossos/dataset/layer/layer.py
+++ b/webknossos/webknossos/dataset/layer/layer.py
@@ -55,12 +55,12 @@ from webknossos.utils import (
     copytree,
     dump_path,
     enrich_path,
-    get_executor_for_args,
     is_fs_path,
     movetree,
     named_partial,
     rmtree,
     warn_deprecated,
+    wrap_executor,
 )
 
 logger = logging.getLogger(__name__)
@@ -1194,7 +1194,7 @@ class Layer(AbstractLayer):
         )
 
         # perform downsampling
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             if buffer_shape is None:
                 buffer_shape = determine_downsample_buffer_shape(target_view.info)
             else:
@@ -1457,7 +1457,7 @@ class Layer(AbstractLayer):
             target_view = target_mag_view.get_view(absolute_bounding_box=bbox_mag1)
 
             # perform upsampling
-            with get_executor_for_args(None, executor) as actual_executor:
+            with wrap_executor(executor) as actual_executor:
                 if buffer_shape is None:
                     buffer_shape = determine_upsample_buffer_shape(prev_mag_view.info)
                 else:

--- a/webknossos/webknossos/dataset/layer/view/_array.py
+++ b/webknossos/webknossos/dataset/layer/view/_array.py
@@ -2,15 +2,12 @@ import re
 from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator, Sequence
 from dataclasses import dataclass, field, replace
-from functools import lru_cache
 from logging import getLogger
-from tempfile import mkdtemp
 from typing import (
     Any,
     Literal,
     TypedDict,
 )
-from urllib.parse import urlparse
 
 import numpy as np
 import tensorstore
@@ -18,7 +15,7 @@ import wkw
 from typing_extensions import NotRequired, Self
 from upath import UPath
 
-from webknossos.dataset._utils.tensorstore_helpers import TS_CONTEXT
+from webknossos.dataset._utils.tensorstore_helpers import TS_CONTEXT, _make_kvstore
 from webknossos.dataset._utils.tinywkw import TinyWkwArray
 from webknossos.dataset_properties import DataFormat
 from webknossos.geometry import BoundingBox, NormalizedBoundingBox, Vec3Int
@@ -410,59 +407,6 @@ class WKWArray(BaseArray):
         self.__dict__ = d
 
 
-class AWSCredentialManager:
-    entries: dict[int, tuple[str, str]]
-    folder_path: UPath
-
-    def __init__(self, folder_path: UPath) -> None:
-        self.entries = {}
-        self.folder_path = folder_path
-
-        self.credentials_file_path.touch()
-        self.config_file_path.write_text("[default]\n")
-
-    @property
-    def credentials_file_path(self) -> UPath:
-        return self.folder_path / "credentials"
-
-    @property
-    def config_file_path(self) -> UPath:
-        return self.folder_path / "config"
-
-    def _dump_credentials(self) -> None:
-        self.credentials_file_path.write_text(
-            "\n".join(
-                [
-                    f"[profile-{key_hash}]\naws_access_key_id = {access_key_id}\naws_secret_access_key = {secret_access_key}\n"
-                    for key_hash, (
-                        access_key_id,
-                        secret_access_key,
-                    ) in self.entries.items()
-                ]
-            )
-        )
-
-    def add(self, access_key_id: str, secret_access_key: str) -> dict[str, str]:
-        key_tuple = (access_key_id, secret_access_key)
-        key_hash = hash(key_tuple)
-        self.entries[key_hash] = key_tuple
-        self._dump_credentials()
-        return {
-            "type": "profile",
-            "profile": f"profile-{key_hash}",
-            "config_file": str(self.config_file_path),
-            "credentials_file": str(self.credentials_file_path),
-        }
-
-
-@lru_cache
-def _aws_credential_folder() -> UPath:
-    return UPath(mkdtemp())
-
-
-_aws_credential_manager = AWSCredentialManager(_aws_credential_folder())
-
-
 class TensorStoreArray(BaseArray):
     _cached_array: tensorstore.TensorStore | None
     _tensorstore_data_format: str
@@ -555,50 +499,6 @@ class TensorStoreArray(BaseArray):
             ),
         )
 
-    @staticmethod
-    def _make_kvstore(path: UPath) -> str | dict[str, str | list[str]]:
-        if is_fs_path(path):
-            return {"driver": "file", "path": str(path)}
-        elif path.protocol in ("http", "https"):
-            return {
-                "driver": "http",
-                "base_url": str(path),
-                "headers": [
-                    f"{key}: {value}"
-                    for key, value in path.storage_options.get("headers", {}).items()
-                ],
-            }
-        elif path.protocol in ("s3"):
-            parsed_url = urlparse(str(path))
-            kvstore_spec: dict[str, Any] = {
-                "driver": "s3",
-                "path": parsed_url.path.lstrip("/"),
-                "bucket": parsed_url.netloc,
-                "use_conditional_write": False,
-            }
-            if endpoint_url := path.storage_options.get("endpoint_url", None):
-                kvstore_spec["endpoint"] = endpoint_url
-            if "key" in path.storage_options and "secret" in path.storage_options:
-                kvstore_spec["aws_credentials"] = _aws_credential_manager.add(
-                    path.storage_options["key"], path.storage_options["secret"]
-                )
-            else:
-                kvstore_spec["aws_credentials"] = {"type": "default"}
-            return kvstore_spec
-        elif path.protocol == "memory":
-            # use memory driver (in-memory file systems), e.g. useful for testing
-            # attention: this is not a persistent storage and it does not support
-            # multiprocessing since memory is not shared between processes
-            return {
-                "driver": "memory",
-                "path": path.path,
-            }
-        else:
-            return {
-                "driver": "file",
-                "path": str(path),
-            }
-
     @classmethod
     def open(cls, path: UPath) -> "TensorStoreArray":
         classes = (Zarr3Array, Zarr2Array)
@@ -614,7 +514,7 @@ class TensorStoreArray(BaseArray):
     def _open_spec(cls, path: UPath) -> dict[str, Any]:
         return {
             "driver": cls._tensorstore_data_format,
-            "kvstore": cls._make_kvstore(path),
+            "kvstore": _make_kvstore(path),
         }
 
     @classmethod
@@ -682,7 +582,7 @@ class TensorStoreArray(BaseArray):
                 lambda: tensorstore.open(
                     {
                         "driver": self._tensorstore_data_format,
-                        "kvstore": self._make_kvstore(self._path),
+                        "kvstore": _make_kvstore(self._path),
                     },
                     context=TS_CONTEXT,
                     recheck_cached="open",
@@ -789,7 +689,7 @@ class TensorStoreArray(BaseArray):
                     lambda: tensorstore.open(
                         {
                             "driver": self._tensorstore_data_format,
-                            "kvstore": self._make_kvstore(self._path),
+                            "kvstore": _make_kvstore(self._path),
                         },
                         context=TS_CONTEXT,
                         recheck_cached="open",
@@ -798,7 +698,7 @@ class TensorStoreArray(BaseArray):
                 )
             except Exception as e:
                 raise ArrayException(
-                    f"Exception while opening array for {self._make_kvstore(self._path)}"
+                    f"Exception while opening array for {_make_kvstore(self._path)}"
                 ) from e
         return self._cached_array
 
@@ -907,7 +807,7 @@ class Zarr3Array(TensorStoreArray):
         _array = tensorstore.open(
             {
                 "driver": str(cls.data_format),
-                "kvstore": cls._make_kvstore(path),
+                "kvstore": _make_kvstore(path),
                 "metadata": {
                     "data_type": str(array_info.voxel_type),
                     "shape": shape,
@@ -980,7 +880,7 @@ class Zarr2Array(TensorStoreArray):
         _array = tensorstore.open(
             {
                 "driver": "zarr",
-                "kvstore": cls._make_kvstore(path),
+                "kvstore": _make_kvstore(path),
                 "metadata": {
                     "shape": shape,
                     "chunks": chunk_shape,
@@ -1023,7 +923,7 @@ class NeuroglancerPrecomputedArray(TensorStoreArray):
     @classmethod
     def _open_spec(cls, path: UPath) -> dict[str, Any]:
         # need to open the parent dir, because that is the multiscale path
-        uri = cls._make_kvstore(path.parent)
+        uri = _make_kvstore(path.parent)
         return {
             "driver": cls._tensorstore_data_format,
             "kvstore": uri,

--- a/webknossos/webknossos/dataset/layer/view/mag_view.py
+++ b/webknossos/webknossos/dataset/layer/view/mag_view.py
@@ -10,12 +10,12 @@ from cluster_tools import Executor
 from upath import UPath
 
 from webknossos.utils import (
-    get_executor_for_args,
     is_fs_path,
     rmtree,
     strip_trailing_slash,
     wait_and_ensure_success,
     warn_deprecated,
+    wrap_executor,
 )
 
 from ....dataset_properties import DataFormat, MagViewProperties
@@ -481,7 +481,7 @@ class MagView(View, Generic[LayerTypeT]):
                 if not view.read_only:
                     view.write(processed_data)
 
-            with get_executor_for_args(None) as executor:
+            with get_executor("multiprocessing", max_workers=3) as executor:
                 executor.map(process_chunk, mag1.get_views_on_disk())
             ```
 
@@ -651,7 +651,7 @@ class MagView(View, Generic[LayerTypeT]):
                     ):
                         yield bbox
 
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             try:
                 bbox_iterator = self._array.list_bounding_boxes()
             except NotImplementedError:

--- a/webknossos/webknossos/dataset/layer/view/view.py
+++ b/webknossos/webknossos/dataset/layer/view/view.py
@@ -20,9 +20,9 @@ from ....geometry import (
 from ....geometry.vec_int import VecIntLike
 from ....utils import (
     count_defined_values,
-    get_executor_for_args,
     get_rich_progress,
     wait_and_ensure_success,
+    wrap_executor,
 )
 from ._array import ArrayInfo, BaseArray
 
@@ -1168,7 +1168,7 @@ class View:
             job_args.append(chunk_view)
 
         # execute the work for each chunk
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             results = wait_and_ensure_success(
                 executor.map_to_futures(func_per_chunk, job_args),
                 executor=executor,
@@ -1373,7 +1373,7 @@ class View:
         """
         if self.bounding_box.size != other.bounding_box.size:
             return False
-        with get_executor_for_args(None, executor) as executor:
+        with wrap_executor(executor) as executor:
             # read-only views are required for more flexible chunk shapes
             # otherwise, shard-aligned chunk shapes would be required
             read_only_self = self.get_view(read_only=True)

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -106,10 +106,17 @@ def time_stop(identifier: str) -> None:
     logger.debug(f"{identifier} took {time.time() - _time:.8f}s")
 
 
+def wrap_executor(executor: Executor | None = None) -> AbstractContextManager[Executor]:
+    if executor is not None:
+        return nullcontext(enter_result=executor)
+    return get_executor("multiprocessing", max_workers=cpu_count())
+
+
 def get_executor_for_args(
     args: argparse.Namespace | None,
     executor: Executor | None = None,
 ) -> AbstractContextManager[Executor]:
+    warn_deprecated("get_executor_for_args", "cluster_tools.get_executor")
     if executor is not None:
         return nullcontext(enter_result=executor)
 


### PR DESCRIPTION
### Description:
- Added `slurm+batching` distribution strategy for CLI commands. `--jobs` can be used to specify the target number of jobs and the `batch-size` key can be specified in the `--job-resources`. 
- Added the `--apply-mapping` option to the `export-as-tiff` CLI command.
- The job resources for `slurm`, `slurm+batching` and `kubernetes` in the CLI commands are now specified as comma-separated key-value pairs instead of JSON, e.g. `--job-resources mem=10G,time=02:00:00`. The JSON syntax is still available for backwards compatibility. 
- The `export-as-tiff` CLI command now compressed exported segmentation layers.
- S3 retry settings are eagerly applied for all CLI commands.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests