### PR TITLE
adds fix for virtual ImageJ stacks

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed a conversion issue with Tiff files produced by ImageJ virtual stacks. [#1481](https://github.com/scalableminds/webknossos-libs/pull/1481)
 
 
 ## [3.5.2](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.2) - 2026-06-18

--- a/webknossos/tests/dataset/test_from_images.py
+++ b/webknossos/tests/dataset/test_from_images.py
@@ -74,6 +74,44 @@ def test_ZCYX_tiff(tmp_upath: UPath) -> None:
     assert ds.get_color_layers()[0].bounding_box.size == Vec3Int(x=6, y=7, z=5)
 
 
+def test_imagej_virtual_stack_tiff(tmp_upath: UPath) -> None:
+    # ImageJ virtual stacks store all frames contiguously after a single IFD
+    # (series.is_truncated=True). series.pages only exposes that 1 IFD, so
+    # reading any frame beyond index 0 used to raise IndexError.
+    Z, Y, X = 8, 16, 12
+    data = np.arange(Z * Y * X, dtype="uint16").reshape(Z, Y, X)
+    tif_path = tmp_upath / "test_virtual_stack.tif"
+    imwrite(str(tif_path), data, imagej=True, truncate=True, metadata={"axes": "ZYX"})
+
+    t = TiffFile(str(tif_path))
+    assert t.series[0].is_truncated, (
+        "expected an ImageJ virtual stack (truncated series)"
+    )
+    assert len(t.pages) == 1, "expected exactly 1 real IFD"
+    assert t.series[0].shape == (Z, Y, X)
+
+    reader = PimsTiffReader(tif_path)
+    reader.bundle_axes = ["y", "x"]
+    reader.iter_axes = ["z"]
+
+    assert reader.shape == (Z, Y, X)
+    assert reader.frame_shape == (Y, X)
+
+    for z in range(Z):
+        np.testing.assert_array_equal(np.array(reader[z]), data[z])
+
+    with SequentialExecutor() as executor:
+        ds = Dataset.from_images(
+            tif_path,
+            tmp_upath / "ds",
+            (1, 1, 1),
+            executor=executor,
+        )
+    assert ds.get_color_layers()[0].bounding_box.size == Vec3Int(x=X, y=Y, z=Z)
+    result = ds.get_color_layers()[0].get_finest_mag().read()[0]
+    np.testing.assert_array_equal(result, data.transpose(2, 1, 0))
+
+
 def test_tiled_CZYX_tiff(tmp_upath: UPath) -> None:
     import tifffile as tifffile_module
 

--- a/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
@@ -51,6 +51,11 @@ class PimsTiffReader(FramesSequenceND):
                 axis for axis in self._tiff_axes if axis not in self._other_axes
             )
 
+            # ImageJ virtual stacks store all frames contiguously after a single IFD
+            # (series.is_truncated). In that case series.pages only exposes 1 real
+            # page and we must seek by computed byte offsets instead.
+            self._series_is_truncated = _tiff.is_truncated
+
             if "c" in self._tiff_axes:
                 self._register_get_frame(self.get_frame_2D, "cyx")
             else:
@@ -74,7 +79,18 @@ class PimsTiffReader(FramesSequenceND):
         ]
 
         with self.path.open("rb") as f:
-            pages = tifffile.TiffFile(f).series[0].pages
+            tiff = tifffile.TiffFile(f)
+            series = tiff.series[0]
+
+            # ImageJ virtual stacks (series.is_truncated=True) have only 1 real IFD
+            # but store all frames contiguously at series.dataoffset. Reading them
+            # via series.pages[i] fails for i > 0; use direct byte seeks instead.
+            use_direct_seek = series.is_truncated and series.dataoffset is not None
+            if use_direct_seek:
+                frame_bytes = int(np.prod(self._shape)) * self._dtype.itemsize
+                raw_dtype = np.dtype(tiff.byteorder + self._dtype.str[1:])
+            else:
+                pages = series.pages
 
             for bundled_page_coords in (
                 product(*[range(self.sizes[axis]) for axis in bundled_page_axes])
@@ -96,9 +112,19 @@ class PimsTiffReader(FramesSequenceND):
                     else 0
                 )
 
