### PR TITLE
add delete method to remote ds

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 
 ### Changed
 

--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -526,6 +526,19 @@ def test_upload_twice(tmp_upath: UPath) -> None:
     assert remote1.name == remote2.name
 
 
+def test_delete_remote_dataset(tmp_upath: UPath) -> None:
+    ds_original = get_sample_dataset(tmp_upath)
+    remote_ds = ds_original.upload(new_dataset_name="test_delete_remote_dataset")
+    dataset_id = remote_ds.dataset_id
+
+    remote_ds.delete()
+
+    assert remote_ds.read_only
+    with pytest.raises(RuntimeError):
+        remote_ds.description = "should fail"
+    assert dataset_id not in RemoteDataset.list()
+
+
 def test_remote_dataset_add_layer_as_ref_rejects_local_layer(
     tmp_upath: UPath,
 ) -> None:

--- a/webknossos/webknossos/client/api_client/wk_api_client.py
+++ b/webknossos/webknossos/client/api_client/wk_api_client.py
@@ -175,6 +175,10 @@ class WkApiClient(AbstractApiClient):
         route = "/datasets/exploreAndAddRemote"
         return self._post_json_with_json_response(route, dataset, str)
 
+    def dataset_delete(self, *, dataset_id: str) -> None:
+        route = f"/datasets/{dataset_id}"
+        self._delete(route)
+
     def annotation_list(self, *, is_finished: bool | None) -> list[ApiAnnotation]:
         route = "/annotations/readable"
         return self._get_json(

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1147,6 +1147,15 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         self._save_dataset_properties()
         return self.layers[layer_name]
 
+    def delete(self) -> None:
+        """Deletes the dataset from the WEBKNOSSOS server. This action is irreversible."""
+        from ..client.context import _get_api_client
+
+        self._ensure_writable()
+        with self._context:
+            client = _get_api_client()
+            client.dataset_delete(dataset_id=self.dataset_id)
+
     @classmethod
     def list(
         cls,

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1148,13 +1148,22 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         return self.layers[layer_name]
 
     def delete(self) -> None:
-        """Deletes the dataset from the WEBKNOSSOS server. This action is irreversible."""
+        """Deletes the dataset from the WEBKNOSSOS server. This action is irreversible.
+
+        Raises:
+            RuntimeError: If dataset is read-only, or if this instance was opened as
+                an annotation view of another dataset.
+        """
         from ..client.context import _get_api_client
 
         self._ensure_writable()
+        if self.annotation_id is not None:
+            raise RuntimeError("Cannot delete a dataset from an annotation view.")
+
         with self._context:
             client = _get_api_client()
             client.dataset_delete(dataset_id=self.dataset_id)
+        self._read_only = True
 
     @classmethod
     def list(

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1148,7 +1148,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         return self.layers[layer_name]
 
     def delete(self) -> None:
-        """Deletes the dataset from the WEBKNOSSOS server. This action is irreversible.
+        """Deletes the dataset from the WEBKNOSSOS server. Use with caution: This action is irreversible.
 
         Raises:
             RuntimeError: If dataset is read-only, or if this instance was opened as


### PR DESCRIPTION
### Description:
- adds a `dataset_delete` method to the WkApiClient which can then be used to delete remote ds

### Issues:
- fixes #1453 

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests