### PR TITLE
More Robust and Faster S3 Deletion

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
-
+- faster deletion of S3 directories by using the delete methods from the s3fs file system, retry more S3 errors observed when deleting directories [#4554](https://github.com/scalableminds/webknossos-libs/pull/4554)
 
 ## [3.4.2](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.4.2) - 2026-04-28
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v3.4.1...v3.4.2)

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -322,24 +322,7 @@ def strip_trailing_slash(path: UPath) -> UPath:
 
 
 def rmtree(path: UPath) -> None:
-    def _walk(path: UPath) -> Iterator[UPath]:
-        if path.exists():
-            if path.is_dir() and not path.is_symlink():
-                for p in path.iterdir():
-                    yield from _walk(p)
-            yield path
-
-    for sub_path in _walk(path):
-        try:
-            if sub_path.is_file() or sub_path.is_symlink():
-                sub_path.unlink()
-            elif sub_path.is_dir():
-                sub_path.rmdir()
-        except FileNotFoundError:  # noqa:  PERF203 `try`-`except` within a loop incurs performance overhead
-            # Some implementations `UPath` do not have explicit directory representations
-            # Therefore, directories only exist, if they have files. Consequently, when
-            # all files have been deleted, the directory does not exist anymore.
-            pass
+    path.fs.delete(path, recursive=True)
 
 
 def copytree(
@@ -562,6 +545,8 @@ def set_s3fs_retry_settings(
                 exc_info=exception,
                 stack_info=True,
             )
+            return True
+        if "connection was closed" in str(exception).lower():
             return True
 
         return False

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -518,6 +518,7 @@ def set_s3fs_retry_settings(
     *, read_timeout: int = 60, connect_timeout: int = 30, retries: int = 10
 ) -> None:
     import s3fs
+    from aiohttp.http_exceptions import ClientPayloadError, TransferEncodingError
     from botocore.exceptions import ClientError, ConnectionClosedError
 
     s3fs_logger = logging.getLogger("s3fs")
@@ -546,12 +547,22 @@ def set_s3fs_retry_settings(
                 stack_info=True,
             )
             return True
-        if "connection was closed" in str(exception).lower():
+        if (
+            "connection was closed" in str(exception).lower()
+            or "not enough data for satisfy" in str(exception).lower()
+        ):
+            s3fs_logger.warning(
+                f"Retrying unexpected error: {exception}",
+                exc_info=exception,
+                stack_info=True,
+            )
             return True
 
         return False
 
     s3fs.add_retryable_error(ConnectionClosedError)
+    s3fs.add_retryable_error(TransferEncodingError)
+    s3fs.add_retryable_error(ClientPayloadError)
     s3fs.set_custom_error_handler(custom_s3fs_error_handler)
 
 

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -322,7 +322,13 @@ def strip_trailing_slash(path: UPath) -> UPath:
 
 
 def rmtree(path: UPath) -> None:
-    path.fs.delete(path, recursive=True)
+    try:
+        path.fs.delete(str(path), recursive=True)
+    except FileNotFoundError:
+        # Some implementations of `UPath` do not have explicit directory representations
+        # Therefore, directories only exist, if they have files. Consequently, when
+        # all files have been deleted, the directory does not exist anymore.
+        pass
 
 
 def copytree(
@@ -518,7 +524,8 @@ def set_s3fs_retry_settings(
     *, read_timeout: int = 60, connect_timeout: int = 30, retries: int = 10
 ) -> None:
     import s3fs
-    from aiohttp.http_exceptions import ClientPayloadError, TransferEncodingError
+    from aiohttp.client_exceptions import ClientPayloadError
+    from aiohttp.http_exceptions import TransferEncodingError
     from botocore.exceptions import ClientError, ConnectionClosedError
 
     s3fs_logger = logging.getLogger("s3fs")


### PR DESCRIPTION
### Description:
- use fsspec.fs.delete method for deleting directory trees since it is faster than manually iterating files with S3 (it internally uses async and bulk delete requests)
- more aggressive retry of s3fs errors (a bit overkill and ugly but hopefully robust, especially the string comparisons -> if we do not see the corresponding warning in the logs in the future, we can remove them again) 

### Todos:
 - [x] Updated Changelog