-                page = pages[page_idx]
-                assert page is not None, f"Page {page_idx} not found in TIFF file."
-                page_data = page.asarray()
+                if use_direct_seek:
+                    assert series.dataoffset is not None
+                    f.seek(series.dataoffset + page_idx * frame_bytes)
+                    raw = f.read(frame_bytes)
+                    page_data: np.ndarray = (
+                        np.frombuffer(raw, dtype=raw_dtype)
+                        .reshape(self._shape)
+                        .astype(self._dtype)
+                    )
+                else:
+                    page = pages[page_idx]
+                    assert page is not None, f"Page {page_idx} not found in TIFF file."
+                    page_data = page.asarray()
 
                 # Index away page axes that are not part of bundle_axes (e.g. S in ZCYXS)
                 if extra_page_axes:

--- a/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
@@ -116,6 +116,11 @@ class PimsTiffReader(FramesSequenceND):
                     assert series.dataoffset is not None
                     f.seek(series.dataoffset + page_idx * frame_bytes)
                     raw = f.read(frame_bytes)
+                    if len(raw) < frame_bytes:
+                        raise OSError(
+                            f"Premature end of file while reading frame {page_idx}. "
+                            f"Expected {frame_bytes} bytes, got {len(raw)}."
+                        )
                     page_data: np.ndarray = (
                         np.frombuffer(raw, dtype=raw_dtype)
                         .reshape(self._shape)

--- a/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
@@ -122,8 +122,12 @@ class PimsTiffReader(FramesSequenceND):
                         .astype(self._dtype)
                     )
                 else:
-                    page = pages[page_idx]
-                    assert page is not None, f"Page {page_idx} not found in TIFF file."
+                    try:
+                        page = pages[page_idx]
+                    except IndexError:
+                        raise ValueError(f"Page {page_idx} not found in TIFF file.")
+                    if page is None:
+                        raise ValueError(f"Page {page_idx} not found in TIFF file.")
                     page_data = page.asarray()
 
                 # Index away page axes that are not part of bundle_axes (e.g. S in ZCYXS)

--- a/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
@@ -51,11 +51,6 @@ class PimsTiffReader(FramesSequenceND):
                 axis for axis in self._tiff_axes if axis not in self._other_axes
             )
 
-            # ImageJ virtual stacks store all frames contiguously after a single IFD
-            # (series.is_truncated). In that case series.pages only exposes 1 real
-            # page and we must seek by computed byte offsets instead.
-            self._series_is_truncated = _tiff.is_truncated
-
             if "c" in self._tiff_axes:
                 self._register_get_frame(self.get_frame_2D, "cyx")
             else:

--- a/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
+++ b/webknossos/webknossos/dataset/_utils/pims_tiff_reader.py
@@ -77,7 +77,7 @@ class PimsTiffReader(FramesSequenceND):
             tiff = tifffile.TiffFile(f)
             series = tiff.series[0]
 
-            # ImageJ virtual stacks (series.is_truncated=True) have only 1 real IFD
+            # truncated tiff series (for example ImageJ virtual stacks) have only 1 real IFD
             # but store all frames contiguously at series.dataoffset. Reading them
             # via series.pages[i] fails for i > 0; use direct byte seeks instead.
             use_direct_seek = series.is_truncated and series.dataoffset is not None


### PR DESCRIPTION
### Description:
- Fixed a conversion issue with Tiff files produced by ImageJ virtual stacks.

### Issues:
- `uv run webknossos convert data/imagej_virtual_stack data/test --jobs 2 --voxel-size 3,3,3 --no-downsample`

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests