### PR TITLE
Allow supplying credentials in RemoteDataset.explore_and_add_remote

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- `RemoteDataset.explore_and_add_remote` can now take optional remote storage credentials. [#1488](https://github.com/scalableminds/webknossos-libs/pull/1488)
 
 ### Changed
 

--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -132,6 +132,8 @@ class ApiDatasetExploreAndAddRemote:
     dataset_name: str
     folder_id: str | None = None
     data_store_name: str | None = None
+    credential_identifier: str | None = None
+    credential_secret: str | None = None
 
 
 @attr.s(auto_attribs=True)

--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -133,7 +133,7 @@ class ApiDatasetExploreAndAddRemote:
     folder_id: str | None = None
     data_store_name: str | None = None
     credential_identifier: str | None = None
-    credential_secret: str | None = None
+    credential_secret: str | None = attr.ib(default=None, repr=False)
 
 
 @attr.s(auto_attribs=True)

--- a/webknossos/webknossos/dataset/__init__.py
+++ b/webknossos/webknossos/dataset/__init__.py
@@ -25,7 +25,7 @@ from .layer import (
     SegmentIndexAttachment,
     View,
 )
-from .remote_dataset import StorageCredentials, RemoteAccessMode, RemoteDataset
+from .remote_dataset import RemoteAccessMode, RemoteDataset, StorageCredentials
 from .remote_folder import RemoteFolder
 from .sampling_modes import SamplingModes
 from .transfer_mode import TransferMode

--- a/webknossos/webknossos/dataset/__init__.py
+++ b/webknossos/webknossos/dataset/__init__.py
@@ -25,7 +25,7 @@ from .layer import (
     SegmentIndexAttachment,
     View,
 )
-from .remote_dataset import ExploreCredentials, RemoteAccessMode, RemoteDataset
+from .remote_dataset import StorageCredentials, RemoteAccessMode, RemoteDataset
 from .remote_folder import RemoteFolder
 from .sampling_modes import SamplingModes
 from .transfer_mode import TransferMode

--- a/webknossos/webknossos/dataset/__init__.py
+++ b/webknossos/webknossos/dataset/__init__.py
@@ -25,7 +25,7 @@ from .layer import (
     SegmentIndexAttachment,
     View,
 )
-from .remote_dataset import RemoteAccessMode, RemoteDataset
+from .remote_dataset import ExploreCredentials, RemoteAccessMode, RemoteDataset
 from .remote_folder import RemoteFolder
 from .sampling_modes import SamplingModes
 from .transfer_mode import TransferMode

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1487,7 +1487,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
 
         client = _get_api_client()
         dataset = ApiDatasetExploreAndAddRemote(
-            remote_uri=dataset_uri,
+            remote_uri=str(dataset_uri),
             dataset_name=dataset_name,
             folder_id=None if folder_obj is None else folder_obj.id,
             data_store_name=None,

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -82,6 +82,16 @@ def _assert_same_webknossos_instance(
         )
 
 
+@attr.frozen
+class ExploreCredentials:
+    """Credentials for accessing remote storage when exploring and adding a dataset."""
+
+    credential_identifier: str
+    """Remote storage credential identifier (e.g. aws access key id)."""
+    credential_secret: str
+    """Remote storage credential secret (e.g. aws secret access key)."""
+
+
 class RemoteAccessMode(Enum):
     """Determines how data of a remote dataset is accessed. Note that DIRECT_PATH can only be used if the client has access to the underlying storage."""
 
@@ -1430,8 +1440,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         *,
         folder: str | RemoteFolder | None = None,
         folder_path: str | None = None,
-        credential_identifier: str | None = None,
-        credential_secret: str | None = None,
+        credentials: ExploreCredentials | None = None,
     ) -> "RemoteDataset":
         """Explore and add an external dataset as a remote dataset.
 
@@ -1443,8 +1452,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
             dataset_name: Name to register dataset under in WEBKNOSSOS
             folder: Path in WEBKNOSSOS folder structure where dataset should appear
             folder_path: Deprecated, use folder instead.
-            credential_identifier: remote storage credential identifier (e.g. aws access key id)
-            credential_secret: remote storage credential secret (e.g. aws secret access key)
+            credentials: Credentials for accessing remote storage
 
         Returns:
             RemoteDataset: The newly added dataset accessible via WEBKNOSSOS
@@ -1479,12 +1487,16 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
 
         client = _get_api_client()
         dataset = ApiDatasetExploreAndAddRemote(
-            remote_uri=UPath(dataset_uri).resolve().as_uri(),
+            remote_uri=dataset_uri,
             dataset_name=dataset_name,
             folder_id=None if folder_obj is None else folder_obj.id,
             data_store_name=None,
-            credential_identifier=credential_identifier,
-            credential_secret=credential_secret,
+            credential_identifier=(
+                None if credentials is None else credentials.credential_identifier
+            ),
+            credential_secret=(
+                None if credentials is None else credentials.credential_secret
+            ),
         )
         dataset_id = client.dataset_explore_and_add_remote(dataset=dataset)
 

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -83,7 +83,7 @@ def _assert_same_webknossos_instance(
 
 
 @attr.frozen
-class ExploreCredentials:
+class StorageCredentials:
     """Credentials for accessing remote storage when exploring and adding a dataset."""
 
     credential_identifier: str
@@ -1440,7 +1440,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         *,
         folder: str | RemoteFolder | None = None,
         folder_path: str | None = None,
-        credentials: ExploreCredentials | None = None,
+        credentials: StorageCredentials | None = None,
     ) -> "RemoteDataset":
         """Explore and add an external dataset as a remote dataset.
 

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1430,6 +1430,8 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         *,
         folder: str | RemoteFolder | None = None,
         folder_path: str | None = None,
+        credential_identifier: str | None = None,
+        credential_secret: str | None = None,
     ) -> "RemoteDataset":
         """Explore and add an external dataset as a remote dataset.
 
@@ -1441,6 +1443,8 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
             dataset_name: Name to register dataset under in WEBKNOSSOS
             folder: Path in WEBKNOSSOS folder structure where dataset should appear
             folder_path: Deprecated, use folder instead.
+            credential_identifier: remote storage credential identifier (e.g. aws access key id)
+            credential_secret: remote storage credential secret (e.g. aws secret access key)
 
         Returns:
             RemoteDataset: The newly added dataset accessible via WEBKNOSSOS
@@ -1475,9 +1479,12 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
 
         client = _get_api_client()
         dataset = ApiDatasetExploreAndAddRemote(
-            UPath(dataset_uri).resolve().as_uri(),
-            dataset_name,
-            None if folder_obj is None else folder_obj.id,
+            remote_uri=UPath(dataset_uri).resolve().as_uri(),
+            dataset_name=dataset_name,
+            folder_id=None if folder_obj is None else folder_obj.id,
+            data_store_name=None,
+            credential_identifier=credential_identifier,
+            credential_secret=credential_secret,
         )
         dataset_id = client.dataset_explore_and_add_remote(dataset=dataset)
 


### PR DESCRIPTION
### Description:
- adds new optional String parameters `credential_identifier` and `credential_secret` to `RemoteDataset.explore_and_add_remote`
- Corresponding wk PR https://github.com/scalableminds/webknossos/pull/9749

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog