### PR TITLE
add support for endpoint-specific aws env vars

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added support for Python 3.14. [#1473](https://github.com/scalableminds/webknossos-libs/pull/1473)
+- Added support endpoint and path specific AWS credentials in env vars. [#1475](https://github.com/scalableminds/webknossos-libs/pull/1475)
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added support for Python 3.14. [#1473](https://github.com/scalableminds/webknossos-libs/pull/1473)
-- Added support endpoint and path specific AWS credentials in env vars, e.g. `AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET` for `s3://example.com/bucket/path/to/file`. [#1475](https://github.com/scalableminds/webknossos-libs/pull/1475)
+- Added support for endpoint and path specific AWS credentials in env vars, e.g. `AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET` for `s3://example.com/bucket/path/to/file`. [#1475](https://github.com/scalableminds/webknossos-libs/pull/1475)
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added support for Python 3.14. [#1473](https://github.com/scalableminds/webknossos-libs/pull/1473)
-- Added support endpoint and path specific AWS credentials in env vars. [#1475](https://github.com/scalableminds/webknossos-libs/pull/1475)
+- Added support endpoint and path specific AWS credentials in env vars, e.g. `AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET` for `s3://example.com/bucket/path/to/file`. [#1475](https://github.com/scalableminds/webknossos-libs/pull/1475)
 
 ### Changed
 

--- a/webknossos/tests/test_cli.py
+++ b/webknossos/tests/test_cli.py
@@ -87,13 +87,13 @@ def _tiff_cubing(out_path: UPath, data_format: DataFormat) -> None:
     assert (out_path / "tiff" / "1").exists()
 
 
-def test_tiff_cubing_zarr_s3() -> None:
+def test_tiff_cubing_zarr_s3(monkeypatch: pytest.MonkeyPatch) -> None:
     """Tests zarr support when performing tiff cubing."""
 
     out_path = REMOTE_TESTOUTPUT_DIR / "tiff_cubing"
-    os.environ["AWS_SECRET_ACCESS_KEY"] = MINIO_ROOT_PASSWORD
-    os.environ["AWS_ACCESS_KEY_ID"] = MINIO_ROOT_USER
-    os.environ["S3_ENDPOINT_URL"] = f"http://localhost:{MINIO_PORT}"
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", MINIO_ROOT_PASSWORD)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", MINIO_ROOT_USER)
+    monkeypatch.setenv("S3_ENDPOINT_URL", f"http://localhost:{MINIO_PORT}")
 
     random.seed(1)
     _tiff_cubing(out_path, DataFormat.Zarr3)

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -1,3 +1,4 @@
+import os
 from shutil import ignore_patterns
 from unittest.mock import Mock, patch
 
@@ -5,7 +6,7 @@ import pytest
 from upath import UPath
 
 from tests.utils import TestTemporaryDirectoryNonLocal
-from webknossos.utils import call_with_retries, copytree, dump_path
+from webknossos.utils import call_with_retries, copytree, dump_path, enrich_path
 
 
 def test_call_with_retries_success() -> None:
@@ -233,3 +234,26 @@ def test_copytree_with_ignore() -> None:
 
         # subdir2 should have been ignored entirely
         assert not (dst_dir / "subdir2").exists()
+
+
+@pytest.mark.parametrize(
+    "s3_path,env",
+    [
+        ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET__PATH__TO__FILE"),
+        ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET__PATH__TO"),
+        ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET"),
+        ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM"),
+        ("s3://localhost:5000/bucket/path/to/file", "LOCALHOST_5000"),
+    ],
+)
+def test_enrich_path_aws_credentials(s3_path: str, env: str) -> None:
+    os.environ[f"AWS_ACCESS_KEY_ID__{env}"] = "access_key"
+    os.environ[f"AWS_SECRET_ACCESS_KEY__{env}"] = "secret_key"
+    try:
+        upath = enrich_path(s3_path)
+        assert upath.protocol == "s3"
+        assert upath.storage_options["key"] == "access_key"
+        assert upath.storage_options["secret"] == "secret_key"
+    finally:
+        del os.environ[f"AWS_ACCESS_KEY_ID__{env}"]
+        del os.environ[f"AWS_SECRET_ACCESS_KEY__{env}"]

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -263,3 +263,72 @@ def test_enrich_path_aws_credentials(
     assert upath.protocol == "s3"
     assert upath.storage_options["key"] == "access_key"
     assert upath.storage_options["secret"] == "secret_key"
+
+
+@pytest.mark.parametrize(
+    "s3_path,env",
+    [
+        ("s3://ex.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET__PATH__TO__FILE"),
+        (
+            "s3://example.com/bucket/path/to/file",
+            "EXAMPLE_COM__BUCKET__PATH__TO__OTHER",
+        ),
+        ("s3://example.com/buck/path/to/file", "EXAMPLE_COM__BUCKET"),
+        ("s3://example.com/bucket/path/to/file", "EXAMPLE"),
+        ("s3://example.com/bucket/", "EXAMPLE_COM__BUCK"),
+        ("s3://localhost:5000/bucket/path/to/file", "LOCALHOST"),
+        ("s3://localhost/bucket/path/to/file", "LOCALHOST_5000"),
+        ("s3://localhost:6000/bucket/path/to/file", "LOCALHOST_5000"),
+    ],
+)
+def test_enrich_path_aws_credentials_fail(
+    s3_path: str, env: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(f"AWS_ACCESS_KEY_ID__{env}", "access_key")
+    monkeypatch.setenv(f"AWS_SECRET_ACCESS_KEY__{env}", "secret_key")
+    upath = enrich_path(s3_path)
+    assert upath.protocol == "s3"
+    assert "key" not in upath.storage_options
+    assert "secret" not in upath.storage_options
+
+
+def test_enrich_path_aws_credentials_bare_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "access_key")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secret_key")
+    upath = enrich_path("s3://example.com/bucket/path/to/file")
+    assert upath.protocol == "s3"
+    assert upath.storage_options["key"] == "access_key"
+    assert upath.storage_options["secret"] == "secret_key"
+
+
+def test_enrich_path_aws_credentials_missing_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET", "access_key")
+    upath = enrich_path("s3://example.com/bucket/path/to/file")
+    assert upath.protocol == "s3"
+    assert "key" not in upath.storage_options
+    assert "secret" not in upath.storage_options
+
+
+def test_enrich_path_aws_credentials_empty_string(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET", "")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY__EXAMPLE_COM__BUCKET", "secret_key")
+    upath = enrich_path("s3://example.com/bucket/path/to/file")
+    assert upath.protocol == "s3"
+    assert "key" not in upath.storage_options
+    assert "secret" not in upath.storage_options
+
+
+def test_enrich_path_aws_credentials_bare_missing_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "access_key")
+    upath = enrich_path("s3://example.com/bucket/path/to/file")
+    assert upath.protocol == "s3"
+    assert "key" not in upath.storage_options
+    assert "secret" not in upath.storage_options

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -244,6 +244,14 @@ def test_copytree_with_ignore() -> None:
         ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET"),
         ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM"),
         ("s3://localhost:5000/bucket/path/to/file", "LOCALHOST_5000"),
+        (
+            "s3://my-endpoint.com/my-bucket/path/to/file",
+            "MY_ENDPOINT_COM__MY_BUCKET__PATH__TO__FILE",
+        ),
+        ("s3://my-endpoint.com/my-bucket/path/to/file", "MY_ENDPOINT_COM__MY_BUCKET"),
+        ("s3://my-endpoint.com/my-bucket", "MY_ENDPOINT_COM__MY_BUCKET"),
+        ("s3://my-endpoint.com/my-bucket", "MY_ENDPOINT_COM"),
+        ("s3://my-endpoint.com/my-bucket/", "MY_ENDPOINT_COM__MY_BUCKET"),
     ],
 )
 def test_enrich_path_aws_credentials(s3_path: str, env: str) -> None:
@@ -257,3 +265,16 @@ def test_enrich_path_aws_credentials(s3_path: str, env: str) -> None:
     finally:
         del os.environ[f"AWS_ACCESS_KEY_ID__{env}"]
         del os.environ[f"AWS_SECRET_ACCESS_KEY__{env}"]
+
+
+def test_enrich_path_aws_credentials_bucket_only() -> None:
+    os.environ["AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET"] = "access_key"
+    os.environ["AWS_SECRET_ACCESS_KEY__EXAMPLE_COM__BUCKET"] = "secret_key"
+    try:
+        upath = enrich_path("s3://example.com/bucket")
+        assert upath.protocol == "s3"
+        assert upath.storage_options["key"] == "access_key"
+        assert upath.storage_options["secret"] == "secret_key"
+    finally:
+        del os.environ["AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET"]
+        del os.environ["AWS_SECRET_ACCESS_KEY__EXAMPLE_COM__BUCKET"]

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -1,4 +1,3 @@
-import os
 from shutil import ignore_patterns
 from unittest.mock import Mock, patch
 
@@ -243,38 +242,24 @@ def test_copytree_with_ignore() -> None:
         ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET__PATH__TO"),
         ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM__BUCKET"),
         ("s3://example.com/bucket/path/to/file", "EXAMPLE_COM"),
+        ("s3://example.com/bucket/", "EXAMPLE_COM__BUCKET"),
+        ("s3://example.com/bucket/", "EXAMPLE_COM"),
+        ("s3://example.com/bucket", "EXAMPLE_COM__BUCKET"),
+        ("s3://example.com/bucket", "EXAMPLE_COM"),
         ("s3://localhost:5000/bucket/path/to/file", "LOCALHOST_5000"),
         (
             "s3://my-endpoint.com/my-bucket/path/to/file",
             "MY_ENDPOINT_COM__MY_BUCKET__PATH__TO__FILE",
         ),
         ("s3://my-endpoint.com/my-bucket/path/to/file", "MY_ENDPOINT_COM__MY_BUCKET"),
-        ("s3://my-endpoint.com/my-bucket", "MY_ENDPOINT_COM__MY_BUCKET"),
-        ("s3://my-endpoint.com/my-bucket", "MY_ENDPOINT_COM"),
-        ("s3://my-endpoint.com/my-bucket/", "MY_ENDPOINT_COM__MY_BUCKET"),
     ],
 )
-def test_enrich_path_aws_credentials(s3_path: str, env: str) -> None:
-    os.environ[f"AWS_ACCESS_KEY_ID__{env}"] = "access_key"
-    os.environ[f"AWS_SECRET_ACCESS_KEY__{env}"] = "secret_key"
-    try:
-        upath = enrich_path(s3_path)
-        assert upath.protocol == "s3"
-        assert upath.storage_options["key"] == "access_key"
-        assert upath.storage_options["secret"] == "secret_key"
-    finally:
-        del os.environ[f"AWS_ACCESS_KEY_ID__{env}"]
-        del os.environ[f"AWS_SECRET_ACCESS_KEY__{env}"]
-
-
-def test_enrich_path_aws_credentials_bucket_only() -> None:
-    os.environ["AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET"] = "access_key"
-    os.environ["AWS_SECRET_ACCESS_KEY__EXAMPLE_COM__BUCKET"] = "secret_key"
-    try:
-        upath = enrich_path("s3://example.com/bucket")
-        assert upath.protocol == "s3"
-        assert upath.storage_options["key"] == "access_key"
-        assert upath.storage_options["secret"] == "secret_key"
-    finally:
-        del os.environ["AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET"]
-        del os.environ["AWS_SECRET_ACCESS_KEY__EXAMPLE_COM__BUCKET"]
+def test_enrich_path_aws_credentials(
+    s3_path: str, env: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv(f"AWS_ACCESS_KEY_ID__{env}", "access_key")
+    monkeypatch.setenv(f"AWS_SECRET_ACCESS_KEY__{env}", "secret_key")
+    upath = enrich_path(s3_path)
+    assert upath.protocol == "s3"
+    assert upath.storage_options["key"] == "access_key"
+    assert upath.storage_options["secret"] == "secret_key"

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -586,7 +586,7 @@ def set_s3fs_retry_settings(
     s3fs.set_custom_error_handler(custom_s3fs_error_handler)
 
 
-def _detect_aws_credentials(path_parts: Sequence[str]) -> tuple[str, str] | None:
+def _detect_aws_credentials(path_parts: Iterable[str]) -> tuple[str, str] | None:
     path_parts = [part for part in path_parts if part != ""]
     while len(path_parts) > 0:
         env_var_suffix = (
@@ -596,16 +596,15 @@ def _detect_aws_credentials(path_parts: Sequence[str]) -> tuple[str, str] | None
             .replace("-", "_")
             .upper()
         )
-        if (
-            f"AWS_ACCESS_KEY_ID__{env_var_suffix}" in os.environ
-            and f"AWS_SECRET_ACCESS_KEY__{env_var_suffix}" in os.environ
-        ):
-            return os.environ[f"AWS_ACCESS_KEY_ID__{env_var_suffix}"], os.environ[
-                f"AWS_SECRET_ACCESS_KEY__{env_var_suffix}"
-            ]
+        access_key = os.environ.get(f"AWS_ACCESS_KEY_ID__{env_var_suffix}")
+        secret_key = os.environ.get(f"AWS_SECRET_ACCESS_KEY__{env_var_suffix}")
+        if access_key and secret_key:
+            return access_key, secret_key
         path_parts.pop()
-    if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
-        return os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
+    access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if access_key and secret_key:
+        return access_key, secret_key
     return None
 
 

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -586,6 +586,25 @@ def set_s3fs_retry_settings(
     s3fs.set_custom_error_handler(custom_s3fs_error_handler)
 
 
+def _detect_aws_credentials(path_parts: Sequence[str]) -> tuple[str, str] | None:
+    path_parts = list(path_parts)
+    while len(path_parts) > 0:
+        env_var_suffix = (
+            "__".join(path_parts).replace(".", "_").replace(":", "_").upper()
+        )
+        if (
+            f"AWS_ACCESS_KEY_ID__{env_var_suffix}" in os.environ
+            and f"AWS_SECRET_ACCESS_KEY__{env_var_suffix}" in os.environ
+        ):
+            return os.environ[f"AWS_ACCESS_KEY_ID__{env_var_suffix}"], os.environ[
+                f"AWS_SECRET_ACCESS_KEY__{env_var_suffix}"
+            ]
+        path_parts.pop()
+    if "AWS_ACCESS_KEY_ID" in os.environ and "AWS_SECRET_ACCESS_KEY" in os.environ:
+        return os.environ["AWS_ACCESS_KEY_ID"], os.environ["AWS_SECRET_ACCESS_KEY"]
+    return None
+
+
 def enrich_path(
     path: str | PathLike | UPath, dataset_path: UPath | None = None
 ) -> UPath:
@@ -607,9 +626,19 @@ def enrich_path(
         if upath.storage_options.get("endpoint_url") is not None:
             return upath
         parsed_url = urlparse(str(upath))
-        endpoint_url = f"https://{parsed_url.netloc}"
+        endpoint_domain = parsed_url.netloc
+        endpoint_url = f"https://{endpoint_domain}"
         bucket, key = parsed_url.path.lstrip("/").split("/", maxsplit=1)
 
+        if credentials := _detect_aws_credentials(
+            (endpoint_domain, bucket) + tuple(key.split("/"))
+        ):
+            return UPath(
+                f"s3://{bucket}/{key}",
+                endpoint_url=endpoint_url,
+                key=credentials[0],
+                secret=credentials[1],
+            )
         return UPath(f"s3://{bucket}/{key}", endpoint_url=endpoint_url)
 
     if not upath.is_absolute():

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -587,10 +587,14 @@ def set_s3fs_retry_settings(
 
 
 def _detect_aws_credentials(path_parts: Sequence[str]) -> tuple[str, str] | None:
-    path_parts = list(path_parts)
+    path_parts = [part for part in path_parts if part != ""]
     while len(path_parts) > 0:
         env_var_suffix = (
-            "__".join(path_parts).replace(".", "_").replace(":", "_").upper()
+            "__".join(path_parts)
+            .replace(".", "_")
+            .replace(":", "_")
+            .replace("-", "_")
+            .upper()
         )
         if (
             f"AWS_ACCESS_KEY_ID__{env_var_suffix}" in os.environ
@@ -628,18 +632,23 @@ def enrich_path(
         parsed_url = urlparse(str(upath))
         endpoint_domain = parsed_url.netloc
         endpoint_url = f"https://{endpoint_domain}"
-        bucket, key = parsed_url.path.lstrip("/").split("/", maxsplit=1)
+
+        path_parts = parsed_url.path.lstrip("/").split("/", maxsplit=1)
+        bucket = path_parts[0]
+        key = path_parts[1] if len(path_parts) > 1 else ""
+        s3_path = f"s3://{bucket}/{key}" if key else f"s3://{bucket}"
+        key_parts = tuple(part for part in key.split("/") if part)
 
         if credentials := _detect_aws_credentials(
-            (endpoint_domain, bucket) + tuple(key.split("/"))
+            (endpoint_domain, bucket) + key_parts
         ):
             return UPath(
-                f"s3://{bucket}/{key}",
+                s3_path,
                 endpoint_url=endpoint_url,
                 key=credentials[0],
                 secret=credentials[1],
             )
-        return UPath(f"s3://{bucket}/{key}", endpoint_url=endpoint_url)
+        return UPath(s3_path, endpoint_url=endpoint_url)
 
     if not upath.is_absolute():
         assert dataset_path is not None, (


### PR DESCRIPTION
### Description:
- Added support endpoint and path specific AWS credentials in env vars, e.g. `AWS_ACCESS_KEY_ID__EXAMPLE_COM__BUCKET` for `s3://example.com/bucket/path/to/file`.

### Steps to test
```bash
AWS_ACCESS_KEY_ID__FSN1_YOUR_OBJECTSTORAGE_COM=...
AWS_SECRET_ACCESS_KEY__FSN1_YOUR_OBJECTSTORAGE_COM=...
```

```python
from webknossos.utils import enrich_path

a = enrich_path("s3://fsn1.your-objectstorage.com/webknossos-test/hello.txt")
assert "key" in a.storage_options
a.read_text()

from webknossos import Dataset
a = Dataset.open(enrich_path("s3://fsn1.your-objectstorage.com/webknossos-test/l4_sample"))
a.get_layer("color").get_mag("16-16-4").read().shape
```

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests