### PR TITLE
Avoid unwarranted PermissionErrors in Annotation.open_remote

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed unwarrented PermissionError when using Annotation.open_remote(...). [#1470](https://github.com/scalableminds/webknossos-libs/pull/1470)
 
 
 ## [3.5.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.0) - 2026-06-02

--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -481,7 +481,6 @@ class Annotation:
                 annotation.annotation_id,
                 annotation.organization_id,
                 annotation.dataset_id,
-                name=annotation.name,
                 skeleton=annotation.skeleton,
                 owner_name=annotation.owner_name,
                 time=annotation.time,
@@ -1391,7 +1390,6 @@ class RemoteAnnotation(Annotation):
         organization_id: str,
         dataset_id: str | None = None,
         *,
-        name: str,
         skeleton: Skeleton,
         owner_name: str,
         time: int | None = None,
@@ -1408,7 +1406,6 @@ class RemoteAnnotation(Annotation):
         self.skeleton = skeleton
         self.dataset_id = dataset_id
         self.organization_id = organization_id
-        self.name = name
         self.owner_name = owner_name
         self.time = time
         self.edit_position = edit_position


### PR DESCRIPTION
### Description:
- Setting self.name in `__init__` invoked the name property setter, which unconditionally fired a PATCH /annotations/.../edit request even though the name was already correct.
This caused a 400 permission error for read-only annotations. Remove the name param and assignment from __init__; the getter already fetches the name live from the server.

### Issues:
- fixes #1458 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
