### PR TITLE
Retry More S3FS Errors

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -35,6 +35,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Fixed
 - Fixed unwarrented PermissionError when using Annotation.open_remote(...). [#1470](https://github.com/scalableminds/webknossos-libs/pull/1470)
 - Make `MultiprocessExecutor` safe to be use from multiple threads simultaneously [#1464](https://github.com/scalableminds/webknossos-libs/pull/1464)
+- Broader s3fs retries for `Not enough data...` errors. [#1479](https://github.com/scalableminds/webknossos-libs/pull/1479)
 
 
 

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -569,7 +569,7 @@ def set_s3fs_retry_settings(
             return True
         if (
             "connection was closed" in str(exception).lower()
-            or "not enough data for satisfy" in str(exception).lower()
+            or "not enough data" in str(exception).lower()
         ):
             s3fs_logger.warning(
                 f"Retrying unexpected error: {exception}",


### PR DESCRIPTION
### Description:
- I have seen both error messages:
   - `Not enough data for satisfy transfer length header`
   - `Not enough data to satisfy content length header`
   - Probably, they have fixed the grammar, leading to our retries to fail
   - Now, we just match `Not enough data` which should handle both cases
 - Still, would be better to match by type not by str but since this is hard to reproduce and test and, I am not 100% sure which error type is bubbled up to the retry logic, I  would like to go with this quick fix. Let's see whether this silences those errors in the future. 

### Issues:
- fixes #4636

### Todos:
 - [x] Updated Changelog