### PR TITLE
Adapt test setup to new webknossos config format

### DIFF
--- a/webknossos/tests/docker-compose.yml
+++ b/webknossos/tests/docker-compose.yml
@@ -14,7 +14,9 @@ services:
       - -Dtracingstore.redis.address=redis
       - -Ddatastore.redis.address=redis
       - -Dslick.db.url=jdbc:postgresql://postgres/webknossos
-      - -Ddatastore.baseDirectory=${BINARY_DATA_DIR}
+      - -Ddatastore.baseDirectories.0.path=${BINARY_DATA_DIR}
+      - -Ddatastore.baseDirectories.0.allowsUpload=true
+      - -Ddatastore.baseDirectories.0.doScan=true
     volumes:
       - ${BINARY_DATA_DIR}:${BINARY_DATA_DIR}
     environment:


### PR DESCRIPTION
### Description:
- The libs tests start a webknossos docker container. The config format changed in https://github.com/scalableminds/webknossos/pull/9663 and this PR adapts the libs tests to use this new config format.

### Todos:
 - [x] Added / Updated Tests
