### PR TITLE
Fix SlurmExecutor srun jobs failing on some Slurm >=22.05 clusters due to missing resource inheritance

### DIFF
--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automaticall leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
+- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automatically, leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Pass the configured `job_resources` that Slurm's `srun` does not automatically inherit from the enclosing `sbatch` job (e.g. `cpus-per-task`, `gpus`) also to the `srun` call within the generated `sbatch` script, since Slurm versions >=22.05 no longer inherit these settings automatically, leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
+- Pass the configured `job_resources` that Slurm's `srun` does not automatically inherit from the enclosing `sbatch` job (e.g. `cpus-per-task`, `gpus`) also to the `srun` call within the generated `sbatch` script, since Slurm versions >=22.05 no longer inherit these settings automatically, leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables...` on some clusters. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automaticall leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`.
+- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automaticall leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
-- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automatically, leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
+- Pass the configured `job_resources` that Slurm's `srun` does not automatically inherit from the enclosing `sbatch` job (e.g. `cpus-per-task`, `gpus`) also to the `srun` call within the generated `sbatch` script, since Slurm versions >=22.05 no longer inherit these settings automatically, leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24

--- a/cluster_tools/Changelog.md
+++ b/cluster_tools/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective *Breaking Changes* section
 ### Changed
 
 ### Fixed
+- Pass configured `job_resources` (e.g. `cpus-per-task`, `mem`) also to the `srun` call within the generated `sbatch` script, since recent Slurm versions do not inherit `#SBATCH` resource settings into `srun` automaticall leading to `SlurmExecutor` jobs failing with errors such as `srun: fatal: cpus-per-task set by two different environment variables`.
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -54,6 +54,22 @@ SLURM_STATES = {
     "Unclear": ["SUSPENDED", "REVOKED", "SIGNALING", "SPECIAL_EXIT", "STAGE_OUT"],
 }
 
+# Since Slurm 22.05, some resource flags are not automatically inherited from the
+# enclosing sbatch job by srun calls within the script anymore and must be restated
+# explicitly, or srun computes its own (potentially conflicting) resource request
+# leading to failures like:
+# "srun: fatal: cpus-per-task set by two different environment variables ..."
+# Other job_resources (e.g. --mem, --gres) should be inherited by srun automatically.
+# Therefore, we currently do not add them to the srun call
+SLURM_SRUN_NON_INHERITED_RESOURCE_KEYS = {
+    "cpus-per-task",
+    "ntasks",
+    "gpus",
+    "gpus-per-node",
+    "gpus-per-socket",
+    "gpus-per-task",
+}
+
 SLURM_QUEUE_CHECK_INTERVAL = 1 if "pytest" in sys.modules else 60
 
 T = TypeVar("T")
@@ -307,11 +323,8 @@ class SlurmExecutor(ClusterExecutor):
         if self.job_resources is not None:
             for resource, value in self.job_resources.items():
                 job_resources_lines += [f"#SBATCH --{resource}={value}"]
-                srun_resource_args += [f"--{resource}={value}"]
-        # Resources requested via #SBATCH (e.g. --cpus-per-task) are not
-        # automatically inherited by srun calls within the script anymore and need to be
-        # restated explicitly. Otherwise, srun computes its own (potentially conflicting)
-        # resource request, which can lead to errors.
+                if resource in SLURM_SRUN_NON_INHERITED_RESOURCE_KEYS:
+                    srun_resource_args += [f"--{resource}={value}"]
         srun_resource_args_str = (
             " " + " ".join(srun_resource_args) if srun_resource_args else ""
         )

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -303,9 +303,18 @@ class SlurmExecutor(ClusterExecutor):
         log_path = self.format_log_file_path(self.cfut_dir, job_id_string)
 
         job_resources_lines = []
+        srun_resource_args = []
         if self.job_resources is not None:
             for resource, value in self.job_resources.items():
                 job_resources_lines += [f"#SBATCH --{resource}={value}"]
