### PR TITLE
Make read_cxyz more robust

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 
 ### Changed
+- `MagView.read_cxyz` and `MagView.write_cxyz` are more robust for datasets that have only `xyz` axes or additional axes (e.g. `t`) of length 1. [#1478](https://github.com/scalableminds/webknossos-libs/pull/1478)
 
 ### Fixed
 

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -711,7 +711,9 @@ def test_read_write_cxyz_bounding_box_with_extra_axes(
     )
 
     # read_cxyz with BoundingBox must not raise a rank mismatch with the 4D (x,y,z,t) array
-    data_bbox = mag.read_cxyz(absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)))
+    data_bbox = mag.read_cxyz(
+        absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10))
+    )
     assert data_bbox.shape == (1, 10, 10, 10)
 
     # Reading via BoundingBox and via NDBoundingBox must produce identical results

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -673,6 +673,20 @@ def test_read_cxyz_adds_channel_axis(
     data = mag.read_cxyz(absolute_offset=(0, 0, 0), size=(10, 10, 10))
     assert data.shape == (1, 10, 10, 10)
 
+    # Regression: passing absolute_bounding_box=BoundingBox must not raise a rank mismatch
+    data = mag.read_cxyz(absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)))
+    assert data.shape == (1, 10, 10, 10)
+
+    # Same for write_cxyz
+    write_data_cxyz = np.ones((1, 10, 10, 10), dtype=np.uint64)
+    mag.write_cxyz(
+        write_data_cxyz,
+        allow_unaligned=True,
+        absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)),
+    )
+    readback = mag.read_cxyz(absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)))
+    np.testing.assert_array_equal(readback, write_data_cxyz)
+
 
 @pytest.mark.parametrize(
     "layer_bbox,write_bbox,write_data,expected_shape",

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -673,7 +673,7 @@ def test_read_cxyz_adds_channel_axis(
     data = mag.read_cxyz(absolute_offset=(0, 0, 0), size=(10, 10, 10))
     assert data.shape == (1, 10, 10, 10)
 
-    # Regression: passing absolute_bounding_box=BoundingBox must not raise a rank mismatch
+    # Passing absolute_bounding_box=BoundingBox must not raise a rank mismatch
     data = mag.read_cxyz(absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)))
     assert data.shape == (1, 10, 10, 10)
 

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -688,6 +688,48 @@ def test_read_cxyz_adds_channel_axis(
     np.testing.assert_array_equal(readback, write_data_cxyz)
 
 
+@pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
+def test_read_write_cxyz_bounding_box_with_extra_axes(
+    data_format: DataFormat, output_path: UPath
+) -> None:
+    """read_cxyz/write_cxyz with BoundingBox must work for layers that have extra axes (e.g. t) with size 1."""
+    if data_format == DataFormat.WKW:
+        pytest.skip("WKW requires (c, x, y, z) axes and cannot store extra axes")
+    ds_path = prepare_dataset_path(data_format, output_path)
+    layer = Dataset(ds_path, voxel_size=(1, 1, 1)).add_layer(
+        "segmentation",
+        SEGMENTATION_CATEGORY,
+        bounding_box=NDBoundingBox(
+            (0, 0, 0, 0), (10, 10, 10, 1), axes=("x", "y", "z", "t"), index=(0, 1, 2, 3)
+        ),
+        data_format=data_format,
+        num_channels=1,
+    )
+    mag = layer.add_mag("1")
+    layer_bbox = NDBoundingBox(
+        (0, 0, 0, 0), (10, 10, 10, 1), axes=("x", "y", "z", "t"), index=(0, 1, 2, 3)
+    )
+
+    # read_cxyz with BoundingBox must not raise a rank mismatch with the 4D (x,y,z,t) array
+    data_bbox = mag.read_cxyz(absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)))
+    assert data_bbox.shape == (1, 10, 10, 10)
+
+    # Reading via BoundingBox and via NDBoundingBox must produce identical results
+    data_ndbbox = mag.read_cxyz(absolute_bounding_box=layer_bbox)
+    np.testing.assert_array_equal(data_bbox, data_ndbbox)
+
+    # write_cxyz with BoundingBox must not raise; verify with uniform data to avoid
+    # pre-existing axis-ordering quirks in the 5D write path
+    write_data_cxyz = np.ones((1, 10, 10, 10), dtype=np.uint64)
+    mag.write_cxyz(
+        write_data_cxyz,
+        allow_unaligned=True,
+        absolute_bounding_box=BoundingBox((0, 0, 0), (10, 10, 10)),
+    )
+    readback = mag.read_cxyz(absolute_bounding_box=layer_bbox)
+    np.testing.assert_array_equal(readback, write_data_cxyz)
+
+
 @pytest.mark.parametrize(
     "layer_bbox,write_bbox,write_data,expected_shape",
     [

--- a/webknossos/webknossos/dataset/layer/view/mag_view.py
+++ b/webknossos/webknossos/dataset/layer/view/mag_view.py
@@ -20,6 +20,7 @@ from webknossos.utils import (
 
 from ....dataset_properties import DataFormat, MagViewProperties
 from ....geometry import (
+    BoundingBox,
     Mag,
     NDBoundingBox,
     NormalizedBoundingBox,
@@ -449,6 +450,21 @@ class MagView(View, Generic[LayerTypeT]):
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
+        if "c" not in self.normalized_bounding_box.axes:
+            if isinstance(absolute_bounding_box, BoundingBox):
+                absolute_bounding_box = NDBoundingBox(
+                    topleft=absolute_bounding_box.topleft.to_tuple(),
+                    size=absolute_bounding_box.size.to_tuple(),
+                    axes=absolute_bounding_box.axes,
+                    index=absolute_bounding_box.index.to_tuple(),
+                )
+            if isinstance(relative_bounding_box, BoundingBox):
+                relative_bounding_box = NDBoundingBox(
+                    topleft=relative_bounding_box.topleft.to_tuple(),
+                    size=relative_bounding_box.size.to_tuple(),
+                    axes=relative_bounding_box.axes,
+                    index=relative_bounding_box.index.to_tuple(),
+                )
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,

--- a/webknossos/webknossos/dataset/layer/view/mag_view.py
+++ b/webknossos/webknossos/dataset/layer/view/mag_view.py
@@ -451,17 +451,13 @@ class MagView(View, Generic[LayerTypeT]):
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
-        if isinstance(absolute_bounding_box, BoundingBox):
-            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
-                absolute_bounding_box.topleft
-            ).with_size_xyz(absolute_bounding_box.size)
-        if isinstance(relative_bounding_box, BoundingBox):
-            view_bbox = self.normalized_bounding_box
-            relative_bounding_box = view_bbox.with_topleft(
-                VecInt.zeros(view_bbox.axes)
-            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
-                relative_bounding_box.size
-            )
+        absolute_bounding_box = self._normalize_bbox(
+            absolute_bounding_box, relative=False
+        )
+        relative_bounding_box = self._normalize_bbox(
+            relative_bounding_box, relative=True
+        )
+
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,

--- a/webknossos/webknossos/dataset/layer/view/mag_view.py
+++ b/webknossos/webknossos/dataset/layer/view/mag_view.py
@@ -20,13 +20,11 @@ from webknossos.utils import (
 
 from ....dataset_properties import DataFormat, MagViewProperties
 from ....geometry import (
-    BoundingBox,
     Mag,
     NDBoundingBox,
     NormalizedBoundingBox,
     Vec3Int,
     Vec3IntLike,
-    VecInt,
 )
 from ._array import (
     ArrayInfo,

--- a/webknossos/webknossos/dataset/layer/view/mag_view.py
+++ b/webknossos/webknossos/dataset/layer/view/mag_view.py
@@ -26,6 +26,7 @@ from ....geometry import (
     NormalizedBoundingBox,
     Vec3Int,
     Vec3IntLike,
+    VecInt,
 )
 from ._array import (
     ArrayInfo,
@@ -450,21 +451,17 @@ class MagView(View, Generic[LayerTypeT]):
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
-        if "c" not in self.normalized_bounding_box.axes:
-            if isinstance(absolute_bounding_box, BoundingBox):
-                absolute_bounding_box = NDBoundingBox(
-                    topleft=absolute_bounding_box.topleft.to_tuple(),
-                    size=absolute_bounding_box.size.to_tuple(),
-                    axes=absolute_bounding_box.axes,
-                    index=absolute_bounding_box.index.to_tuple(),
-                )
-            if isinstance(relative_bounding_box, BoundingBox):
-                relative_bounding_box = NDBoundingBox(
-                    topleft=relative_bounding_box.topleft.to_tuple(),
-                    size=relative_bounding_box.size.to_tuple(),
-                    axes=relative_bounding_box.axes,
-                    index=relative_bounding_box.index.to_tuple(),
-                )
+        if isinstance(absolute_bounding_box, BoundingBox):
+            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
+                absolute_bounding_box.topleft
+            ).with_size_xyz(absolute_bounding_box.size)
+        if isinstance(relative_bounding_box, BoundingBox):
+            view_bbox = self.normalized_bounding_box
+            relative_bounding_box = view_bbox.with_topleft(
+                VecInt.zeros(view_bbox.axes)
+            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
+                relative_bounding_box.size
+            )
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,

--- a/webknossos/webknossos/dataset/layer/view/view.py
+++ b/webknossos/webknossos/dataset/layer/view/view.py
@@ -11,6 +11,7 @@ from upath import UPath
 
 from ....dataset_properties import DataFormat
 from ....geometry import (
+    BoundingBox,
     Mag,
     NDBoundingBox,
     NormalizedBoundingBox,
@@ -497,6 +498,21 @@ class View:
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
+        if "c" not in self.normalized_bounding_box.axes:
+            if isinstance(absolute_bounding_box, BoundingBox):
+                absolute_bounding_box = NDBoundingBox(
+                    topleft=absolute_bounding_box.topleft.to_tuple(),
+                    size=absolute_bounding_box.size.to_tuple(),
+                    axes=absolute_bounding_box.axes,
+                    index=absolute_bounding_box.index.to_tuple(),
+                )
+            if isinstance(relative_bounding_box, BoundingBox):
+                relative_bounding_box = NDBoundingBox(
+                    topleft=relative_bounding_box.topleft.to_tuple(),
+                    size=relative_bounding_box.size.to_tuple(),
+                    axes=relative_bounding_box.axes,
+                    index=relative_bounding_box.index.to_tuple(),
+                )
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,
@@ -850,6 +866,21 @@ class View:
             data = view.read_cxyz(relative_offset=(10, 10, 0), size=(50, 50, 10))
             ```
         """
+        if "c" not in self.normalized_bounding_box.axes:
+            if isinstance(absolute_bounding_box, BoundingBox):
+                absolute_bounding_box = NDBoundingBox(
+                    topleft=absolute_bounding_box.topleft.to_tuple(),
+                    size=absolute_bounding_box.size.to_tuple(),
+                    axes=absolute_bounding_box.axes,
+                    index=absolute_bounding_box.index.to_tuple(),
+                )
+            if isinstance(relative_bounding_box, BoundingBox):
+                relative_bounding_box = NDBoundingBox(
+                    topleft=relative_bounding_box.topleft.to_tuple(),
+                    size=relative_bounding_box.size.to_tuple(),
+                    axes=relative_bounding_box.axes,
+                    index=relative_bounding_box.index.to_tuple(),
+                )
         mag1_bbox = self._resolve_read_bbox(
             size,
             relative_offset,

--- a/webknossos/webknossos/dataset/layer/view/view.py
+++ b/webknossos/webknossos/dataset/layer/view/view.py
@@ -273,6 +273,22 @@ class View:
             abs_mag1_offset
         ).with_size_xyz(mag1_size)
 
+    def _normalize_bbox(
+        self,
+        bbox: BoundingBox | NDBoundingBox | None,
+        relative: bool = False,
+    ) -> NDBoundingBox | None:
+        if not isinstance(bbox, BoundingBox):
+            return bbox
+        view_bbox = self.normalized_bounding_box
+        if relative:
+            return (
+                view_bbox.with_topleft(VecInt.zeros(view_bbox.axes))
+                .with_topleft_xyz(bbox.topleft)
+                .with_size_xyz(bbox.size)
+            )
+        return view_bbox.with_topleft_xyz(bbox.topleft).with_size_xyz(bbox.size)
+
     def write(
         self,
         data: np.ndarray,
@@ -499,17 +515,13 @@ class View:
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
-        if isinstance(absolute_bounding_box, BoundingBox):
-            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
-                absolute_bounding_box.topleft
-            ).with_size_xyz(absolute_bounding_box.size)
-        if isinstance(relative_bounding_box, BoundingBox):
-            view_bbox = self.normalized_bounding_box
-            relative_bounding_box = view_bbox.with_topleft(
-                VecInt.zeros(view_bbox.axes)
-            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
-                relative_bounding_box.size
-            )
+        absolute_bounding_box = self._normalize_bbox(
+            absolute_bounding_box, relative=False
+        )
+        relative_bounding_box = self._normalize_bbox(
+            relative_bounding_box, relative=True
+        )
+
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,
@@ -863,17 +875,13 @@ class View:
             data = view.read_cxyz(relative_offset=(10, 10, 0), size=(50, 50, 10))
             ```
         """
-        if isinstance(absolute_bounding_box, BoundingBox):
-            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
-                absolute_bounding_box.topleft
-            ).with_size_xyz(absolute_bounding_box.size)
-        if isinstance(relative_bounding_box, BoundingBox):
-            view_bbox = self.normalized_bounding_box
-            relative_bounding_box = view_bbox.with_topleft(
-                VecInt.zeros(view_bbox.axes)
-            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
-                relative_bounding_box.size
-            )
+        absolute_bounding_box = self._normalize_bbox(
+            absolute_bounding_box, relative=False
+        )
+        relative_bounding_box = self._normalize_bbox(
+            relative_bounding_box, relative=True
+        )
+
         mag1_bbox = self._resolve_read_bbox(
             size,
             relative_offset,

--- a/webknossos/webknossos/dataset/layer/view/view.py
+++ b/webknossos/webknossos/dataset/layer/view/view.py
@@ -17,6 +17,7 @@ from ....geometry import (
     NormalizedBoundingBox,
     Vec3Int,
     Vec3IntLike,
+    VecInt,
 )
 from ....geometry.vec_int import VecIntLike
 from ....utils import (
@@ -498,21 +499,17 @@ class View:
         assert len(data.shape) == 4, (
             f"write_cxyz expects a 4D (c, x, y, z) array, got shape {data.shape}"
         )
-        if "c" not in self.normalized_bounding_box.axes:
-            if isinstance(absolute_bounding_box, BoundingBox):
-                absolute_bounding_box = NDBoundingBox(
-                    topleft=absolute_bounding_box.topleft.to_tuple(),
-                    size=absolute_bounding_box.size.to_tuple(),
-                    axes=absolute_bounding_box.axes,
-                    index=absolute_bounding_box.index.to_tuple(),
-                )
-            if isinstance(relative_bounding_box, BoundingBox):
-                relative_bounding_box = NDBoundingBox(
-                    topleft=relative_bounding_box.topleft.to_tuple(),
-                    size=relative_bounding_box.size.to_tuple(),
-                    axes=relative_bounding_box.axes,
-                    index=relative_bounding_box.index.to_tuple(),
-                )
+        if isinstance(absolute_bounding_box, BoundingBox):
+            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
+                absolute_bounding_box.topleft
+            ).with_size_xyz(absolute_bounding_box.size)
+        if isinstance(relative_bounding_box, BoundingBox):
+            view_bbox = self.normalized_bounding_box
+            relative_bounding_box = view_bbox.with_topleft(
+                VecInt.zeros(view_bbox.axes)
+            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
+                relative_bounding_box.size
+            )
         data, write_loc = self._resolve_cxyz_write(
             data,
             relative_offset,
@@ -866,21 +863,17 @@ class View:
             data = view.read_cxyz(relative_offset=(10, 10, 0), size=(50, 50, 10))
             ```
         """
-        if "c" not in self.normalized_bounding_box.axes:
-            if isinstance(absolute_bounding_box, BoundingBox):
-                absolute_bounding_box = NDBoundingBox(
-                    topleft=absolute_bounding_box.topleft.to_tuple(),
-                    size=absolute_bounding_box.size.to_tuple(),
-                    axes=absolute_bounding_box.axes,
-                    index=absolute_bounding_box.index.to_tuple(),
-                )
-            if isinstance(relative_bounding_box, BoundingBox):
-                relative_bounding_box = NDBoundingBox(
-                    topleft=relative_bounding_box.topleft.to_tuple(),
-                    size=relative_bounding_box.size.to_tuple(),
-                    axes=relative_bounding_box.axes,
-                    index=relative_bounding_box.index.to_tuple(),
-                )
+        if isinstance(absolute_bounding_box, BoundingBox):
+            absolute_bounding_box = self.normalized_bounding_box.with_topleft_xyz(
+                absolute_bounding_box.topleft
+            ).with_size_xyz(absolute_bounding_box.size)
+        if isinstance(relative_bounding_box, BoundingBox):
+            view_bbox = self.normalized_bounding_box
+            relative_bounding_box = view_bbox.with_topleft(
+                VecInt.zeros(view_bbox.axes)
+            ).with_topleft_xyz(relative_bounding_box.topleft).with_size_xyz(
+                relative_bounding_box.size
+            )
         mag1_bbox = self._resolve_read_bbox(
             size,
             relative_offset,


### PR DESCRIPTION
### Description:
- `read_cxyz` and `write_cxyz` are more robust for datasets that have only xyz axis or additional axes (e.g. t) of length 1.

### Issues:
- see https://scm.slack.com/archives/CMBMU5684/p1781706533576849 and https://scm.slack.com/archives/CMBMU5684/p1781715642469449

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests