### PR TITLE
Add layer view configurations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: Restart Slurm Cluster
         run: cd ./dockered-slurm && docker compose restart slurmctld c1 c2
 
-      - name: "Run Tests (test_all, test_slurm) with modified slurn.conf"
+      - name: "Run Tests (test_all, test_slurm) with modified slurm.conf"
         run: |
           # Run tests requiring a modified slurm config
           docker exec \

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added `RemoteLayer.view_configuration` property to access the layer view configuration (alpha, inverted, min/max histogram, etc). [#1456](https://github.com/scalableminds/webknossos-libs/pull/1456)
 
 ### Changed
 

--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -277,6 +277,20 @@ def test_changing_properties_on_remote_dataset() -> None:
     )
 
 
+def test_remote_layer_view_configuration() -> None:
+    remote_dataset = RemoteDataset.open(dataset_id="59e9cfbdba632ac2ab8b23b5")
+    layer = remote_dataset.get_layer("color")
+    config = layer.view_configuration
+
+    assert isinstance(config, LayerViewConfiguration)
+    assert config.alpha == 1.0
+    assert config.is_inverted == False
+
+    # config values are readyonly
+    with pytest.raises(AttributeError):
+        layer.view_configuration = LayerViewConfiguration(alpha=50.0)
+
+
 def test_changing_properties_on_read_only_remote_dataset() -> None:
     remote_dataset = RemoteDataset.open(
         dataset_id="59e9cfbdba632ac2ab8b23b5", read_only=True

--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -283,7 +283,7 @@ def test_remote_layer_view_configuration() -> None:
     config = layer.view_configuration
 
     assert isinstance(config, LayerViewConfiguration)
-    assert config.alpha == 1.0
+    assert config.alpha == 100.0
     assert config.is_inverted == False
 
     # config values are readyonly

--- a/webknossos/webknossos/client/api_client/wk_api_client.py
+++ b/webknossos/webknossos/client/api_client/wk_api_client.py
@@ -43,6 +43,7 @@ from webknossos.client.api_client.models import (
     ApiWkBuildInfo,
 )
 
+from ...dataset_properties import DatasetViewConfiguration
 from ...utils import time_since_epoch_in_ms
 from ._abstract_api_client import AbstractApiClient
 
@@ -156,6 +157,17 @@ class WkApiClient(AbstractApiClient):
     ) -> ApiDatasetIsValidNewNameResponse:
         route = f"/datasets/{dataset_name}/isValidNewName"
         return self._get_json(route, ApiDatasetIsValidNewNameResponse)
