### PR TITLE
Slrum Scheduling: Always Use `--ntasks=1`

### DIFF
--- a/cluster_tools/cluster_tools/schedulers/slurm.py
+++ b/cluster_tools/cluster_tools/schedulers/slurm.py
@@ -68,7 +68,6 @@ SLURM_STATES = {
 # to prevent task launchers from being bound to a single CPU.
 SLURM_SRUN_NON_INHERITED_RESOURCE_KEYS = {
     "cpus-per-task",
-    "ntasks",
     "gpus",
     "gpus-per-node",
     "gpus-per-socket",
@@ -367,7 +366,7 @@ class SlurmExecutor(ClusterExecutor):
                 + job_resources_lines
                 + [
                     *additional_setup_lines,
-                    f"srun{srun_resource_args_str} {cmdline} {job_index_start}",
+                    f"srun{srun_resource_args_str} --ntasks=1 {cmdline} {job_index_start}",
                 ]
             )
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,10 +19,14 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fix SlurmExecutor on certain slurm clusters: explicitly state `--ntasks=1` in srun calls. [#1487](https://github.com/scalableminds/webknossos-libs/pull/1487)
 
 
 ## [3.5.4](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.4) - 2026-07-08
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v3.5.3...v3.5.4)
+
+### Fixed
+- Fix SlurmExecutor on certain slurm clusters: explicitly repeat srun options that might not be inherited from sbatch. [#1483](https://github.com/scalableminds/webknossos-libs/pull/1483)
 
 
 ## [3.5.3](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.5.3) - 2026-06-24


### PR DESCRIPTION
### Description:
- some cluster configuration might lead to multiple parallel tasks being started for one SlurmExecutor execution unit leading to unwanted effects (e.g. same file accessed in parallel)
- always adding `--ntasks=1` to the generated srun commands prevents this

### Todos:
 - [x] Updated Changelog
