### PR TITLE
Support segment statistics artifact

### DIFF
--- a/docs/src/webknossos-py/spec/datasource_properties.md
+++ b/docs/src/webknossos-py/spec/datasource_properties.md
@@ -231,6 +231,7 @@ References to auxiliary data files for a segmentation layer.
 | `meshes` | Array of [AttachmentProperties](#attachmentproperties) | No | `null` | Precomputed mesh files. |
 | `agglomerates` | Array of [AttachmentProperties](#attachmentproperties) | No | `null` | Agglomerate mapping files. |
 | `segmentIndex` | [AttachmentProperties](#attachmentproperties) | No | `null` | Segment index file. |
+| `segmentStatistics` | [AttachmentProperties](#attachmentproperties) | No | `null` | Segment statistics file. |
 | `cumsum` | [AttachmentProperties](#attachmentproperties) | No | `null` | Cumulative sum file. |
 | `connectomes` | Array of [AttachmentProperties](#attachmentproperties) | No | `null` | Connectome files. |
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,8 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
-- Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
-
+- Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm). [#1474](https://github.com/scalableminds/webknossos-libs/pull/1474)
+- Added support for the new attachment type `SegmentStatisticsAttachment` for segmentation layers. [#1490](https://github.com/scalableminds/webknossos-libs/pull/1490)
 
 ### Changed
 

--- a/webknossos/tests/dataset/test_attachments.py
+++ b/webknossos/tests/dataset/test_attachments.py
@@ -15,6 +15,7 @@ from webknossos import (
     MeshAttachment,
     SegmentationLayer,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
 )
 from webknossos.geometry import BoundingBox
 
@@ -107,6 +108,24 @@ def test_attachments(tmp_upath: UPath) -> None:
         == AttachmentDataFormat.HDF5
     )
 
+    # segment statistics
+    seg_layer.attachments.add_attachment_as_ref(
+        SegmentStatisticsAttachment.from_path_and_name(
+            dataset.path / "seg" / "segment_statistics.zarr",
+            name="main",
+            data_format=AttachmentDataFormat.Zarr3,
+        )
+    )
+    assert seg_layer._properties.attachments.segment_statistics is not None
+    assert (
+        seg_layer._properties.attachments.segment_statistics.path
+        == "./seg/segment_statistics.zarr"
+    )
+    assert (
+        seg_layer._properties.attachments.segment_statistics.data_format
+        == AttachmentDataFormat.Zarr3
+    )
+
     # cumsum
     seg_layer.attachments.add_attachment_as_ref(
         CumsumAttachment.from_path_and_name(
@@ -135,6 +154,7 @@ def test_attachments(tmp_upath: UPath) -> None:
     assert len(attachments_json["agglomerates"]) == 1
     assert len(attachments_json["connectomes"]) == 1
     assert attachments_json["segmentIndex"] is not None
+    assert attachments_json["segmentStatistics"] is not None
     assert attachments_json["cumsum"] is not None
 
     # delete
@@ -146,6 +166,8 @@ def test_attachments(tmp_upath: UPath) -> None:
     assert seg_layer._properties.attachments.connectomes is None
     seg_layer.attachments.delete_attachment(seg_layer.attachments.segment_index)
     assert seg_layer._properties.attachments.segment_index is None
+    seg_layer.attachments.delete_attachment(seg_layer.attachments.segment_statistics)
+    assert seg_layer._properties.attachments.segment_statistics is None
     seg_layer.attachments.delete_attachment(seg_layer.attachments.cumsum)
     assert seg_layer._properties.attachments.cumsum is None
 
@@ -411,6 +433,22 @@ def test_add_copy_attachments(tmp_upath: UPath) -> None:
         == "./seg/segmentIndex/main"
     )
 
+    # segment statistics (has camel-casing)
+    segment_statistics_path = tmp_upath / "segment_statistics"
+    segment_statistics_path.write_text("test")
+
+    segment_statistics = SegmentStatisticsAttachment.from_path_and_name(
+        segment_statistics_path,
+        "main",
+        data_format=AttachmentDataFormat.Zarr3,
+    )
+    seg_layer.attachments.add_attachment_as_copy(segment_statistics)
+    assert seg_layer._properties.attachments.segment_statistics is not None
+    assert (
+        seg_layer._properties.attachments.segment_statistics.path
+        == "./seg/segmentStatistics/main"
+    )
+
 
 def test_add_symlink_attachments(tmp_upath: UPath) -> None:
     dataset, seg_layer = make_dataset(tmp_upath)
@@ -455,6 +493,28 @@ def test_add_symlink_attachments(tmp_upath: UPath) -> None:
     assert (
         dataset.path / "seg" / "segmentIndex" / "main"
     ).resolve() == segment_index_path
+
+    # segment statistics (has camel-casing)
+    segment_statistics_path = tmp_upath / "segment_statistics"
+    segment_statistics_path.write_text("test")
+
+    segment_statistics = SegmentStatisticsAttachment.from_path_and_name(
+        segment_statistics_path,
+        "main",
+        data_format=AttachmentDataFormat.Zarr3,
+    )
+    with pytest.warns(DeprecationWarning):
+        seg_layer.attachments.add_symlink_attachments(segment_statistics)
+    assert seg_layer._properties.attachments.segment_statistics is not None
+    assert (
+        seg_layer._properties.attachments.segment_statistics.path
+        == segment_statistics_path.as_posix()
+    )
+    assert (dataset.path / "seg" / "segmentStatistics" / "main").exists()
+    assert (dataset.path / "seg" / "segmentStatistics" / "main").is_symlink()
+    assert (
+        dataset.path / "seg" / "segmentStatistics" / "main"
+    ).resolve() == segment_statistics_path
 
 
 def test_deprecated_add_methods(tmp_upath: UPath) -> None:

--- a/webknossos/webknossos/dataset/__init__.py
+++ b/webknossos/webknossos/dataset/__init__.py
@@ -23,6 +23,7 @@ from .layer import (
     RemoteSegmentationLayer,
     SegmentationLayer,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
     View,
 )
 from .remote_dataset import RemoteAccessMode, RemoteDataset, StorageCredentials

--- a/webknossos/webknossos/dataset/layer/__init__.py
+++ b/webknossos/webknossos/dataset/layer/__init__.py
@@ -16,6 +16,7 @@ from .segmentation_layer import (
     RemoteSegmentationLayer,
     SegmentationLayer,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
 )
 from .view import (
     ArrayException,

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/__init__.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/__init__.py
@@ -10,6 +10,7 @@ from .attachments import (
     MeshAttachment,
     RemoteAttachments,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
 )
 from .remote_segmentation_layer import RemoteSegmentationLayer
 from .segmentation_layer import SegmentationLayer

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/__init__.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/__init__.py
@@ -6,5 +6,6 @@ from .attachment import (
     CumsumAttachment,
     MeshAttachment,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
 )
 from .attachments import AbstractAttachments, Attachments, RemoteAttachments

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
@@ -110,6 +110,12 @@ class SegmentIndexAttachment(Attachment):
     type_name = "segmentIndex"
 
 
+class SegmentStatisticsAttachment(Attachment):
+    data_format: Literal[AttachmentDataFormat.Zarr3]
+    container_name = "segment_statistics"
+    type_name = "segmentStatistics"
+
+
 class CumsumAttachment(Attachment):
     data_format: Literal[AttachmentDataFormat.Zarr3, AttachmentDataFormat.JSON]
     container_name = "cumsum"

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
@@ -38,13 +38,25 @@ class Attachment:
     path: UPath
     data_format: AttachmentDataFormat
     container_name: Literal[
-        "agglomerates", "meshes", "segment_index", "cumsum", "connectomes"
+        "agglomerates",
+        "meshes",
+        "segment_index",
+        "segment_statistics",
+        "cumsum",
+        "connectomes",
     ]
     """
     The container names are also used to derive the folder names to put the attachments.
     The container names are converted to camelCase to get the folder names.
     """
-    type_name: Literal["mesh", "agglomerate", "segmentIndex", "connectome", "cumsum"]
+    type_name: Literal[
+        "mesh",
+        "agglomerate",
+        "segmentIndex",
+        "segmentStatistics",
+        "connectome",
+        "cumsum",
+    ]
     """
     The type names are used to communicate to WEBKNOSSOS which attachment type we want to e.g. upload.
     """

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachments.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachments.py
@@ -25,6 +25,7 @@ from .attachment import (
     CumsumAttachment,
     MeshAttachment,
     SegmentIndexAttachment,
+    SegmentStatisticsAttachment,
     _validate_name,
 )
 
@@ -51,9 +52,10 @@ def _assert_absolute_path(path: str | PathLike | UPath) -> UPath:
 
 def _is_singleton_attachment(
     attachment: Attachment,
-) -> TypeGuard[CumsumAttachment | SegmentIndexAttachment]:
-    return isinstance(attachment, CumsumAttachment) or isinstance(
-        attachment, SegmentIndexAttachment
+) -> TypeGuard[CumsumAttachment | SegmentIndexAttachment | SegmentStatisticsAttachment]:
+    return isinstance(
+        attachment,
+        (CumsumAttachment, SegmentIndexAttachment, SegmentStatisticsAttachment),
     )
 
 
@@ -115,6 +117,18 @@ class AbstractAttachments:
         )
 
     @property
+    def segment_statistics(self) -> SegmentStatisticsAttachment | None:
+        if self._properties.segment_statistics is None:
+            return None
+        return SegmentStatisticsAttachment(
+            self._properties.segment_statistics,
+            enrich_path(
+                self._properties.segment_statistics.path,
+                self._get_optional_dataset_path(),
+            ),
+        )
+
+    @property
     def cumsum(self) -> CumsumAttachment | None:
         if self._properties.cumsum is None:
             return None
@@ -164,6 +178,7 @@ class AbstractAttachments:
             and (len(self.agglomerates) == 0)
             and (len(self.connectomes) == 0)
             and (self.segment_index is None)
+            and (self.segment_statistics is None)
             and (self.cumsum is None)
         )
 
@@ -172,6 +187,8 @@ class AbstractAttachments:
         yield from (self.agglomerates or [])
         if self.segment_index is not None:
             yield self.segment_index
+        if self.segment_statistics is not None:
+            yield self.segment_statistics
         if self.cumsum is not None:
             yield self.cumsum
         yield from (self.connectomes or [])

--- a/webknossos/webknossos/dataset_properties/dataset_properties.py
+++ b/webknossos/webknossos/dataset_properties/dataset_properties.py
@@ -119,6 +119,7 @@ class AttachmentsProperties:
     meshes: list[AttachmentProperties] | None = None
     agglomerates: list[AttachmentProperties] | None = None
     segment_index: AttachmentProperties | None = None
+    segment_statistics: AttachmentProperties | None = None
     cumsum: AttachmentProperties | None = None
     connectomes: list[AttachmentProperties] | None = None
 
@@ -129,6 +130,8 @@ class AttachmentsProperties:
             yield attachment
         if self.segment_index is not None:
             yield self.segment_index
+        if self.segment_statistics is not None:
+            yield self.segment_statistics
         if self.cumsum is not None:
             yield self.cumsum
         for attachment in self.connectomes or []:


### PR DESCRIPTION
### Description:
- Allow adding and accessing new zarr3-based `SegmentStatisticsAttachment` for segmentation layers. Does not actually access its content.
- Corresponding webknossos PR https://github.com/scalableminds/webknossos/pull/9772

### Issues:
- contributes to https://github.com/scalableminds/webknossos/issues/9748

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
