### PR TITLE
Faster BoundingBox Chunking Returning Topleft Chunk Corners as Integer Tuples

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,7 +18,6 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Added `NDBoundingBox.iter_chunk_starts` / `BoundingBox.iter_chunk_starts`, a fast, allocation-free variant of `chunk()` that yields the raw integer topleft coordinate of each chunk (no per-chunk `Vec3Int`/`BoundingBox` allocation). Also added `iter_overlapping_grid_cells`, which yields the toplefts of the origin-aligned grid cells that overlap the box (optionally clipped to another box). [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Changed
-- `BoundingBox.chunk` / `NDBoundingBox.chunk` now share their chunk-grid math with the new `iter_chunk_starts` iterator. Their output is unchanged. [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Fixed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added `NDBoundingBox.iter_chunk_starts` / `BoundingBox.iter_chunk_starts`, a fast, allocation-free variant of `chunk()` that yields the raw integer topleft coordinate of each chunk (no per-chunk `Vec3Int`/`BoundingBox` allocation). Also added `iter_overlapping_grid_cells`, which yields the toplefts of the origin-aligned grid cells that overlap the box (optionally clipped to another box). [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Changed
+- `BoundingBox.chunk` / `NDBoundingBox.chunk` are now implemented on top of the new `iter_chunk_starts` iterator so the chunk-grid math has a single source of truth. Their output is unchanged. [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Fixed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,6 +18,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Added `NDBoundingBox.iter_chunk_starts` / `BoundingBox.iter_chunk_starts`, a fast, allocation-free variant of `chunk()` that yields the raw integer topleft coordinate of each chunk (no per-chunk `Vec3Int`/`BoundingBox` allocation). Also added `iter_overlapping_grid_cells`, which yields the toplefts of the origin-aligned grid cells that overlap the box (optionally clipped to another box). [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Changed
+- `NDBoundingBox.chunk` (and the new chunk iterators) now accept a `VecInt` chunk shape with axis names, which is matched to the box's axes by name instead of by position. A shape of three unnamed entries is still the xyz shorthand, but it is now rejected with a `ValueError` for a box with exactly three axes that are not x, y and z (e.g. `("x", "y", "t")`), where it previously silently dropped the third entry and iterated the remaining axis one index at a time. [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Fixed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -18,7 +18,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 - Added `NDBoundingBox.iter_chunk_starts` / `BoundingBox.iter_chunk_starts`, a fast, allocation-free variant of `chunk()` that yields the raw integer topleft coordinate of each chunk (no per-chunk `Vec3Int`/`BoundingBox` allocation). Also added `iter_overlapping_grid_cells`, which yields the toplefts of the origin-aligned grid cells that overlap the box (optionally clipped to another box). [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Changed
-- `BoundingBox.chunk` / `NDBoundingBox.chunk` are now implemented on top of the new `iter_chunk_starts` iterator so the chunk-grid math has a single source of truth. Their output is unchanged. [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
+- `BoundingBox.chunk` / `NDBoundingBox.chunk` now share their chunk-grid math with the new `iter_chunk_starts` iterator. Their output is unchanged. [#1489](https://github.com/scalableminds/webknossos-libs/pull/1489)
 
 ### Fixed
 

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -368,30 +368,3 @@ def test_iter_overlapping_grid_cells_clip_to_axes_mismatch() -> None:
     )
     with pytest.raises(ValueError):
         list(bbox.iter_overlapping_grid_cells((4, 4, 4), clip_to=clip))
-
-
-@pytest.mark.parametrize(
-    "topleft, size, chunk_shape, alignment",
-    [
-        ((5, 7, 9), (50, 60, 70), (16, 8, 4), None),
-        ((-33, -1, -64), (50, 60, 70), (32, 32, 32), None),
-        ((-5, 3, -7), (33, 17, 64), (16, 8, 4), (8, 4, 2)),
-    ],
-)
-def test_iter_chunk_starts_matches_nd_implementation(
-    topleft: tuple[int, int, int],
-    size: tuple[int, int, int],
-    chunk_shape: tuple[int, int, int],
-    alignment: tuple[int, int, int] | None,
-) -> None:
-    """`BoundingBox` overrides the generic `NDBoundingBox` implementations with a
-    3D fast path – both must agree."""
-    bbox = BoundingBox(topleft, size)
-    nd_bbox = NDBoundingBox(topleft=topleft, size=size, axes=("x", "y", "z"))
-
-    assert list(bbox.iter_chunk_starts(chunk_shape, alignment)) == list(
-        nd_bbox.iter_chunk_starts(chunk_shape, alignment)
-    )
-    assert list(bbox.iter_overlapping_grid_cells(chunk_shape)) == list(
-        nd_bbox.iter_overlapping_grid_cells(chunk_shape)
-    )

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -199,48 +199,114 @@ def test_contains_bbox_with_normalized_bbox() -> None:
 
 
 @pytest.mark.parametrize(
-    "topleft, size, chunk_shape, alignment",
+    "topleft, size, chunk_shape, alignment, expected",
     [
-        ((0, 0, 0), (100, 100, 100), (32, 32, 32), None),
-        ((5, 7, 9), (50, 60, 70), (16, 16, 16), None),
-        ((7, 3, 1), (33, 33, 33), (10, 10, 10), None),
-        ((0, 0, 0), (100, 100, 100), (32, 32, 32), (16, 16, 16)),
-        ((-33, -1, -64), (50, 60, 70), (32, 32, 32), None),
-        ((-5, 3, -7), (33, 17, 64), (16, 8, 4), (8, 4, 2)),
-        ((5, 7, 9), (50, 60, 70), (32, 32, 32), (16, 16, 16)),
+        # Grid is aligned to the box topleft, ordered x-major, z-minor.
+        (
+            (0, 0, 0),
+            (20, 20, 20),
+            (16, 16, 16),
+            None,
+            [(x, y, z) for x in (0, 16) for y in (0, 16) for z in (0, 16)],
+        ),
+        # Unaligned topleft: starts are offset by the topleft, the last chunk of each
+        # axis sticks out of the box (starts are not clipped).
+        (
+            (5, 7, 9),
+            (20, 20, 20),
+            (16, 16, 16),
+            None,
+            [(x, y, z) for x in (5, 21) for y in (7, 23) for z in (9, 25)],
+        ),
+        # Chunk shape larger than the box -> exactly one chunk at the box topleft.
+        ((7, 3, 1), (5, 5, 5), (10, 10, 10), None, [(7, 3, 1)]),
+        # Negative coordinates.
+        (
+            (-33, -1, -64),
+            (40, 40, 40),
+            (32, 32, 32),
+            None,
+            [(x, y, z) for x in (-33, -1) for y in (-1, 31) for z in (-64, -32)],
+        ),
+        # With alignment the first start is moved back to the previous multiple of the
+        # alignment (topleft 10 -> 0 for alignment 16), so all borders between chunks
+        # are multiples of the alignment.
+        (
+            (10, 10, 10),
+            (60, 60, 60),
+            (32, 32, 32),
+            (16, 16, 16),
+            [(x, y, z) for x in (0, 32, 64) for y in (0, 32, 64) for z in (0, 32, 64)],
+        ),
+        # Per-axis alignment with negative coordinates: -5 % 8 == 3 -> -8,
+        # 3 % 4 == 3 -> 0, -7 % 2 == 1 -> -8.
+        (
+            (-5, 3, -7),
+            (20, 10, 10),
+            (16, 8, 4),
+            (8, 4, 2),
+            [(x, y, z) for x in (-8, 8) for y in (0, 8) for z in (-8, -4, 0)],
+        ),
     ],
 )
-def test_iter_chunk_starts_matches_chunk(
+def test_iter_chunk_starts(
     topleft: tuple[int, int, int],
     size: tuple[int, int, int],
     chunk_shape: tuple[int, int, int],
     alignment: tuple[int, int, int] | None,
+    expected: list[tuple[int, int, int]],
 ) -> None:
     bbox = BoundingBox(topleft, size)
     starts = list(bbox.iter_chunk_starts(chunk_shape, alignment))
 
+    assert starts == expected
     # Yielded values are plain python int tuples (no numpy scalars).
     assert all(type(v) is int for start in starts for v in start)
 
-    # Reconstructing chunk() by wrapping+clipping each start is identical to chunk().
-    reconstructed = [
-        BoundingBox(list(start), chunk_shape).intersected_with(bbox) for start in starts
+
+@pytest.mark.parametrize(
+    "topleft, size, chunk_shape, alignment, expected",
+    [
+        # Border chunks are clipped to the box.
+        (
+            (0, 0, 0),
+            (20, 20, 20),
+            (16, 16, 16),
+            None,
+            [
+                ((x, y, z), (x_s, y_s, z_s))
+                for x, x_s in ((0, 16), (16, 4))
+                for y, y_s in ((0, 16), (16, 4))
+                for z, z_s in ((0, 16), (16, 4))
+            ],
+        ),
+        # With alignment the first chunk's topleft is clipped up to the box topleft
+        # (unlike `iter_chunk_starts()`, which yields the raw grid start).
+        (
+            (10, 10, 10),
+            (60, 60, 60),
+            (32, 32, 32),
+            (16, 16, 16),
+            [
+                ((x, y, z), (x_s, y_s, z_s))
+                for x, x_s in ((10, 22), (32, 32), (64, 6))
+                for y, y_s in ((10, 22), (32, 32), (64, 6))
+                for z, z_s in ((10, 22), (32, 32), (64, 6))
+            ],
+        ),
+    ],
+)
+def test_chunk(
+    topleft: tuple[int, int, int],
+    size: tuple[int, int, int],
+    chunk_shape: tuple[int, int, int],
+    alignment: tuple[int, int, int] | None,
+    expected: list[tuple[tuple[int, int, int], tuple[int, int, int]]],
+) -> None:
+    bbox = BoundingBox(topleft, size)
+    assert list(bbox.chunk(chunk_shape, alignment)) == [
+        BoundingBox(chunk_topleft, chunk_size) for chunk_topleft, chunk_size in expected
     ]
-    assert reconstructed == list(bbox.chunk(chunk_shape, alignment))
-
-
-def test_iter_chunk_starts_equals_toplefts_without_alignment() -> None:
-    bbox = BoundingBox((5, 7, 9), (50, 60, 70))
-    assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
-        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
-    ]
-
-
-def test_iter_chunk_starts_alignment_yields_unclipped_start() -> None:
-    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
-    starts = list(bbox.iter_chunk_starts((32, 32, 32), (16, 16, 16)))
-    # First grid line lies before the box topleft and is *not* clipped.
-    assert starts[0] == (0, 0, 0)
 
 
 def test_iter_chunk_starts_alignment_divisibility_assertion() -> None:

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -3,7 +3,7 @@ import pytest
 from hypothesis import given, infer
 
 from webknossos import BoundingBox, Mag
-from webknossos.geometry import NormalizedBoundingBox
+from webknossos.geometry import NDBoundingBox, NormalizedBoundingBox
 
 
 def test_align_with_mag_ceiled() -> None:
@@ -205,6 +205,9 @@ def test_contains_bbox_with_normalized_bbox() -> None:
         ((5, 7, 9), (50, 60, 70), (16, 16, 16), None),
         ((7, 3, 1), (33, 33, 33), (10, 10, 10), None),
         ((0, 0, 0), (100, 100, 100), (32, 32, 32), (16, 16, 16)),
+        ((-33, -1, -64), (50, 60, 70), (32, 32, 32), None),
+        ((-5, 3, -7), (33, 17, 64), (16, 8, 4), (8, 4, 2)),
+        ((5, 7, 9), (50, 60, 70), (32, 32, 32), (16, 16, 16)),
     ],
 )
 def test_iter_chunk_starts_matches_chunk(
@@ -281,3 +284,48 @@ def test_iter_overlapping_grid_cells_outside_clip_is_empty() -> None:
     bbox = BoundingBox((200, 200, 200), (10, 10, 10))
     clip = BoundingBox((0, 0, 0), (40, 40, 40))
     assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == []
+
+
+def test_iter_overlapping_grid_cells_negative_coordinates() -> None:
+    # Box [-33, -1) crosses the grid lines at -32 and 0, so it overlaps the cells
+    # starting at -64 and -32 (the grid is aligned to the origin, not to the box).
+    bbox = BoundingBox((-33, -33, -33), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+        (x, y, z) for x in (-64, -32) for y in (-64, -32) for z in (-64, -32)
+    ]
+
+
+def test_iter_overlapping_grid_cells_clip_to_axes_mismatch() -> None:
+    bbox = BoundingBox((0, 0, 0), (10, 10, 10))
+    clip = NDBoundingBox(
+        topleft=(0, 0, 0, 0), size=(5, 5, 5, 5), axes=("x", "y", "z", "t")
+    )
+    with pytest.raises(ValueError):
+        list(bbox.iter_overlapping_grid_cells((4, 4, 4), clip_to=clip))
+
+
+@pytest.mark.parametrize(
+    "topleft, size, chunk_shape, alignment",
+    [
+        ((5, 7, 9), (50, 60, 70), (16, 8, 4), None),
+        ((-33, -1, -64), (50, 60, 70), (32, 32, 32), None),
+        ((-5, 3, -7), (33, 17, 64), (16, 8, 4), (8, 4, 2)),
+    ],
+)
+def test_iter_chunk_starts_matches_nd_implementation(
+    topleft: tuple[int, int, int],
+    size: tuple[int, int, int],
+    chunk_shape: tuple[int, int, int],
+    alignment: tuple[int, int, int] | None,
+) -> None:
+    """`BoundingBox` overrides the generic `NDBoundingBox` implementations with a
+    3D fast path – both must agree."""
+    bbox = BoundingBox(topleft, size)
+    nd_bbox = NDBoundingBox(topleft=topleft, size=size, axes=("x", "y", "z"))
+
+    assert list(bbox.iter_chunk_starts(chunk_shape, alignment)) == list(
+        nd_bbox.iter_chunk_starts(chunk_shape, alignment)
+    )
+    assert list(bbox.iter_overlapping_grid_cells(chunk_shape)) == list(
+        nd_bbox.iter_overlapping_grid_cells(chunk_shape)
+    )

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -196,3 +196,88 @@ def test_contains_bbox_with_normalized_bbox() -> None:
     # NormalizedBoundingBox.contains_bbox(BoundingBox)
     assert outer_normalized.contains_bbox(inner)
     assert not outer_normalized.contains_bbox(not_contained)
+
+
+@pytest.mark.parametrize(
+    "topleft, size, chunk_shape, alignment",
+    [
+        ((0, 0, 0), (100, 100, 100), (32, 32, 32), None),
+        ((5, 7, 9), (50, 60, 70), (16, 16, 16), None),
+        ((7, 3, 1), (33, 33, 33), (10, 10, 10), None),
+        ((0, 0, 0), (100, 100, 100), (32, 32, 32), (16, 16, 16)),
+    ],
+)
+def test_iter_chunk_starts_matches_chunk(
+    topleft: tuple[int, int, int],
+    size: tuple[int, int, int],
+    chunk_shape: tuple[int, int, int],
+    alignment: tuple[int, int, int] | None,
+) -> None:
+    bbox = BoundingBox(topleft, size)
+    starts = list(bbox.iter_chunk_starts(chunk_shape, alignment))
+
+    # Yielded values are plain python int tuples (no numpy scalars).
+    assert all(type(v) is int for start in starts for v in start)
+
+    # Reconstructing chunk() by wrapping+clipping each start is identical to chunk().
+    reconstructed = [
+        BoundingBox(list(start), chunk_shape).intersected_with(bbox) for start in starts
+    ]
+    assert reconstructed == list(bbox.chunk(chunk_shape, alignment))
+
+
+def test_iter_chunk_starts_equals_toplefts_without_alignment() -> None:
+    bbox = BoundingBox((5, 7, 9), (50, 60, 70))
+    assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
+        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
+    ]
+
+
+def test_iter_chunk_starts_alignment_yields_unclipped_start() -> None:
+    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
+    starts = list(bbox.iter_chunk_starts((32, 32, 32), (16, 16, 16)))
+    # First grid line lies before the box topleft and is *not* clipped.
+    assert starts[0] == (0, 0, 0)
+
+
+def test_iter_chunk_starts_alignment_divisibility_assertion() -> None:
+    bbox = BoundingBox((0, 0, 0), (10, 10, 10))
+    with pytest.raises(AssertionError):
+        list(bbox.iter_chunk_starts((32, 32, 32), (7, 7, 7)))
+
+
+def test_iter_overlapping_grid_cells() -> None:
+    # Box [10, 50) on every axis overlaps origin-aligned 32-grid cells 0 and 32.
+    bbox = BoundingBox((10, 10, 10), (40, 40, 40))
+    cells = list(bbox.iter_overlapping_grid_cells((32, 32, 32)))
+    assert all(type(v) is int for cell in cells for v in cell)
+    assert cells == [(x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)]
+
+
+def test_iter_overlapping_grid_cells_touching_border_excluded() -> None:
+    # Box exactly spanning one grid cell [32, 64) only overlaps that single cell;
+    # neighbouring cells that merely touch its borders are excluded (half-open).
+    bbox = BoundingBox((32, 32, 32), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [(32, 32, 32)]
+
+
+def test_iter_overlapping_grid_cells_non_origin_aligned() -> None:
+    # Box [1, 33) crosses the grid line at 32, so it overlaps cells 0 and 32.
+    bbox = BoundingBox((1, 1, 1), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+
+def test_iter_overlapping_grid_cells_clip_to() -> None:
+    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+
+def test_iter_overlapping_grid_cells_outside_clip_is_empty() -> None:
+    bbox = BoundingBox((200, 200, 200), (10, 10, 10))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == []

--- a/webknossos/tests/geometry/test_nd_bounding_box.py
+++ b/webknossos/tests/geometry/test_nd_bounding_box.py
@@ -381,12 +381,50 @@ def test_iter_overlapping_grid_cells_nd_clip_to() -> None:
     )
     cells = list(bbox.iter_overlapping_grid_cells((16, 16, 16), clip_to=clip))
     assert all(type(v) is int for cell in cells for v in cell)
-    # xyz overlap cells 0 and 16, the c axis collapses to a single cell (cell size
-    # == size.c), and the t axis (size 1) yields every t index in the clip range.
+    # xyz overlap cells 0 and 16; all non-xyz axes (c and t) use a cell size of 1, so
+    # every index in the clip range is yielded for them.
     assert cells == [
-        (x, y, z, 0, t)
+        (x, y, z, c, t)
         for x in (0, 16)
         for y in (0, 16)
         for z in (0, 16)
+        for c in (0, 1, 2)
         for t in (0, 1, 2, 3)
     ]
+
+
+def test_iter_overlapping_grid_cells_nd_grid_is_independent_of_box_size() -> None:
+    """Unlike `chunk()`, the origin-aligned grid must not depend on the box's own
+    size on the channel axis."""
+    cells_per_c_size = [
+        list(
+            NDBoundingBox(
+                topleft=(0, 0, 0, 2),
+                size=(8, 8, 8, c_size),
+                axes=("x", "y", "z", "c"),
+            ).iter_overlapping_grid_cells((8, 8, 8))
+        )
+        for c_size in (1, 2)
+    ]
+    assert cells_per_c_size[0] == [(0, 0, 0, 2)]
+    assert cells_per_c_size[1] == [(0, 0, 0, 2), (0, 0, 0, 3)]
+
+
+def test_iter_chunk_starts_nd_alignment_and_negative_coordinates() -> None:
+    bbox = NDBoundingBox(
+        topleft=(-33, 7, -64, 0, 0),
+        size=(50, 60, 70, 3, 2),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    starts = list(bbox.iter_chunk_starts((32, 32, 32), (16, 16, 16)))
+    assert all(type(v) is int for start in starts for v in start)
+
+    # Reconstructing chunk() by wrapping+clipping each start is identical to chunk().
+    chunk_size = VecInt(32, 32, 32, 3, 1, axes=bbox.axes)
+    reconstructed = [
+        bbox.intersected_with(
+            NDBoundingBox(topleft=start, size=chunk_size, axes=bbox.axes)
+        )
+        for start in starts
+    ]
+    assert reconstructed == list(bbox.chunk((32, 32, 32), (16, 16, 16)))

--- a/webknossos/tests/geometry/test_nd_bounding_box.py
+++ b/webknossos/tests/geometry/test_nd_bounding_box.py
@@ -354,16 +354,56 @@ def test_iter_chunk_starts_nd() -> None:
     ]
 
 
-def test_iter_chunk_starts_xyz_shorthand_without_z_axis() -> None:
+def test_iter_chunk_starts_three_entries_are_ambiguous_without_z_axis() -> None:
     bbox = NDBoundingBox(
         topleft=(10, 20, 5),
         size=(30, 30, 30),
         axes=("x", "y", "t"),
     )
-    # A 3D chunk shape is the xyz shorthand even if the box has no z axis: x and y use
-    # the given sizes, every other axis (here t) is iterated one index at a time.
+    # Three entries for a three-axis box that is not xyz could be either reading, so
+    # an unnamed shape is rejected instead of silently dropping the third entry.
+    with pytest.raises(ValueError, match="ambiguous"):
+        list(bbox.iter_chunk_starts((16, 16, 16)))
+
+    # A named shape says which entry belongs to which axis and is used verbatim.
+    assert list(bbox.iter_chunk_starts(VecInt(16, 16, 16, axes=("x", "y", "t")))) == [
+        (x, y, t) for x in (10, 26) for y in (20, 36) for t in (5, 21)
+    ]
+
+
+def test_iter_chunk_starts_xyz_shorthand_maps_by_axis_name() -> None:
+    """Three unnamed entries are the sizes of x, y and z whatever the axis order is."""
+    bbox = NDBoundingBox(topleft=(0, 0, 0), size=(64, 64, 64), axes=("z", "y", "x"))
+    assert [tuple(chunk.size) for chunk in bbox.chunk((8, 16, 32))][0] == (32, 16, 8)
+    assert list(bbox.iter_chunk_starts((8, 16, 32)))[:2] == [(0, 0, 0), (0, 0, 8)]
+
+
+def test_iter_chunk_starts_named_shape_is_reordered_to_box_axes() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0),
+        size=(20, 20, 20, 4),
+        axes=("x", "y", "z", "t"),
+    )
+    reordered = VecInt(2, 16, 16, 16, axes=("t", "z", "y", "x"))
+    assert list(bbox.iter_chunk_starts(reordered)) == list(
+        bbox.iter_chunk_starts(VecInt(16, 16, 16, 2, axes=bbox.axes))
+    )
+
+
+def test_iter_chunk_starts_xyz_shorthand_ignores_missing_z_axis() -> None:
+    """With more than three axes a three-entry shape is unambiguous, so the entry for
+    the missing z axis is simply unused."""
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0),
+        size=(20, 20, 3, 2),
+        axes=("x", "y", "t", "s"),
+    )
     assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
-        (x, y, t) for x in (10, 26) for y in (20, 36) for t in range(5, 35)
+        (x, y, t, s)
+        for x in (0, 16)
+        for y in (0, 16)
+        for t in (0, 1, 2)
+        for s in (0, 1)
     ]
 
 

--- a/webknossos/tests/geometry/test_nd_bounding_box.py
+++ b/webknossos/tests/geometry/test_nd_bounding_box.py
@@ -335,26 +335,74 @@ def test_negative_inversion(
     assert bbox == bbox.padded_with_margins(-bbox.size, -bbox.size)
 
 
-def test_iter_chunk_starts_matches_chunk_toplefts_nd() -> None:
+def test_iter_chunk_starts_nd() -> None:
     bbox = NDBoundingBox(
         topleft=(0, 0, 0, 0, 0),
-        size=(50, 60, 70, 3, 4),
+        size=(20, 20, 20, 3, 2),
         axes=("x", "y", "z", "c", "t"),
     )
-    assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
-        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
+    starts = list(bbox.iter_chunk_starts((16, 16, 16)))
+    assert all(type(v) is int for start in starts for v in start)
+    # An xyz chunk shape chunks xyz, spans the whole c axis and iterates all other axes
+    # one index at a time.
+    assert starts == [
+        (x, y, z, 0, t)
+        for x in (0, 16)
+        for y in (0, 16)
+        for z in (0, 16)
+        for t in (0, 1)
     ]
 
 
-def test_iter_chunk_starts_full_nd_shape() -> None:
+def test_iter_chunk_starts_xyz_shorthand_without_z_axis() -> None:
     bbox = NDBoundingBox(
         topleft=(10, 20, 5),
         size=(30, 30, 30),
         axes=("x", "y", "t"),
     )
-    # A full-length (non-xyz-shorthand) chunk shape is used verbatim per axis.
+    # A 3D chunk shape is the xyz shorthand even if the box has no z axis: x and y use
+    # the given sizes, every other axis (here t) is iterated one index at a time.
     assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
-        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
+        (x, y, t) for x in (10, 26) for y in (20, 36) for t in range(5, 35)
+    ]
+
+
+def test_iter_chunk_starts_full_length_shape() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(20, 20, 20, 3, 4),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    # A chunk shape with one entry per axis is used verbatim, i.e. the c axis is not
+    # forced to span all channels.
+    assert list(bbox.iter_chunk_starts((16, 16, 16, 2, 2))) == [
+        (x, y, z, c, t)
+        for x in (0, 16)
+        for y in (0, 16)
+        for z in (0, 16)
+        for c in (0, 2)
+        for t in (0, 2)
+    ]
+
+
+def test_chunk_nd() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(20, 20, 20, 3, 2),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    axes = ("x", "y", "z", "c", "t")
+    # Border chunks are clipped to the box, the c axis is never split.
+    assert list(bbox.chunk((16, 16, 16))) == [
+        NDBoundingBox(
+            topleft=VecInt(x, y, z, 0, t, axes=axes),
+            size=VecInt(x_size, y_size, z_size, 3, 1, axes=axes),
+            axes=axes,
+        )
+        for x, x_size in ((0, 16), (16, 4))
+        for y, y_size in ((0, 16), (16, 4))
+        for z, z_size in ((0, 16), (16, 4))
+        for t in (0, 1)
     ]
 
 
@@ -419,12 +467,12 @@ def test_iter_chunk_starts_nd_alignment_and_negative_coordinates() -> None:
     starts = list(bbox.iter_chunk_starts((32, 32, 32), (16, 16, 16)))
     assert all(type(v) is int for start in starts for v in start)
 
-    # Reconstructing chunk() by wrapping+clipping each start is identical to chunk().
-    chunk_size = VecInt(32, 32, 32, 3, 1, axes=bbox.axes)
-    reconstructed = [
-        bbox.intersected_with(
-            NDBoundingBox(topleft=start, size=chunk_size, axes=bbox.axes)
-        )
-        for start in starts
+    # Per axis the first start is the previous multiple of the alignment:
+    # -33 % 16 == 15 -> -48, 7 % 16 == 7 -> 0, -64 % 16 == 0 -> -64.
+    assert starts == [
+        (x, y, z, 0, t)
+        for x in (-48, -16, 16)
+        for y in (0, 32, 64)
+        for z in (-64, -32, 0)
+        for t in (0, 1)
     ]
-    assert reconstructed == list(bbox.chunk((32, 32, 32), (16, 16, 16)))

--- a/webknossos/tests/geometry/test_nd_bounding_box.py
+++ b/webknossos/tests/geometry/test_nd_bounding_box.py
@@ -333,3 +333,60 @@ def test_negative_inversion(
     """Flipping the topleft and bottomright (by padding both with the negative size)
     results in the original bbox, as negative sizes are converted to positive ones."""
     assert bbox == bbox.padded_with_margins(-bbox.size, -bbox.size)
+
+
+def test_iter_chunk_starts_matches_chunk_toplefts_nd() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(50, 60, 70, 3, 4),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
+        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
+    ]
+
+
+def test_iter_chunk_starts_full_nd_shape() -> None:
+    bbox = NDBoundingBox(
+        topleft=(10, 20, 5),
+        size=(30, 30, 30),
+        axes=("x", "y", "t"),
+    )
+    # A full-length (non-xyz-shorthand) chunk shape is used verbatim per axis.
+    assert list(bbox.iter_chunk_starts((16, 16, 16))) == [
+        tuple(chunk.topleft) for chunk in bbox.chunk((16, 16, 16))
+    ]
+
+
+def test_iter_chunk_starts_alignment_divisibility_assertion_nd() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(10, 10, 10, 1, 1),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    with pytest.raises(AssertionError):
+        list(bbox.iter_chunk_starts((32, 32, 32), (7, 7, 7)))
+
+
+def test_iter_overlapping_grid_cells_nd_clip_to() -> None:
+    bbox = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(50, 60, 70, 3, 4),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    clip = NDBoundingBox(
+        topleft=(0, 0, 0, 0, 0),
+        size=(20, 20, 20, 3, 4),
+        axes=("x", "y", "z", "c", "t"),
+    )
+    cells = list(bbox.iter_overlapping_grid_cells((16, 16, 16), clip_to=clip))
+    assert all(type(v) is int for cell in cells for v in cell)
+    # xyz overlap cells 0 and 16, the c axis collapses to a single cell (cell size
+    # == size.c), and the t axis (size 1) yields every t index in the clip range.
+    assert cells == [
+        (x, y, z, 0, t)
+        for x in (0, 16)
+        for y in (0, 16)
+        for z in (0, 16)
+        for t in (0, 1, 2, 3)
+    ]

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -1,6 +1,6 @@
 import json
 import re
-from collections.abc import Callable, Generator, Iterable, Iterator
+from collections.abc import Callable, Generator, Iterable
 from typing import Union, cast, overload
 
 import attr
@@ -441,121 +441,12 @@ class BoundingBox(NDBoundingBox):
                 and self.topleft[2] <= coord[2] < self.bottomright[2]
             )
 
-    def iter_chunk_starts(
-        self,
-        chunk_shape: Vec3IntLike,
-        chunk_border_alignments: Vec3IntLike | None = None,
-    ) -> Iterator[tuple[int, int, int]]:
-        """Yield the topleft coordinate of every chunk as a plain ``(x, y, z)`` int tuple.
-
-        This is a fast, allocation-free variant of `chunk()`: it performs no
-        per-chunk `Vec3Int`/`BoundingBox` allocation and does **not** clip the chunks
-        to this box (border chunks are therefore *not* shrunk – the caller can
-        clip/filter cheaply on the raw integers if needed).
-
-        The chunk grid matches `chunk()` exactly (same cells, same order). Without
-        `chunk_border_alignments`, the yielded starts equal the chunk toplefts, i.e.
-        ``list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in self.chunk(cs)]``.
-        With `chunk_border_alignments`, the first grid line on an axis may lie
-        *before* this box's topleft; `chunk()` clips that first chunk's topleft up to
-        the box, whereas this method yields the unclipped grid start.
-
-        Args:
-            chunk_shape (Vec3IntLike): The size of the chunks to generate.
-            chunk_border_alignments (Vec3IntLike | None): The alignment of the chunk borders.
-
-        Yields:
-            tuple[int, int, int]: The topleft coordinate of each chunk.
-        """
-
-        # This intentionally duplicates the grid math of
-        # `NDBoundingBox.iter_chunk_starts()` (as `chunk()` does, too): staying on
-        # plain python ints avoids the generic per-axis machinery, which dominates the
-        # runtime for small boxes. Keep both implementations in sync.
-        (sx, sy, sz) = self.topleft
-        (wx, wy, wz) = self.size
-        chunk_shape_vec = Vec3Int(chunk_shape)
-        (cx, cy, cz) = chunk_shape_vec
-
-        (ax, ay, az) = (0, 0, 0)
-        if chunk_border_alignments is not None:
-            alignments = Vec3Int(chunk_border_alignments)
-            (alx, aly, alz) = alignments
-            assert cx % alx == 0 and cy % aly == 0 and cz % alz == 0, (
-                f"{chunk_shape_vec} not divisible by {alignments}"
-            )
-
-            # Move the start to be aligned correctly. This doesn't actually change
-            # the start of the first chunk, because callers clip against `self`, but
-            # it'll lead to all chunk borders being aligned correctly.
-            (ax, ay, az) = (sx % alx, sy % aly, sz % alz)
-
-        for x in range(sx - ax, sx + wx, cx):
-            for y in range(sy - ay, sy + wy, cy):
-                for z in range(sz - az, sz + wz, cz):
-                    yield (x, y, z)
-
-    def iter_overlapping_grid_cells(
-        self,
-        chunk_shape: Vec3IntLike,
-        clip_to: "NDBoundingBox | None" = None,
-    ) -> Iterator[tuple[int, int, int]]:
-        """Yield the topleft of every origin-aligned grid cell overlapping this box.
-
-        The grid is aligned to the coordinate origin (cell ``k`` on an axis spans
-        ``[k * cell, (k + 1) * cell)``) and has cell size `chunk_shape`. This differs
-        from `chunk()` / `iter_chunk_starts()`, whose grid is aligned to the box's own
-        topleft.
-
-        Overlap uses half-open intervals: cells that only *touch* this box (or
-        `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
-        allocation-free and yields plain ``(x, y, z)`` int tuples.
-
-        Args:
-            chunk_shape (Vec3IntLike): The size of the grid cells.
-            clip_to (NDBoundingBox | None): If given, only cells overlapping both this
-                box and `clip_to` are yielded. Must have the same axes as this box,
-                i.e. a plain 3D bounding box.
-
-        Raises:
-            ValueError: If `clip_to` does not have the same axes as this box.
-
-        Yields:
-            tuple[int, int, int]: The topleft coordinate of each overlapping grid cell.
-        """
-
-        # Kept in sync with `NDBoundingBox.iter_overlapping_grid_cells()`, see the note
-        # in `iter_chunk_starts()` about the duplicated grid math.
-        (cx, cy, cz) = Vec3Int(chunk_shape)
-
-        region_start = self.topleft
-        region_end = self.bottomright
-        if clip_to is not None:
-            self._check_compatibility(clip_to)
-            region_start = region_start.pairmax(clip_to.topleft)
-            region_end = region_end.pairmin(clip_to.bottomright)
-
-        (start_x, start_y, start_z) = region_start
-        (end_x, end_y, end_z) = region_end
-
-        if start_x >= end_x or start_y >= end_y or start_z >= end_z:
-            # Empty overlap on at least one axis -> no cells at all.
-            return
-
-        for x in range((start_x // cx) * cx, end_x, cx):
-            for y in range((start_y // cy) * cy, end_y, cy):
-                for z in range((start_z // cz) * cz, end_z, cz):
-                    yield (x, y, z)
-
     def chunk(
         self,
         chunk_shape: Vec3IntLike,
         chunk_border_alignments: Vec3IntLike | None = None,
     ) -> Generator["BoundingBox", None, None]:
         """Decompose the bounding box into smaller chunks of size `chunk_shape`.
-
-        For a fast, allocation-free variant that yields raw integer coordinates
-        instead of `BoundingBox` objects, see `iter_chunk_starts()`.
 
         Args:
             chunk_shape (Vec3IntLike): Size of chunks to decompose into. Each chunk

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -468,26 +468,27 @@ class BoundingBox(NDBoundingBox):
             tuple[int, int, int]: The topleft coordinate of each chunk.
         """
 
-        start = self.topleft.to_np()
-        chunk_shape_array = Vec3Int(chunk_shape).to_np()
+        # This intentionally duplicates the grid math of
+        # `NDBoundingBox.iter_chunk_starts()` (as `chunk()` does, too): staying on
+        # plain python ints avoids the generic per-axis machinery, which dominates the
+        # runtime for small boxes. Keep both implementations in sync.
+        (sx, sy, sz) = self.topleft
+        (wx, wy, wz) = self.size
+        chunk_shape_vec = Vec3Int(chunk_shape)
+        (cx, cy, cz) = chunk_shape_vec
 
-        start_adjust = np.array([0, 0, 0])
+        (ax, ay, az) = (0, 0, 0)
         if chunk_border_alignments is not None:
-            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
-            assert np.all(chunk_shape_array % chunk_border_alignments_array == 0), (
-                f"{chunk_shape_array} not divisible by {chunk_border_alignments_array}"
+            alignments = Vec3Int(chunk_border_alignments)
+            (alx, aly, alz) = alignments
+            assert cx % alx == 0 and cy % aly == 0 and cz % alz == 0, (
+                f"{chunk_shape_vec} not divisible by {alignments}"
             )
 
             # Move the start to be aligned correctly. This doesn't actually change
             # the start of the first chunk, because callers clip against `self`, but
             # it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % chunk_border_alignments_array
-
-        # Work on plain python ints so the yielded tuples contain no numpy scalars.
-        (sx, sy, sz) = start.tolist()
-        (wx, wy, wz) = self.size.to_np().tolist()
-        (cx, cy, cz) = chunk_shape_array.tolist()
-        (ax, ay, az) = start_adjust.tolist()
+            (ax, ay, az) = (sx % alx, sy % aly, sz % alz)
 
         for x in range(sx - ax, sx + wx, cx):
             for y in range(sy - ay, sy + wy, cy):
@@ -513,23 +514,29 @@ class BoundingBox(NDBoundingBox):
         Args:
             chunk_shape (Vec3IntLike): The size of the grid cells.
             clip_to (NDBoundingBox | None): If given, only cells overlapping both this
-                box and `clip_to` are yielded.
+                box and `clip_to` are yielded. Must have the same axes as this box,
+                i.e. a plain 3D bounding box.
+
+        Raises:
+            ValueError: If `clip_to` does not have the same axes as this box.
 
         Yields:
             tuple[int, int, int]: The topleft coordinate of each overlapping grid cell.
         """
 
-        (cx, cy, cz) = Vec3Int(chunk_shape).to_np().tolist()
+        # Kept in sync with `NDBoundingBox.iter_overlapping_grid_cells()`, see the note
+        # in `iter_chunk_starts()` about the duplicated grid math.
+        (cx, cy, cz) = Vec3Int(chunk_shape)
 
-        region_start = self.topleft.to_np()
-        region_end = region_start + self.size.to_np()
+        region_start = self.topleft
+        region_end = self.bottomright
         if clip_to is not None:
             self._check_compatibility(clip_to)
-            region_start = np.maximum(region_start, clip_to.topleft.to_np())
-            region_end = np.minimum(region_end, clip_to.bottomright.to_np())
+            region_start = region_start.pairmax(clip_to.topleft)
+            region_end = region_end.pairmin(clip_to.bottomright)
 
-        (start_x, start_y, start_z) = region_start.tolist()
-        (end_x, end_y, end_z) = region_end.tolist()
+        (start_x, start_y, start_z) = region_start
+        (end_x, end_y, end_z) = region_end
 
         if start_x >= end_x or start_y >= end_y or start_z >= end_z:
             # Empty overlap on at least one axis -> no cells at all.

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -1,6 +1,6 @@
 import json
 import re
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
 from typing import Union, cast, overload
 
 import attr
@@ -441,12 +441,114 @@ class BoundingBox(NDBoundingBox):
                 and self.topleft[2] <= coord[2] < self.bottomright[2]
             )
 
+    def iter_chunk_starts(
+        self,
+        chunk_shape: Vec3IntLike,
+        chunk_border_alignments: Vec3IntLike | None = None,
+    ) -> Iterator[tuple[int, int, int]]:
+        """Yield the topleft coordinate of every chunk as a plain ``(x, y, z)`` int tuple.
+
+        This is a fast, allocation-free variant of `chunk()`: it performs no
+        per-chunk `Vec3Int`/`BoundingBox` allocation and does **not** clip the chunks
+        to this box (border chunks are therefore *not* shrunk – the caller can
+        clip/filter cheaply on the raw integers if needed).
+
+        The chunk grid matches `chunk()` exactly (same cells, same order). Without
+        `chunk_border_alignments`, the yielded starts equal the chunk toplefts, i.e.
+        ``list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in self.chunk(cs)]``.
+        With `chunk_border_alignments`, the first grid line on an axis may lie
+        *before* this box's topleft; `chunk()` clips that first chunk's topleft up to
+        the box, whereas this method yields the unclipped grid start.
+
+        Args:
+            chunk_shape (Vec3IntLike): The size of the chunks to generate.
+            chunk_border_alignments (Vec3IntLike | None): The alignment of the chunk borders.
+
+        Yields:
+            tuple[int, int, int]: The topleft coordinate of each chunk.
+        """
+
+        start = self.topleft.to_np()
+        chunk_shape_array = Vec3Int(chunk_shape).to_np()
+
+        start_adjust = np.array([0, 0, 0])
+        if chunk_border_alignments is not None:
+            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
+            assert np.all(chunk_shape_array % chunk_border_alignments_array == 0), (
+                f"{chunk_shape_array} not divisible by {chunk_border_alignments_array}"
+            )
+
+            # Move the start to be aligned correctly. This doesn't actually change
+            # the start of the first chunk, because callers clip against `self`, but
+            # it'll lead to all chunk borders being aligned correctly.
+            start_adjust = start % chunk_border_alignments_array
+
+        # Work on plain python ints so the yielded tuples contain no numpy scalars.
+        (sx, sy, sz) = start.tolist()
+        (wx, wy, wz) = self.size.to_np().tolist()
+        (cx, cy, cz) = chunk_shape_array.tolist()
+        (ax, ay, az) = start_adjust.tolist()
+
+        for x in range(sx - ax, sx + wx, cx):
+            for y in range(sy - ay, sy + wy, cy):
+                for z in range(sz - az, sz + wz, cz):
+                    yield (x, y, z)
+
+    def iter_overlapping_grid_cells(
+        self,
+        chunk_shape: Vec3IntLike,
+        clip_to: "NDBoundingBox | None" = None,
+    ) -> Iterator[tuple[int, int, int]]:
+        """Yield the topleft of every origin-aligned grid cell overlapping this box.
+
+        The grid is aligned to the coordinate origin (cell ``k`` on an axis spans
+        ``[k * cell, (k + 1) * cell)``) and has cell size `chunk_shape`. This differs
+        from `chunk()` / `iter_chunk_starts()`, whose grid is aligned to the box's own
+        topleft.
+
+        Overlap uses half-open intervals: cells that only *touch* this box (or
+        `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
+        allocation-free and yields plain ``(x, y, z)`` int tuples.
+
+        Args:
+            chunk_shape (Vec3IntLike): The size of the grid cells.
+            clip_to (NDBoundingBox | None): If given, only cells overlapping both this
+                box and `clip_to` are yielded.
+
+        Yields:
+            tuple[int, int, int]: The topleft coordinate of each overlapping grid cell.
+        """
+
+        (cx, cy, cz) = Vec3Int(chunk_shape).to_np().tolist()
+
+        region_start = self.topleft.to_np()
+        region_end = region_start + self.size.to_np()
+        if clip_to is not None:
+            self._check_compatibility(clip_to)
+            region_start = np.maximum(region_start, clip_to.topleft.to_np())
+            region_end = np.minimum(region_end, clip_to.bottomright.to_np())
+
+        (start_x, start_y, start_z) = region_start.tolist()
+        (end_x, end_y, end_z) = region_end.tolist()
+
+        if start_x >= end_x or start_y >= end_y or start_z >= end_z:
+            # Empty overlap on at least one axis -> no cells at all.
+            return
+
+        for x in range((start_x // cx) * cx, end_x, cx):
+            for y in range((start_y // cy) * cy, end_y, cy):
+                for z in range((start_z // cz) * cz, end_z, cz):
+                    yield (x, y, z)
+
     def chunk(
         self,
         chunk_shape: Vec3IntLike,
         chunk_border_alignments: Vec3IntLike | None = None,
     ) -> Generator["BoundingBox", None, None]:
         """Decompose the bounding box into smaller chunks of size `chunk_shape`.
+
+        For a fast, allocation-free variant that yields raw integer coordinates
+        instead of `BoundingBox` objects, see `iter_chunk_starts()`.
 
         Args:
             chunk_shape (Vec3IntLike): Size of chunks to decompose into. Each chunk
@@ -468,34 +570,13 @@ class BoundingBox(NDBoundingBox):
               chunks will be aligned to those values
         """
 
-        start = self.topleft.to_np()
-        chunk_shape = Vec3Int(chunk_shape).to_np()
+        chunk_shape = Vec3Int(chunk_shape)
 
-        start_adjust = np.array([0, 0, 0])
-        if chunk_border_alignments is not None:
-            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
-            assert np.all(chunk_shape % chunk_border_alignments_array == 0), (
-                f"{chunk_shape} not divisible by {chunk_border_alignments_array}"
+        for x, y, z in self.iter_chunk_starts(chunk_shape, chunk_border_alignments):
+            yield cast(
+                BoundingBox,
+                BoundingBox([x, y, z], chunk_shape).intersected_with(self),
             )
-
-            # Move the start to be aligned correctly. This doesn't actually change
-            # the start of the first chunk, because we'll intersect with `self`,
-            # but it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % chunk_border_alignments_array
-
-        for x in range(
-            start[0] - start_adjust[0], start[0] + self.size[0], chunk_shape[0]
-        ):
-            for y in range(
-                start[1] - start_adjust[1], start[1] + self.size[1], chunk_shape[1]
-            ):
-                for z in range(
-                    start[2] - start_adjust[2], start[2] + self.size[2], chunk_shape[2]
-                ):
-                    yield cast(
-                        BoundingBox,
-                        BoundingBox([x, y, z], chunk_shape).intersected_with(self),
-                    )
 
     def offset(self, vector: Vec3IntLike) -> "BoundingBox":
         """Creates an offset copy of this bounding box by adding a vector to the topleft coordinate.

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -697,63 +697,71 @@ class NDBoundingBox:
         self._check_compatibility(inner_bbox)
         return inner_bbox.intersected_with(self, dont_assert=True) == inner_bbox
 
-    def _normalize_chunk_grid(
+    def _expand_shape_to_axes(
+        self, shape: VecIntLike, channels_whole: bool
+    ) -> np.ndarray:
+        """Expand a chunk/cell `shape` to all axes of this bounding box.
+
+        A shape with one entry per axis is used verbatim. If a 3D shape is given it is
+        assumed that iteration over xyz is intended, so all other axes get a size of 1
+        – except for the channel axis, which spans all channels if `channels_whole` is
+        set (`chunk()` does this so that every chunk contains all channels).
+
+        Returns:
+            The expanded shape as a numpy array, in axis order.
+        """
+
+        try:
+            expanded = VecInt.ones(self.axes).with_xyz(Vec3Int(shape))
+            if channels_whole and "c" in self.axes:
+                expanded = expanded.with_c(self.size.c)
+            return expanded.to_np()
+        except AssertionError:
+            return VecInt(shape, axes=self.axes).to_np()
+
+    def _chunk_grid_ranges(
         self,
         chunk_shape: VecIntLike,
         chunk_border_alignments: VecIntLike | None,
-    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-        """Normalize `chunk_shape` and `chunk_border_alignments` to numpy arrays that
-        match this box's axes and compute the (aligned) start offset.
+    ) -> tuple[list[range], np.ndarray]:
+        """Compute the chunk grid of `chunk()` / `iter_chunk_starts()`.
 
-        This is the shared grid math used by `chunk()`, `iter_chunk_starts()` and
-        `iter_overlapping_grid_cells()` so there is a single source of truth.
+        This is the shared grid math of both methods, so there is a single source of
+        truth for the chunk start coordinates.
 
         Returns:
-            A tuple of ``(start, chunk_shape, start_adjust)`` numpy arrays.
+            A tuple of the per-axis ranges of chunk start coordinates (as plain python
+            ints, so no numpy scalars leak into the yielded coordinates) and the
+            expanded `chunk_shape` as a numpy array.
         """
 
         start = self.topleft.to_np()
-        try:
-            # If a 3D chunk_shape is given it is assumed that iteration over xyz is
-            # intended. Therefore NDBoundingBoxes are generated that have a shape of
-            # x: chunk_shape.x, y: chunk_shape.y, z: chunk_shape.z, c: size.c and 1 for all other
-            # axes.
-            chunk_shape = Vec3Int(chunk_shape)
-            chunk_shape = VecInt.ones(self.axes).with_xyz(chunk_shape)
-            if "c" in self.axes:
-                chunk_shape = chunk_shape.with_c(self.size.c)
-            chunk_shape = chunk_shape.to_np()
-        except AssertionError:
-            chunk_shape = VecInt(chunk_shape, axes=self.axes).to_np()
+        chunk_shape_np = self._expand_shape_to_axes(chunk_shape, channels_whole=True)
 
         start_adjust = VecInt.zeros(self.axes).to_np()
         if chunk_border_alignments is not None:
-            try:
-                chunk_border_alignments = Vec3Int(chunk_border_alignments)
+            alignments = self._expand_shape_to_axes(
+                chunk_border_alignments, channels_whole=True
+            )
 
-                chunk_border_alignments = VecInt.ones(self.axes).with_xyz(
-                    chunk_border_alignments
-                )
-                if "c" in self.axes:
-                    chunk_border_alignments = chunk_border_alignments.with_c(
-                        self.size.c
-                    )
-                chunk_border_alignments = chunk_border_alignments.to_np()
-            except AssertionError:
-                chunk_border_alignments = VecInt(
-                    chunk_border_alignments, axes=self.axes
-                ).to_np()
-
-            assert np.all(chunk_shape % chunk_border_alignments == 0), (
-                f"{chunk_shape} not divisible by {chunk_border_alignments}"
+            assert np.all(chunk_shape_np % alignments == 0), (
+                f"{chunk_shape_np} not divisible by {alignments}"
             )
 
             # Move the start to be aligned correctly. This doesn't actually change
             # the start of the first chunk, because we'll intersect with `self`,
             # but it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % chunk_border_alignments
+            start_adjust = start % alignments
 
-        return start, chunk_shape, start_adjust
+        starts = start.tolist()
+        sizes = list(self.size)
+        steps = chunk_shape_np.tolist()
+        adjusts = start_adjust.tolist()
+
+        return [
+            range(starts[i] - adjusts[i], starts[i] + sizes[i], steps[i])
+            for i in range(len(self.axes))
+        ], chunk_shape_np
 
     def iter_chunk_starts(
         self,
@@ -782,22 +790,8 @@ class NDBoundingBox:
             tuple[int, ...]: The topleft coordinate of each chunk, in axis order.
         """
 
-        start, chunk_shape_np, start_adjust = self._normalize_chunk_grid(
-            chunk_shape, chunk_border_alignments
-        )
-
-        # Work on plain python ints so the yielded tuples contain no numpy scalars.
-        starts = start.tolist()
-        sizes = self.size.to_np().tolist()
-        steps = chunk_shape_np.tolist()
-        adjusts = start_adjust.tolist()
-
-        yield from product(
-            *[
-                range(starts[i] - adjusts[i], starts[i] + sizes[i], steps[i])
-                for i in range(len(self.axes))
-            ]
-        )
+        ranges, _ = self._chunk_grid_ranges(chunk_shape, chunk_border_alignments)
+        yield from product(*ranges)
 
     def iter_overlapping_grid_cells(
         self,
@@ -811,6 +805,11 @@ class NDBoundingBox:
         from `chunk()` / `iter_chunk_starts()`, whose grid is aligned to the box's own
         topleft.
 
+        If a 3D `chunk_shape` is given, all non-xyz axes (including a channel axis) use
+        a cell size of 1, i.e. every index on those axes is yielded. Unlike for
+        `chunk()`, the channel axis is *not* collapsed into a single cell, so that the
+        grid only depends on `chunk_shape` and not on this box's own size.
+
         Overlap uses half-open intervals: cells that only *touch* this box (or
         `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
         allocation-free and yields plain int tuples.
@@ -818,13 +817,16 @@ class NDBoundingBox:
         Args:
             chunk_shape (VecIntLike): The size of the grid cells.
             clip_to (NDBoundingBox | None): If given, only cells overlapping both this
-                box and `clip_to` are yielded.
+                box and `clip_to` are yielded. Must have the same axes as this box.
+
+        Raises:
+            ValueError: If `clip_to` does not have the same axes as this box.
 
         Yields:
             tuple[int, ...]: The topleft coordinate of each overlapping grid cell.
         """
 
-        _, chunk_shape_np, _ = self._normalize_chunk_grid(chunk_shape, None)
+        chunk_shape_np = self._expand_shape_to_axes(chunk_shape, channels_whole=False)
 
         region_start = self.topleft.to_np()
         region_end = region_start + self.size.to_np()
@@ -873,12 +875,12 @@ class NDBoundingBox:
             Generator[NDBoundingBox]: A generator of the chunks.
         """
 
-        _, chunk_shape_np, _ = self._normalize_chunk_grid(
+        ranges, chunk_shape_np = self._chunk_grid_ranges(
             chunk_shape, chunk_border_alignments
         )
         chunk_size = VecInt(chunk_shape_np, axes=self.axes)
 
-        for coordinates in self.iter_chunk_starts(chunk_shape, chunk_border_alignments):
+        for coordinates in product(*ranges):
             yield self.intersected_with(
                 self.__class__(
                     topleft=VecInt(coordinates, axes=self.axes),

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from collections.abc import Generator, Iterable
+from collections.abc import Generator, Iterable, Iterator
 from itertools import product
 from typing import (
     TYPE_CHECKING,
@@ -697,25 +697,19 @@ class NDBoundingBox:
         self._check_compatibility(inner_bbox)
         return inner_bbox.intersected_with(self, dont_assert=True) == inner_bbox
 
-    def chunk(
-        self: _T,
+    def _normalize_chunk_grid(
+        self,
         chunk_shape: VecIntLike,
-        chunk_border_alignments: VecIntLike | None = None,
-    ) -> Generator[_T, None, None]:
-        """
-        Decompose the bounding box into smaller chunks of size `chunk_shape`.
+        chunk_border_alignments: VecIntLike | None,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Normalize `chunk_shape` and `chunk_border_alignments` to numpy arrays that
+        match this box's axes and compute the (aligned) start offset.
 
-        Chunks at the border of the bounding box might be smaller than chunk_shape.
-        If `chunk_border_alignment` is set, all border coordinates
-        *between two chunks* will be divisible by that value.
+        This is the shared grid math used by `chunk()`, `iter_chunk_starts()` and
+        `iter_overlapping_grid_cells()` so there is a single source of truth.
 
-        Args:
-            chunk_shape (VecIntLike): The size of the chunks to generate.
-            chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
-
-
-        Yields:
-            Generator[NDBoundingBox]: A generator of the chunks.
+        Returns:
+            A tuple of ``(start, chunk_shape, start_adjust)`` numpy arrays.
         """
 
         start = self.topleft.to_np()
@@ -758,18 +752,137 @@ class NDBoundingBox:
             # the start of the first chunk, because we'll intersect with `self`,
             # but it'll lead to all chunk borders being aligned correctly.
             start_adjust = start % chunk_border_alignments
-        for coordinates in product(
+
+        return start, chunk_shape, start_adjust
+
+    def iter_chunk_starts(
+        self,
+        chunk_shape: VecIntLike,
+        chunk_border_alignments: VecIntLike | None = None,
+    ) -> Iterator[tuple[int, ...]]:
+        """Yield the topleft coordinate of every chunk as a plain int tuple.
+
+        This is a fast, allocation-free variant of `chunk()`: it performs no
+        per-chunk `Vec3Int`/`NDBoundingBox` allocation and does **not** clip the
+        chunks to this box (border chunks are therefore *not* shrunk – the caller
+        can clip/filter cheaply on the raw integers if needed).
+
+        The chunk grid matches `chunk()` exactly (same cells, same order). Without
+        `chunk_border_alignments`, the yielded starts equal the chunk toplefts, i.e.
+        ``list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in self.chunk(cs)]``.
+        With `chunk_border_alignments`, the first grid line on an axis may lie
+        *before* this box's topleft; `chunk()` clips that first chunk's topleft up to
+        the box, whereas this method yields the unclipped grid start.
+
+        Args:
+            chunk_shape (VecIntLike): The size of the chunks to generate.
+            chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
+
+        Yields:
+            tuple[int, ...]: The topleft coordinate of each chunk, in axis order.
+        """
+
+        start, chunk_shape_np, start_adjust = self._normalize_chunk_grid(
+            chunk_shape, chunk_border_alignments
+        )
+
+        # Work on plain python ints so the yielded tuples contain no numpy scalars.
+        starts = start.tolist()
+        sizes = self.size.to_np().tolist()
+        steps = chunk_shape_np.tolist()
+        adjusts = start_adjust.tolist()
+
+        yield from product(
             *[
-                range(
-                    start[i] - start_adjust[i], start[i] + self.size[i], chunk_shape[i]
-                )
+                range(starts[i] - adjusts[i], starts[i] + sizes[i], steps[i])
                 for i in range(len(self.axes))
             ]
-        ):
+        )
+
+    def iter_overlapping_grid_cells(
+        self,
+        chunk_shape: VecIntLike,
+        clip_to: "NDBoundingBox | None" = None,
+    ) -> Iterator[tuple[int, ...]]:
+        """Yield the topleft of every origin-aligned grid cell overlapping this box.
+
+        The grid is aligned to the coordinate origin (cell ``k`` on an axis spans
+        ``[k * cell, (k + 1) * cell)``) and has cell size `chunk_shape`. This differs
+        from `chunk()` / `iter_chunk_starts()`, whose grid is aligned to the box's own
+        topleft.
+
+        Overlap uses half-open intervals: cells that only *touch* this box (or
+        `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
+        allocation-free and yields plain int tuples.
+
+        Args:
+            chunk_shape (VecIntLike): The size of the grid cells.
+            clip_to (NDBoundingBox | None): If given, only cells overlapping both this
+                box and `clip_to` are yielded.
+
+        Yields:
+            tuple[int, ...]: The topleft coordinate of each overlapping grid cell.
+        """
+
+        _, chunk_shape_np, _ = self._normalize_chunk_grid(chunk_shape, None)
+
+        region_start = self.topleft.to_np()
+        region_end = region_start + self.size.to_np()
+        if clip_to is not None:
+            self._check_compatibility(clip_to)
+            region_start = np.maximum(region_start, clip_to.topleft.to_np())
+            region_end = np.minimum(region_end, clip_to.bottomright.to_np())
+
+        starts = region_start.tolist()
+        ends = region_end.tolist()
+        cells = chunk_shape_np.tolist()
+
+        ranges = []
+        for i in range(len(self.axes)):
+            start_i, end_i, cell_i = starts[i], ends[i], cells[i]
+            if start_i >= end_i:
+                # Empty overlap on at least one axis -> no cells at all.
+                return
+            first = start_i // cell_i
+            last = (end_i - 1) // cell_i
+            ranges.append(range(first * cell_i, last * cell_i + 1, cell_i))
+
+        yield from product(*ranges)
+
+    def chunk(
+        self: _T,
+        chunk_shape: VecIntLike,
+        chunk_border_alignments: VecIntLike | None = None,
+    ) -> Generator[_T, None, None]:
+        """
+        Decompose the bounding box into smaller chunks of size `chunk_shape`.
+
+        Chunks at the border of the bounding box might be smaller than chunk_shape.
+        If `chunk_border_alignment` is set, all border coordinates
+        *between two chunks* will be divisible by that value.
+
+        For a fast, allocation-free variant that yields raw integer coordinates
+        instead of `NDBoundingBox` objects, see `iter_chunk_starts()`.
+
+        Args:
+            chunk_shape (VecIntLike): The size of the chunks to generate.
+            chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
+
+
+        Yields:
+            Generator[NDBoundingBox]: A generator of the chunks.
+        """
+
+        _, chunk_shape_np, _ = self._normalize_chunk_grid(
+            chunk_shape, chunk_border_alignments
+        )
+        chunk_size = VecInt(chunk_shape_np, axes=self.axes)
+
+        for coordinates in self.iter_chunk_starts(chunk_shape, chunk_border_alignments):
             yield self.intersected_with(
                 self.__class__(
                     topleft=VecInt(coordinates, axes=self.axes),
-                    size=VecInt(chunk_shape, axes=self.axes),
+                    size=chunk_size,
                     axes=self.axes,
                     index=self.index,
                 )

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -702,22 +702,47 @@ class NDBoundingBox:
     ) -> list[int]:
         """Expand a chunk/cell `shape` to all axes of this bounding box.
 
-        A shape with exactly three entries is interpreted as the xyz shorthand: it is
-        assumed that iteration over xyz is intended, so all other axes get a size of 1
-        – except for the channel axis, which spans all channels if `channels_whole` is
-        set (`chunk()` does this so that every chunk contains all channels). Note that
-        this also applies if the box has no z axis, in which case only its x and y axis
-        take their size from `shape`.
+        A `VecInt` carries its own axis names, so it is matched to this box's axes by
+        name (reordered if necessary) and used verbatim. This is the unambiguous way to
+        specify a shape.
 
-        Any other shape must have one entry per axis and is used verbatim, i.e. the
-        channel axis is not treated specially.
+        A shape without axis names is interpreted by its length: a shape with exactly
+        three entries is the xyz shorthand, i.e. it gives the sizes of the x, y and z
+        axis *by name* (the axes may be in any order) and all other axes get a size of
+        1 – except for the channel axis, which spans all channels if `channels_whole`
+        is set (`chunk()` does this so that every chunk contains all channels). Note
+        that a `Vec3Int` is such a shorthand, since its axes are always ``("x", "y",
+        "z")``. Any other length must match the number of axes and is used verbatim, in
+        axis order.
 
         Returns:
             The expanded shape as a list of ints, in axis order.
+
+        Raises:
+            ValueError: If a shape without axis names is ambiguous, i.e. it has three
+                entries and this box has three axes that are not x, y and z. Pass a
+                `VecInt` with this box's axes to say which axis each entry belongs to.
+            AssertionError: If a shape without axis names has neither three entries nor
+                one entry per axis.
         """
+
+        if isinstance(shape, VecInt):
+            # The shape names its own axes, so there is nothing to interpret.
+            if shape.axes == self.axes:
+                return list(shape)
+            if set(shape.axes) == set(self.axes):
+                return [shape[shape.axes.index(axis)] for axis in self.axes]
 
         shape_list = [int(i) for i in shape]
         if len(shape_list) == 3:
+            if len(self.axes) == 3 and set(self.axes) != {"x", "y", "z"}:
+                raise ValueError(
+                    f"A shape with three entries is ambiguous for a bounding box with "
+                    f"the axes {self.axes}: it could be the xyz shorthand or one entry "
+                    f"per axis. Pass a VecInt with axes={self.axes} instead of "
+                    f"{shape_list}."
+                )
+
             size_x, size_y, size_z = shape_list
             expanded = []
             for i, axis in enumerate(self.axes):
@@ -804,7 +829,9 @@ class NDBoundingBox:
         the box, whereas this method yields the unclipped grid start.
 
         Args:
-            chunk_shape (VecIntLike): The size of the chunks to generate.
+            chunk_shape (VecIntLike): The size of the chunks to generate. Either one
+                entry per axis, or three entries for the sizes of the x, y and z axis
+                (matched by name); a `VecInt` is matched by its own axis names.
             chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
 
         Yields:
@@ -826,23 +853,25 @@ class NDBoundingBox:
         from `chunk()` / `iter_chunk_starts()`, whose grid is aligned to the box's own
         topleft.
 
-        If a 3D `chunk_shape` is given, all non-xyz axes (including a channel axis) use
-        a cell size of 1, i.e. every index on those axes is yielded. Unlike for
-        `chunk()`, the channel axis is *not* collapsed into a single cell, so that the
-        grid only depends on `chunk_shape` and not on this box's own size. A
-        `chunk_shape` with one entry per axis is used verbatim.
+        If the xyz shorthand is used for `chunk_shape`, all non-xyz axes (including a
+        channel axis) use a cell size of 1, i.e. every index on those axes is yielded.
+        Unlike for `chunk()`, the channel axis is *not* collapsed into a single cell, so
+        that the grid only depends on `chunk_shape` and not on this box's own size.
 
         Overlap uses half-open intervals: cells that only *touch* this box (or
         `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
         allocation-free and yields plain int tuples.
 
         Args:
-            chunk_shape (VecIntLike): The size of the grid cells.
+            chunk_shape (VecIntLike): The size of the grid cells. Either one entry per
+                axis, or three entries for the sizes of the x, y and z axis (matched by
+                name); a `VecInt` is matched by its own axis names.
             clip_to (NDBoundingBox | None): If given, only cells overlapping both this
                 box and `clip_to` are yielded. Must have the same axes as this box.
 
         Raises:
-            ValueError: If `clip_to` does not have the same axes as this box.
+            ValueError: If `clip_to` does not have the same axes as this box, or if
+                `chunk_shape` is ambiguous for this box's axes.
 
         Yields:
             tuple[int, ...]: The topleft coordinate of each overlapping grid cell.
@@ -885,7 +914,10 @@ class NDBoundingBox:
         *between two chunks* will be divisible by that value.
 
         Args:
-            chunk_shape (VecIntLike): The size of the chunks to generate.
+            chunk_shape (VecIntLike): The size of the chunks to generate. Either one
+                entry per axis, or three entries for the sizes of the x, y and z axis
+                (matched by name), in which case every chunk spans all channels and a
+                single index of any other axis.
             chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
 
 

--- a/webknossos/webknossos/geometry/nd_bounding_box.py
+++ b/webknossos/webknossos/geometry/nd_bounding_box.py
@@ -699,69 +699,90 @@ class NDBoundingBox:
 
     def _expand_shape_to_axes(
         self, shape: VecIntLike, channels_whole: bool
-    ) -> np.ndarray:
+    ) -> list[int]:
         """Expand a chunk/cell `shape` to all axes of this bounding box.
 
-        A shape with one entry per axis is used verbatim. If a 3D shape is given it is
+        A shape with exactly three entries is interpreted as the xyz shorthand: it is
         assumed that iteration over xyz is intended, so all other axes get a size of 1
         – except for the channel axis, which spans all channels if `channels_whole` is
-        set (`chunk()` does this so that every chunk contains all channels).
+        set (`chunk()` does this so that every chunk contains all channels). Note that
+        this also applies if the box has no z axis, in which case only its x and y axis
+        take their size from `shape`.
+
+        Any other shape must have one entry per axis and is used verbatim, i.e. the
+        channel axis is not treated specially.
 
         Returns:
-            The expanded shape as a numpy array, in axis order.
+            The expanded shape as a list of ints, in axis order.
         """
 
-        try:
-            expanded = VecInt.ones(self.axes).with_xyz(Vec3Int(shape))
-            if channels_whole and "c" in self.axes:
-                expanded = expanded.with_c(self.size.c)
-            return expanded.to_np()
-        except AssertionError:
-            return VecInt(shape, axes=self.axes).to_np()
+        shape_list = [int(i) for i in shape]
+        if len(shape_list) == 3:
+            size_x, size_y, size_z = shape_list
+            expanded = []
+            for i, axis in enumerate(self.axes):
+                if axis == "x":
+                    expanded.append(size_x)
+                elif axis == "y":
+                    expanded.append(size_y)
+                elif axis == "z":
+                    expanded.append(size_z)
+                elif axis == "c" and channels_whole:
+                    expanded.append(self.size[i])
+                else:
+                    expanded.append(1)
+            return expanded
+
+        assert len(shape_list) == len(self.axes), (
+            f"Expected a shape with 3 or {len(self.axes)} entries, got {shape_list}."
+        )
+        return shape_list
 
     def _chunk_grid_ranges(
         self,
         chunk_shape: VecIntLike,
         chunk_border_alignments: VecIntLike | None,
-    ) -> tuple[list[range], np.ndarray]:
+    ) -> tuple[list[range], list[int]]:
         """Compute the chunk grid of `chunk()` / `iter_chunk_starts()`.
 
         This is the shared grid math of both methods, so there is a single source of
-        truth for the chunk start coordinates.
+        truth for the chunk start coordinates. Everything is computed on plain python
+        ints, so that no numpy scalars leak into the yielded coordinates and small
+        boxes don't pay for numpy round-trips.
 
         Returns:
-            A tuple of the per-axis ranges of chunk start coordinates (as plain python
-            ints, so no numpy scalars leak into the yielded coordinates) and the
-            expanded `chunk_shape` as a numpy array.
+            A tuple of the per-axis ranges of chunk start coordinates and the expanded
+            `chunk_shape`.
         """
 
-        start = self.topleft.to_np()
-        chunk_shape_np = self._expand_shape_to_axes(chunk_shape, channels_whole=True)
-
-        start_adjust = VecInt.zeros(self.axes).to_np()
-        if chunk_border_alignments is not None:
-            alignments = self._expand_shape_to_axes(
-                chunk_border_alignments, channels_whole=True
-            )
-
-            assert np.all(chunk_shape_np % alignments == 0), (
-                f"{chunk_shape_np} not divisible by {alignments}"
-            )
-
-            # Move the start to be aligned correctly. This doesn't actually change
-            # the start of the first chunk, because we'll intersect with `self`,
-            # but it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % alignments
-
-        starts = start.tolist()
+        starts = list(self.topleft)
         sizes = list(self.size)
-        steps = chunk_shape_np.tolist()
-        adjusts = start_adjust.tolist()
+        steps = self._expand_shape_to_axes(chunk_shape, channels_whole=True)
 
+        if chunk_border_alignments is None:
+            return [
+                range(start, start + size, step)
+                for start, size, step in zip(starts, sizes, steps, strict=True)
+            ], steps
+
+        alignments = self._expand_shape_to_axes(
+            chunk_border_alignments, channels_whole=True
+        )
+        assert all(
+            step % alignment == 0
+            for step, alignment in zip(steps, alignments, strict=True)
+        ), f"{steps} not divisible by {alignments}"
+
+        # Move the start back to the previous multiple of the alignment, so that all
+        # borders *between* chunks are aligned. The first start may then lie before
+        # this box; `chunk()` intersects it with `self` again, whereas
+        # `iter_chunk_starts()` deliberately yields it unclipped.
         return [
-            range(starts[i] - adjusts[i], starts[i] + sizes[i], steps[i])
-            for i in range(len(self.axes))
-        ], chunk_shape_np
+            range(start - start % alignment, start + size, step)
+            for start, size, step, alignment in zip(
+                starts, sizes, steps, alignments, strict=True
+            )
+        ], steps
 
     def iter_chunk_starts(
         self,
@@ -775,7 +796,7 @@ class NDBoundingBox:
         chunks to this box (border chunks are therefore *not* shrunk – the caller
         can clip/filter cheaply on the raw integers if needed).
 
-        The chunk grid matches `chunk()` exactly (same cells, same order). Without
+        `chunk()` shares the same grid (same cells, same order). Without
         `chunk_border_alignments`, the yielded starts equal the chunk toplefts, i.e.
         ``list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in self.chunk(cs)]``.
         With `chunk_border_alignments`, the first grid line on an axis may lie
@@ -808,7 +829,8 @@ class NDBoundingBox:
         If a 3D `chunk_shape` is given, all non-xyz axes (including a channel axis) use
         a cell size of 1, i.e. every index on those axes is yielded. Unlike for
         `chunk()`, the channel axis is *not* collapsed into a single cell, so that the
-        grid only depends on `chunk_shape` and not on this box's own size.
+        grid only depends on `chunk_shape` and not on this box's own size. A
+        `chunk_shape` with one entry per axis is used verbatim.
 
         Overlap uses half-open intervals: cells that only *touch* this box (or
         `clip_to`) at a border are not returned. Like `iter_chunk_starts()`, this is
@@ -826,28 +848,27 @@ class NDBoundingBox:
             tuple[int, ...]: The topleft coordinate of each overlapping grid cell.
         """
 
-        chunk_shape_np = self._expand_shape_to_axes(chunk_shape, channels_whole=False)
+        cells = self._expand_shape_to_axes(chunk_shape, channels_whole=False)
 
-        region_start = self.topleft.to_np()
-        region_end = region_start + self.size.to_np()
+        starts = list(self.topleft)
+        ends = list(self.bottomright)
         if clip_to is not None:
             self._check_compatibility(clip_to)
-            region_start = np.maximum(region_start, clip_to.topleft.to_np())
-            region_end = np.minimum(region_end, clip_to.bottomright.to_np())
-
-        starts = region_start.tolist()
-        ends = region_end.tolist()
-        cells = chunk_shape_np.tolist()
+            starts = [
+                max(start, clip_start)
+                for start, clip_start in zip(starts, clip_to.topleft, strict=True)
+            ]
+            ends = [
+                min(end, clip_end)
+                for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
+            ]
 
         ranges = []
-        for i in range(len(self.axes)):
-            start_i, end_i, cell_i = starts[i], ends[i], cells[i]
-            if start_i >= end_i:
+        for start, end, cell in zip(starts, ends, cells, strict=True):
+            if start >= end:
                 # Empty overlap on at least one axis -> no cells at all.
                 return
-            first = start_i // cell_i
-            last = (end_i - 1) // cell_i
-            ranges.append(range(first * cell_i, last * cell_i + 1, cell_i))
+            ranges.append(range((start // cell) * cell, end, cell))
 
         yield from product(*ranges)
 
@@ -863,9 +884,6 @@ class NDBoundingBox:
         If `chunk_border_alignment` is set, all border coordinates
         *between two chunks* will be divisible by that value.
 
-        For a fast, allocation-free variant that yields raw integer coordinates
-        instead of `NDBoundingBox` objects, see `iter_chunk_starts()`.
-
         Args:
             chunk_shape (VecIntLike): The size of the chunks to generate.
             chunk_border_alignments (VecIntLike | None): The alignment of the chunk borders.
@@ -875,10 +893,10 @@ class NDBoundingBox:
             Generator[NDBoundingBox]: A generator of the chunks.
         """
 
-        ranges, chunk_shape_np = self._chunk_grid_ranges(
+        ranges, expanded_chunk_shape = self._chunk_grid_ranges(
             chunk_shape, chunk_border_alignments
         )
-        chunk_size = VecInt(chunk_shape_np, axes=self.axes)
+        chunk_size = VecInt(expanded_chunk_shape, axes=self.axes)
 
         for coordinates in product(*ranges):
             yield self.intersected_with(


### PR DESCRIPTION
### Description:
- the old `BoundingBox.chunk(...)` implementation allocated BoundingBox objects for all result chunks which led to a lot of overhead due to object creation e.g. when creating chunks in a tight loop
- the new code provides an implementation which works only on and returns lightweight integer tuples, skipping heavy allocations -> often, callers who require the speedup and are fine with not getting full BoundingBox objects back ->  required for https://github.com/scalableminds/voxelytics/pull/4673
- internal, the implementation of `chunk(...)` now also uses the lightweight method to compute the chunk positions, before allocating BoundingBox object for them
- slightly clarified/changed behavior on how to chunk nd-bounding-boxes depending on axes names to prevent unexpected corner cases allowed by the old code (see below)

### Changed behavior: how a `chunk_shape` is mapped to the box axes

A `chunk_shape` is now resolved in three tiers:

1. a `VecInt` **with axis names** is matched to the box's axes by name (reordered if needed) and used verbatim — the unambiguous form
2. **three unnamed entries** (tuple or `Vec3Int`) are the xyz shorthand: sizes for x, y and z **by name**, all other axes get size 1, except that `chunk()` lets the channel axis span all channels
3. **one entry per axis** is used verbatim

Mapping by name matters: a `("z", "y", "x")` box (zarr/NGFF order) chunked with `(8, 16, 32)` must give chunks of size `(32, 16, 8)`. All existing call sites pass a `Vec3Int`, so they stay on tier 2 — verified by diffing full `chunk()` output against master for 7 box layouts × 3 shapes × 2 alignments (63/63 identical, according to Claude).

**Edge case (behavior change):** for a box with exactly three axes that are *not* x, y and z, three unnamed entries fit both tier 2 and tier 3. Previously the third entry was silently dropped:

```python
bbox = NDBoundingBox(topleft=(10, 20, 5), size=(30, 30, 30), axes=("x", "y", "t"))
bbox.chunk((16, 16, 16))
# before: 120 chunks of size (16, 16, 1) — the 16 for t is ignored, t steps by 1
# now:    ValueError, pass VecInt(16, 16, 16, axes=("x", "y", "t")) to step t by 16
```

Boxes with four or more axes are unambiguous and unchanged, and nothing in the library builds a three-non-xyz-axis box.

### Todos:
 - [x] Updated Changelog
 - [x] Added / Updated Tests