+                srun_resource_args += [f"--{resource}={value}"]
+        # Resources requested via #SBATCH (e.g. --cpus-per-task) are not
+        # automatically inherited by srun calls within the script anymore and need to be
+        # restated explicitly. Otherwise, srun computes its own (potentially conflicting)
+        # resource request, which can lead to errors.
+        srun_resource_args_str = (
+            " " + " ".join(srun_resource_args) if srun_resource_args else ""
+        )
 
         max_array_size = self.get_max_array_size()
         max_submit_jobs = self.get_max_submit_jobs()
@@ -340,7 +349,7 @@ class SlurmExecutor(ClusterExecutor):
                 + job_resources_lines
                 + [
                     *additional_setup_lines,
-                    f"srun {cmdline} {job_index_start}",
+                    f"srun{srun_resource_args_str} {cmdline} {job_index_start}",
                 ]
             )
 

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -60,7 +60,8 @@ SLURM_STATES = {
 # leading to failures like:
 # "srun: fatal: cpus-per-task set by two different environment variables ..."
 # Other job_resources (e.g. --mem, --gres) should be inherited by srun automatically.
-# Therefore, we currently explicitely restate only the potentially non-inherited resource but for the srun call.
+# Therefore, we currently explicitely restate potentially non-inherited resource for the srun call.
+# This is most relevant for cpus-per-task, but we have added some others to be on the safe side.
 # It is worth noting that this change was quite disruptive, particularly for MPI implementations.
 # Because of this, in Slurm 23.11, this requirement was largely walked back.
 # SRUN_CPUS_PER_TASK war reverted back to SLURM_CPUS_PER_TASK and an --external-launcher option was introduced to srun

--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -60,7 +60,11 @@ SLURM_STATES = {
 # leading to failures like:
 # "srun: fatal: cpus-per-task set by two different environment variables ..."
 # Other job_resources (e.g. --mem, --gres) should be inherited by srun automatically.
-# Therefore, we currently do not add them to the srun call
+# Therefore, we currently explicitely restate only the potentially non-inherited resource but for the srun call.
+# It is worth noting that this change was quite disruptive, particularly for MPI implementations.
+# Because of this, in Slurm 23.11, this requirement was largely walked back.
+# SRUN_CPUS_PER_TASK war reverted back to SLURM_CPUS_PER_TASK and an --external-launcher option was introduced to srun
+# to prevent task launchers from being bound to a single CPU.
 SLURM_SRUN_NON_INHERITED_RESOURCE_KEYS = {
     "cpus-per-task",
     "ntasks",


### PR DESCRIPTION
## Summary
- Since Slurm 22.05, resources requested via `#SBATCH` (e.g. `--cpus-per-task`) are no longer automatically inherited by `srun` calls inside the sbatch script, which can cause jobs to fail with errors such as `srun: fatal: cpus-per-task set by two different environment variables SLURM_CPUS_PER_TASK=3 != SLURM_TRES_PER_TASK=cpu=1` (probably due to some cluster-defined default which do not match the --cpus-per-task specified for the sbatch)
- `SlurmExecutor.inner_submit` now also passes some configured `job_resources` (e.g. `cpus-per-task`) as explicit flags to the `srun` call, in addition to the existing `#SBATCH` lines.

## Test plan (as executed by Claude)
- [x] Reproduced the bug against a live Slurm 25.05.1 cluster (via `cluster_tools/dockered-slurm`): confirmed the generated script previously emitted a bare `srun ...` line with no resource flags.
- [x] Verified the fix: the generated script now emits `srun --cpus-per-task=1 ...`, restating the resource explicitly.
- [x] Ran a real job submission end-to-end with `job_resources={"cpus-per-task": "1"}` — succeeds.
- [x] Ran the full CI slurm test suite (`test_all.py`, `test_slurm.py`) against the fix: 30 passed, 2 skipped (expected/flaky-long-running), 2 deselected (require modified slurm config).
- [x] `ruff check` and `mypy` pass on the changed file.
- [x] Added a `Changelog.md` entry under `Unreleased > Fixed`.