### PR TITLE
Allow Not Tailing All Log Lines on Completed Futures

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -14,7 +14,6 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
-- Stop 
 
 ### Fixed
 - Fixed `forward_log` raising an unhandled `TailError` when a cluster job completes without a log file being visible from the head node (e.g. due to slow NFS). [#1480](https://github.com/scalableminds/webknossos-libs/pull/1480)

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -14,9 +14,10 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Added
 
 ### Changed
+- Stop 
 
 ### Fixed
-
+- Fixed `forward_log` raising an unhandled `TailError` when a cluster job completes without a log file being visible from the head node (e.g. due to slow NFS). [#1480](https://github.com/scalableminds/webknossos-libs/pull/1480)
 
 ## [3.5.2](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.2) - 2026-06-18
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v3.5.1...v3.5.2)

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Fixed `forward_log` raising an unhandled `TailError` when a cluster job completes without a log file being visible from the head node (e.g. due to slow NFS). [#1480](https://github.com/scalableminds/webknossos-libs/pull/1480)
+- Longer polling for log files of finished jobs in `forward_log` to prevent unhandled `TailError`s when a cluster job completes but the log file is not yet visible from the head node e.g. due to a slow NFS. [#1480](https://github.com/scalableminds/webknossos-libs/pull/1480)
 
 ## [3.5.2](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.2) - 2026-06-18
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v3.5.1...v3.5.2)

--- a/cluster_tools/cluster_tools/_utils/tailf.py
+++ b/cluster_tools/cluster_tools/_utils/tailf.py
@@ -33,15 +33,7 @@ class Tail:
             seconds - Number of seconds to wait between each iteration; Defaults to 1.
         """
 
-        if self.is_cancelled:
-            return
-
-        try:
-            self.check_file_validity(self.tailed_file)
-        except TailError:
-            if self.is_cancelled:
-                return
-            raise
+        self.check_file_validity(self.tailed_file)
         with open(self.tailed_file, encoding="utf-8", errors="replace") as file_:
             # Don't seek, since we want to print the entire file here.
             while True:

--- a/cluster_tools/cluster_tools/_utils/tailf.py
+++ b/cluster_tools/cluster_tools/_utils/tailf.py
@@ -33,7 +33,13 @@ class Tail:
             seconds - Number of seconds to wait between each iteration; Defaults to 1.
         """
 
-        self.check_file_validity(self.tailed_file)
+        try:
+            self.check_file_validity(self.tailed_file)
+        except Exception as e:
+            if self.is_cancelled:
+                return
+            else:
+                raise e
         with open(self.tailed_file, encoding="utf-8", errors="replace") as file_:
             # Don't seek, since we want to print the entire file here.
             while True:

--- a/cluster_tools/cluster_tools/_utils/tailf.py
+++ b/cluster_tools/cluster_tools/_utils/tailf.py
@@ -33,13 +33,15 @@ class Tail:
             seconds - Number of seconds to wait between each iteration; Defaults to 1.
         """
 
+        if self.is_cancelled:
+            return
+
         try:
             self.check_file_validity(self.tailed_file)
-        except Exception as e:
+        except TailError:
             if self.is_cancelled:
                 return
-            else:
-                raise e
+            raise
         with open(self.tailed_file, encoding="utf-8", errors="replace") as file_:
             # Don't seek, since we want to print the entire file here.
             while True:

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -27,7 +27,7 @@ from cluster_tools._utils.reflection import (
     get_function_name,
 )
 from cluster_tools._utils.string_ import random_string, with_preliminary_postfix
-from cluster_tools._utils.tailf import Tail
+from cluster_tools._utils.tailf import Tail, TailError
 from cluster_tools._utils.warning import enrich_future_with_uncaught_warning
 from cluster_tools.executors.multiprocessing_ import CFutDict
 
@@ -780,9 +780,20 @@ class ClusterExecutor(futures.Executor):
         while not (os.path.exists(log_path) or tailer.is_cancelled):
             time.sleep(2)
 
-        # Log the output of the log file until future is resolved
-        # by the done_callback we attached earlier.
-        tailer.follow(2)
+        if not tailer.is_cancelled:
+            # Log the output of the log file until future is resolved
+            # by the done_callback we attached earlier.
+            tailer.follow(2)
+        else:
+            # If the future is already done we still try to read + print any remaining log lines
+            # if this fails (e.g. log file does for some reason not existing, log file not yet visible from the current node due to slow NFS)
+            # we log this.
+            try:
+                tailer.follow(2)
+            except TailError as error:
+                maybe_missing_logs_message = f"Could not read all logs for finished job with id {fut.cluster_jobid}. Some log lines might have been lost. Error was: {error}"  # type: ignore[attr-defined]
+                sys.stderr.write(maybe_missing_logs_message)
+                sys.stdout.write(maybe_missing_logs_message)
         return fut.result()
 
     @abstractmethod

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -1,5 +1,6 @@
 import atexit
 import logging
+import math
 import os
 import signal
 import sys
@@ -37,6 +38,9 @@ NOT_YET_SUBMITTED_STATE: NOT_YET_SUBMITTED_STATE_TYPE = "NOT_YET_SUBMITTED"
 _T = TypeVar("_T")
 _P = ParamSpec("_P")
 _S = TypeVar("_S")
+
+LOG_FILE_POLLING_INTERVAL_SECONDS = 2
+MAX_LOG_FILE_POLLING_TIME_SECONDS = 120
 
 
 def join_messages(strings: list[str]) -> str:
@@ -776,21 +780,27 @@ class ClusterExecutor(futures.Executor):
         tailer = Tail(log_path, log_callback)
         fut.add_done_callback(lambda _: tailer.cancel())
 
-        # Poll until the log file exists
-        while not (os.path.exists(log_path) or tailer.is_cancelled):
-            time.sleep(2)
+        # Wait until the log file exists or the job is completed/cancelled
+        log_file_exists = False
+        while not (
+            (log_file_exists := os.path.exists(log_path)) or tailer.is_cancelled
+        ):
+            time.sleep(LOG_FILE_POLLING_INTERVAL_SECONDS)
 
-        # If the future is already done (tailer.is_cancelled==True) we still try to read + print any remaining log lines.
-        # However, we allow certain errors e.g. if a job is done/cancelled but no log file exists, we just continue with a warning.
-        try:
-            tailer.follow(2)
-        except TailError as error:
-            if tailer.is_cancelled:
-                maybe_missing_logs_message = f"Could not read all logs for finished job with id {fut.cluster_jobid}. Some log lines might have been lost. Error was: {error}\n"  # type: ignore[attr-defined]
-                sys.stderr.write(maybe_missing_logs_message)
-                sys.stdout.write(maybe_missing_logs_message)
-            else:
-                raise
+        # The job might be done/cancelled but the log file might still not exist (e.g. slow/inconsistent NFS)
+        # In this case, we keep polling but with an upper limit to not run into a deadlock.
+        retries = 0
+        max_retries = math.ceil(
+            MAX_LOG_FILE_POLLING_TIME_SECONDS / LOG_FILE_POLLING_INTERVAL_SECONDS
+        )
+        while not log_file_exists and retries < max_retries:
+            log_file_exists = os.path.exists(log_path)
+            retries += 1
+            time.sleep(LOG_FILE_POLLING_INTERVAL_SECONDS)
+            sys.stdout.write(
+                f"Job with id {fut.cluster_jobid} is finished but log file couldn't be found at {log_path}. Retrying {retries}/{max_retries}"  # type: ignore[attr-defined]
+            )
+        tailer.follow(LOG_FILE_POLLING_INTERVAL_SECONDS)
         return fut.result()
 
     @abstractmethod

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -780,9 +780,8 @@ class ClusterExecutor(futures.Executor):
         while not (os.path.exists(log_path) or tailer.is_cancelled):
             time.sleep(2)
 
-        # If the future is already done we still try to read + print any remaining log lines.
-        # If this fails (e.g. log file not yet visible from the current node due to slow NFS)
-        # and the job has already completed, we log a warning. Otherwise we re-raise.
+        # If the future is already done (tailer.is_cancelled==True) we still try to read + print any remaining log lines.
+        # However, we allow certain errors e.g. if a job is done/cancelled but no log file exists, we just continue with a warning.
         try:
             tailer.follow(2)
         except TailError as error:

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -780,20 +780,18 @@ class ClusterExecutor(futures.Executor):
         while not (os.path.exists(log_path) or tailer.is_cancelled):
             time.sleep(2)
 
-        if not tailer.is_cancelled:
-            # Log the output of the log file until future is resolved
-            # by the done_callback we attached earlier.
+        # If the future is already done we still try to read + print any remaining log lines.
+        # If this fails (e.g. log file not yet visible from the current node due to slow NFS)
+        # and the job has already completed, we log a warning. Otherwise we re-raise.
+        try:
             tailer.follow(2)
-        else:
-            # If the future is already done we still try to read + print any remaining log lines
-            # if this fails (e.g. log file does for some reason not existing, log file not yet visible from the current node due to slow NFS)
-            # we log this.
-            try:
-                tailer.follow(2)
-            except TailError as error:
-                maybe_missing_logs_message = f"Could not read all logs for finished job with id {fut.cluster_jobid}. Some log lines might have been lost. Error was: {error}"  # type: ignore[attr-defined]
+        except TailError as error:
+            if tailer.is_cancelled:
+                maybe_missing_logs_message = f"Could not read all logs for finished job with id {fut.cluster_jobid}. Some log lines might have been lost. Error was: {error}\n"  # type: ignore[attr-defined]
                 sys.stderr.write(maybe_missing_logs_message)
                 sys.stdout.write(maybe_missing_logs_message)
+            else:
+                raise
         return fut.result()
 
     @abstractmethod

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -40,7 +40,7 @@ _P = ParamSpec("_P")
 _S = TypeVar("_S")
 
 LOG_FILE_POLLING_INTERVAL_SECONDS = 2
-MAX_LOG_FILE_POLLING_TIME_SECONDS = 120
+MAX_LOG_FILE_POLLING_DURATION_SECONDS = 120
 
 
 def join_messages(strings: list[str]) -> str:
@@ -791,7 +791,7 @@ class ClusterExecutor(futures.Executor):
         # In this case, we keep polling but with an upper limit to not run into a deadlock.
         retries = 0
         max_retries = math.ceil(
-            MAX_LOG_FILE_POLLING_TIME_SECONDS / LOG_FILE_POLLING_INTERVAL_SECONDS
+            MAX_LOG_FILE_POLLING_DURATION_SECONDS / LOG_FILE_POLLING_INTERVAL_SECONDS
         )
         while not log_file_exists and retries < max_retries:
             log_file_exists = os.path.exists(log_path)

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -28,7 +28,7 @@ from cluster_tools._utils.reflection import (
     get_function_name,
 )
 from cluster_tools._utils.string_ import random_string, with_preliminary_postfix
-from cluster_tools._utils.tailf import Tail, TailError
+from cluster_tools._utils.tailf import Tail
 from cluster_tools._utils.warning import enrich_future_with_uncaught_warning
 from cluster_tools.executors.multiprocessing_ import CFutDict
 

--- a/cluster_tools/cluster_tools/schedulers/cluster_executor.py
+++ b/cluster_tools/cluster_tools/schedulers/cluster_executor.py
@@ -796,10 +796,10 @@ class ClusterExecutor(futures.Executor):
         while not log_file_exists and retries < max_retries:
             log_file_exists = os.path.exists(log_path)
             retries += 1
-            time.sleep(LOG_FILE_POLLING_INTERVAL_SECONDS)
             sys.stdout.write(
                 f"Job with id {fut.cluster_jobid} is finished but log file couldn't be found at {log_path}. Retrying {retries}/{max_retries}"  # type: ignore[attr-defined]
             )
+            time.sleep(LOG_FILE_POLLING_INTERVAL_SECONDS)
         tailer.follow(LOG_FILE_POLLING_INTERVAL_SECONDS)
         return fut.result()
 


### PR DESCRIPTION
### Description:
- calling .follow() on a already cancelled Tail object can lead to errors if the log file does not exist (e.g. on a slow NFS the current node might not immediately see a file written  from another node)
- Instead of failing, we just print a warning now
- Might loose some logs when a job is canceled before its log file is detected but might be better than failing, and assuring full logs might be hard with the current implementation + inconsistent NFS.

### Todos:
 - [x] Updated Changelog