+
+    def dataset_configuration(
+        self,
+        *,
+        dataset_id: str,
+        volume_tracing_ids: list[str],
+    ) -> DatasetViewConfiguration:
+        route = f"/datasetConfigurations/{dataset_id}"
+        return self._post_json_with_json_response(
+            route, volume_tracing_ids, DatasetViewConfiguration
+        )
 
     def dataset_explore_and_add_remote(
         self, *, dataset: ApiDatasetExploreAndAddRemote

--- a/webknossos/webknossos/dataset/layer/remote_layer.py
+++ b/webknossos/webknossos/dataset/layer/remote_layer.py
@@ -6,7 +6,11 @@ from cluster_tools import Executor
 from upath import UPath
 
 from webknossos.dataset.sampling_modes import SamplingModes
-from webknossos.dataset_properties import LayerProperties, MagViewProperties
+from webknossos.dataset_properties import (
+    LayerProperties,
+    LayerViewConfiguration,
+    MagViewProperties,
+)
 
 from ...client.api_client.models import (
     ApiDatasetComposeMag,
@@ -413,6 +417,43 @@ class RemoteLayer(AbstractLayer):
             if layer_properties.name == self.name
         )
         self._apply_properties(layer_properties, self.read_only)
+
+    @property
+    def view_configuration(self) -> LayerViewConfiguration | None:
+        """The current view configuration for this layer as stored on the WEBKNOSSOS server.
+
+        This reflects the user-saved view settings (color, opacity, intensity range, etc.)
+        and is distinct from `default_view_configuration`, which is default for all users accessing the dataset
+        properties. The value is fetched from the server on every access.
+
+        Returns:
+            LayerViewConfiguration | None: The saved view configuration, or None if none is set.
+
+        Examples:
+            ```
+            cfg = layer.view_configuration
+            if cfg is not None:
+                print(cfg.color, cfg.alpha)
+            ```
+        """
+        from ...client.context import _get_api_client
+
+        with self._dataset._context:
+            client = _get_api_client()
+            config = client.dataset_configuration(
+                dataset_id=self._dataset.dataset_id,
+                volume_tracing_ids=[],
+            )
+            if config.layers is None:
+                return None
+            return config.layers.get(self.name)
+
+    @view_configuration.setter
+    def view_configuration(self, _value: LayerViewConfiguration) -> None:
+        raise AttributeError(
+            "view_configuration is read-only. "
+            "Use the WEBKNOSSOS web interface to change the view configuration."
+        )
 
     def __repr__(self) -> str:
         return f"RemoteLayer({repr(self.name)}, dtype={self.dtype}, num_channels={self.num_channels})"

--- a/webknossos/webknossos/dataset_properties/dataset_properties.py
+++ b/webknossos/webknossos/dataset_properties/dataset_properties.py
@@ -25,22 +25,6 @@ def float_tpl(voxel_size: list | tuple) -> Iterable:
 
 
 @attr.define
-class DatasetViewConfiguration:
-    """
-    Stores information on how the dataset is shown in webknossos by default.
-    """
-
-    four_bit: bool | None = None
-    interpolation: bool | None = None
-    render_missing_data_black: bool | None = None
-    loading_strategy: str | None = None
-    segmentation_pattern_opacity: int | None = None
-    zoom: float | None = None
-    position: tuple[int, int, int] | None = None
-    rotation: tuple[int, int, int] | None = None
-
-
-@attr.define
 class LayerViewConfiguration:
     """
     Stores information on how the dataset is shown in webknossos by default.
@@ -76,6 +60,26 @@ class LayerViewConfiguration:
 
     mapping: dict[str, str] | None = None
     """Enables ID mapping for a segmentation layer and applies the selected mapping by default. The default WK behavior is to disable ID mapping. Expected values is a Dict with {"name": my_mapping_name, "type": "HDF5"}."""
+
+
+@attr.define
+class DatasetViewConfiguration:
+    """
+    Stores information on how the dataset is shown in WEBKNOSSOS by default.
+    """
+
+    four_bit: bool | None = None
+    interpolation: bool | None = None
+    render_missing_data_black: bool | None = None
+    loading_strategy: str | None = None
+    segmentation_pattern_opacity: int | None = None
+    zoom: float | None = None
+    position: tuple[int, int, int] | None = None
+    rotation: tuple[int, int, int] | None = None
+    layers: dict[str, LayerViewConfiguration] | None = None
+    color_layer_order: list[str] | None = None
+    blend_mode: str | None = None
+    natively_rendered_layer_name: str | None = None
 
 
 @attr.define
@@ -157,7 +161,7 @@ class DatasetProperties:
     id: dict[str, str]
     """
     id is a legacy field that is not used anymore. Its keys are name (dataset directory name) and team (organization id)
-    However, webknossos will take both from the dataset path and not from what is here in the datasource-properties.json.
+    However, WEBKNOSSOS will take both from the dataset path and not from what is here in the datasource-properties.json.
     """
     scale: VoxelSize
     data_layers: list[SegmentationLayerProperties | LayerProperties]


### PR DESCRIPTION
### Description:
- Add read-only access to layer view configurations (`alpha`, histogram `min`/`max`etc) for `RemoteDatasets` via API client

### Issues:
- fixes #...

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [ ] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples
