### PR TITLE
Transfer mode copy: create parent dir first

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -130,7 +130,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Calling the `x`, `y`, `z` and `c` properties of `VecInt` or `Vec3Int` now raises a `KeyError` instead of a `ValueError` if the axis is missing. [#1419](https://github.com/scalableminds/webknossos-libs/pull/1419)
 - Removed `dtype_per_layer` arguments and properties as they have been deprecated for a long time. [#1426](https://github.com/scalableminds/webknossos-libs/pull/1426)
 - Deprecated `dtype_per_channel` argument in `Dataset.add_layer` and `Dataset.get_or_add_layer` and property in `Layer`. Use `dtype` instead. [#1426](https://github.com/scalableminds/webknossos-libs/pull/1426)
-- Deprecated `RemoteAttachements.upload_attachment`. Use `RemoteAttachements.add_attachment_as_copy` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
+- Deprecated `RemoteAttachments.upload_attachment`. Use `RemoteAttachments.add_attachment_as_copy` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
 - Deprecated `Attachments.{add_mesh,add_agglomerate,add_connectome,set_segment_index,set_cumsum}` methods. Use `*Attachment.from_path_and_name` and `Attachments.{add_attachment_as_copy,add_attachment_as_ref}` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
 
 ### Added

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -131,7 +131,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Removed `dtype_per_layer` arguments and properties as they have been deprecated for a long time. [#1426](https://github.com/scalableminds/webknossos-libs/pull/1426)
 - Deprecated `dtype_per_channel` argument in `Dataset.add_layer` and `Dataset.get_or_add_layer` and property in `Layer`. Use `dtype` instead. [#1426](https://github.com/scalableminds/webknossos-libs/pull/1426)
 - Deprecated `RemoteAttachements.upload_attachment`. Use `RemoteAttachements.add_attachment_as_copy` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
-- Deprecated `Attachments.{add_mesh,add_agglomerate,add_connectome,set_segment_index,set_cumsum}` methods. Use `*Attachment.from_path_and_name` and `Attachements.{add_attachment_as_copy,add_attachment_as_ref}` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
+- Deprecated `Attachments.{add_mesh,add_agglomerate,add_connectome,set_segment_index,set_cumsum}` methods. Use `*Attachment.from_path_and_name` and `Attachments.{add_attachment_as_copy,add_attachment_as_ref}` instead. [#1427](https://github.com/scalableminds/webknossos-libs/pull/1427)
 
 ### Added
 - Added support for proxy paths when accessing RemoteDatasets. Use `RemoteDataset.open(..., access_mode=RemoteAccessMode.PROXY_PATH)`. [#1418](https://github.com/scalableminds/webknossos-libs/pull/1418)

--- a/webknossos/webknossos/dataset/transfer_mode.py
+++ b/webknossos/webknossos/dataset/transfer_mode.py
@@ -44,6 +44,7 @@ class TransferMode(str, Enum):
         progress_desc_label = (
             progress_desc_label + " " if progress_desc_label is not None else ""
         )
+        dst_path.parent.mkdir(parents=True, exist_ok=True)
         copytree(
             src_path,
             dst_path,


### PR DESCRIPTION
Tried to upload a hdf5 attachment with transfer_mode copy (local path). This errored with `FileNotFoundError` because the target path parent did not exist. This is pretty edge-casey, because the copytree function will create the parent in case the object to transfer is a directory. However, since the hdf5 is a single file, it won’t.

This change makes this transfer mode behave like the others in this regard.

It should also be safe for remote paths, for exmaple for s3 it should be a no-op (unless the parent is the bucket path, then it would try to create the bucket, and fail with permission error, that seems ok).