### PR TITLE
Restore lexicographic ordering for VecInt and Vec3Int

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -22,7 +22,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
-- Restored the ordering of `VecInt` and `Vec3Int`, which was lost when they stopped subclassing `tuple` in [#1419](https://github.com/scalableminds/webknossos-libs/pull/1419). `sorted()` over vectors, and `Tree.__eq__` / `sorted(tree.nodes)` for any tree whose nodes differ in position, raised `TypeError: '<' not supported`. Vectors are ordered lexicographically again, matching the equivalent plain tuples. [#1492](https://github.com/scalableminds/webknossos-libs/pull/1492)
+- Restored the ordering of `VecInt` and `Vec3Int`, which was lost when they stopped subclassing `tuple` in [#1419](https://github.com/scalableminds/webknossos-libs/pull/1419). `sorted()` over vectors, and `Tree.__eq__` / `sorted(tree.nodes)` for any tree whose nodes differ in position, raised `TypeError: '<' not supported`. Vectors are ordered lexicographically again, matching the equivalent plain tuples. [#1493](https://github.com/scalableminds/webknossos-libs/pull/1493)
 - Fixed a storage leak where downloading annotations and editing volume layers wrote zip data to temporary files on disk instead of keeping it in memory. [#1485](https://github.com/scalableminds/webknossos-libs/pull/1485)
 
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Restored the ordering of `VecInt` and `Vec3Int`, which was lost when they stopped subclassing `tuple` in [#1419](https://github.com/scalableminds/webknossos-libs/pull/1419). `sorted()` over vectors, and `Tree.__eq__` / `sorted(tree.nodes)` for any tree whose nodes differ in position, raised `TypeError: '<' not supported`. Vectors are ordered lexicographically again, matching the equivalent plain tuples. [#1492](https://github.com/scalableminds/webknossos-libs/pull/1492)
 - Fixed a storage leak where downloading annotations and editing volume layers wrote zip data to temporary files on disk instead of keeping it in memory. [#1485](https://github.com/scalableminds/webknossos-libs/pull/1485)
 
 

--- a/webknossos/tests/geometry/test_vec3_int.py
+++ b/webknossos/tests/geometry/test_vec3_int.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from webknossos.geometry import Mag, Vec3Int
 
@@ -81,3 +82,24 @@ def test_custom_initialization() -> None:
 
     assert Vec3Int.ones() - Vec3Int.ones() == Vec3Int.zeros()
     assert Vec3Int.full(4) == Vec3Int.ones() * 4
+
+
+def test_ordering() -> None:
+    """Vectors are ordered lexicographically, like the equivalent plain tuples."""
+    assert Vec3Int(1, 2, 3) < Vec3Int(1, 2, 4)
+    assert Vec3Int(1, 2, 4) > Vec3Int(1, 2, 3)
+    assert Vec3Int(1, 2, 3) <= Vec3Int(1, 2, 3)
+    assert Vec3Int(1, 2, 3) >= Vec3Int(1, 2, 3)
+    assert not Vec3Int(2, 0, 0) < Vec3Int(1, 9, 9)
+
+    # Ordering against plain tuples works in both directions, as for `==`
+    assert Vec3Int(1, 2, 3) < (1, 2, 4)
+    assert (1, 2, 3) < Vec3Int(1, 2, 4)
+
+    # Sorting matches what the equivalent tuples would do
+    vectors = [Vec3Int(5, 5, 5), Vec3Int(0, 0, 0), Vec3Int(1, 9, 9)]
+    assert sorted(vectors) == sorted(v.to_tuple() for v in vectors)
+
+    # Incomparable types still raise rather than comparing by identity
+    with pytest.raises(TypeError):
+        Vec3Int(1, 2, 3) < "abc"  # type: ignore[operator]

--- a/webknossos/tests/geometry/test_vec_int.py
+++ b/webknossos/tests/geometry/test_vec_int.py
@@ -117,3 +117,12 @@ def test_new_axes() -> None:
     old = VecInt(1, 2, 3, 4, axes=("unset_0", "unset_1", "unset_2", "unset_3"))
     new = VecInt(1, 2, 3, 4, axes=("x", "y", "z", "t"))
     assert VecInt(old, axes=("x", "y", "z", "t")) == new
+
+
+def test_ordering() -> None:
+    """N-dimensional vectors are ordered lexicographically, like plain tuples."""
+    axes = ("x", "y", "z", "t")
+    assert VecInt(1, 2, 3, 4, axes=axes) < VecInt(1, 2, 3, 5, axes=axes)
+    assert VecInt(1, 2, 3, 5, axes=axes) > VecInt(1, 2, 3, 4, axes=axes)
+    assert VecInt(1, 2, 3, 4, axes=axes) <= VecInt(1, 2, 3, 4, axes=axes)
+    assert VecInt(1, 2, 3, 4, axes=axes) < (1, 2, 3, 5)

--- a/webknossos/webknossos/geometry/vec_int.py
+++ b/webknossos/webknossos/geometry/vec_int.py
@@ -146,6 +146,39 @@ class VecInt(Sequence[int]):
             return self._data == other
         return NotImplemented
 
+    def _comparable_data(self, other: object) -> tuple[int, ...] | None:
+        """Returns the data of `other` to compare against, or None if it is not comparable."""
+        if isinstance(other, VecInt):
+            return other._data
+        if isinstance(other, tuple):
+            return other
+        return None
+
+    # The vectors are ordered lexicographically, just like the equivalent plain tuples.
+    def __lt__(self, other: object) -> bool:
+        other_data = self._comparable_data(other)
+        if other_data is None:
+            return NotImplemented
+        return self._data < other_data
+
+    def __le__(self, other: object) -> bool:
+        other_data = self._comparable_data(other)
+        if other_data is None:
+            return NotImplemented
+        return self._data <= other_data
+
+    def __gt__(self, other: object) -> bool:
+        other_data = self._comparable_data(other)
+        if other_data is None:
+            return NotImplemented
+        return self._data > other_data
+
+    def __ge__(self, other: object) -> bool:
+        other_data = self._comparable_data(other)
+        if other_data is None:
+            return NotImplemented
+        return self._data >= other_data
+
     def __contains__(self, item: object) -> bool:
         return item in self._data
 


### PR DESCRIPTION
### Description:
This came up during #1491.

- `VecInt` subclassed `tuple` until #1419 changed it to `Sequence[int]` over an internal `_data` tuple. Ordering had been inherited from `tuple` and was silently lost, so `<` fell back to `object`'s default and raised.
- The blast radius is wider than sorting vectors directly. `Node` is `@attr.define(order=True)` with `position` as its first ordered field, so **`sorted(tree.nodes)` and `Tree.__eq__` raise `TypeError` for any tree whose nodes differ in position** — i.e. essentially every real tree.

```python
>>> tree == tree
TypeError: '<' not supported between instances of 'Vec3Int' and 'Vec3Int'
```

- The four comparison operators now compare the underlying tuples, and accept plain tuples on either side just as `__eq__` already did.

### Issues:
- fixes #...

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests