### PR TITLE
Add BoundingBox.iter_chunk_toplefts() (allocation-free chunking, with clip_to)

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 - Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
-- Added `BoundingBox.iter_overlapping_grid_cells()` to cheaply iterate the topleft coordinates of all origin-aligned grid cells overlapping a bounding box (optionally clipped to another box).
+- Added `BoundingBox.iter_chunk_starts()`, a fast, allocation-free variant of `BoundingBox.chunk()` that yields chunk toplefts as plain int tuples instead of `BoundingBox` instances, and accepts an optional `clip_to` bounding box. Passing `chunk_border_alignments=chunk_shape` makes it iterate the origin-aligned grid cells overlapping the box.
 
 
 ### Changed

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 - Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
-- Added `BoundingBox.iter_overlapping_grid_cells()` to cheaply iterate the topleft coordinates of all origin-aligned grid cells overlapping a bounding box (optionally clipped to another box), without allocating a `BoundingBox` per cell.
+- Added `BoundingBox.iter_overlapping_grid_cells()` to cheaply iterate the topleft coordinates of all origin-aligned grid cells overlapping a bounding box (optionally clipped to another box).
 
 
 ### Changed

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 - Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
+- Added `BoundingBox.iter_overlapping_grid_cells()` to cheaply iterate the topleft coordinates of all origin-aligned grid cells overlapping a bounding box (optionally clipped to another box), without allocating a `BoundingBox` per cell.
 
 
 ### Changed

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 - Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
-- Added `BoundingBox.iter_chunk_toplefts()`, a fast, allocation-free variant of `BoundingBox.chunk()` that yields chunk toplefts as plain int tuples instead of `BoundingBox` instances, and accepts an optional `clip_to` bounding box. Passing `chunk_border_alignments=chunk_shape` makes it iterate the origin-aligned grid cells overlapping the box.
+- Added `BoundingBox.iter_chunk_toplefts()`, a fast, allocation-free variant of `BoundingBox.chunk()` that yields chunk toplefts as plain int tuples instead of `BoundingBox` instances, and accepts an optional `clip_to` bounding box. [#1494](https://github.com/scalableminds/webknossos-libs/pull/1494)
 
 
 ### Changed

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added `RemoteDataset.delete()` to enable deletion of remote datasets via the libs. [#1484](https://github.com/scalableminds/webknossos-libs/pull/1484)
 - Added a `transform` function to resample a layer's data into another layer using either a forward `AbstractTransform` such as `AffineTransform` or an arbitrary inverse coordinate transform callable, with support for parallel processing via cluster_tools executors (e.g. multiprocessing, slurm).
-- Added `BoundingBox.iter_chunk_starts()`, a fast, allocation-free variant of `BoundingBox.chunk()` that yields chunk toplefts as plain int tuples instead of `BoundingBox` instances, and accepts an optional `clip_to` bounding box. Passing `chunk_border_alignments=chunk_shape` makes it iterate the origin-aligned grid cells overlapping the box.
+- Added `BoundingBox.iter_chunk_toplefts()`, a fast, allocation-free variant of `BoundingBox.chunk()` that yields chunk toplefts as plain int tuples instead of `BoundingBox` instances, and accepts an optional `clip_to` bounding box. Passing `chunk_border_alignments=chunk_shape` makes it iterate the origin-aligned grid cells overlapping the box.
 
 
 ### Changed

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -259,7 +259,9 @@ def test_iter_chunk_toplefts(
     bbox = BoundingBox(topleft, size)
     starts = list(bbox.iter_chunk_toplefts(chunk_shape, alignment))
 
-    assert starts == expected
+    assert starts == expected, (
+        f"iter_chunk_toplefts with chunk_shape for bbox {bbox} with chunk_shape {chunk_shape} and alignment {alignment} should give {expected} but gave {starts}"
+    )
     # Yielded values are plain python int tuples (no numpy scalars).
     assert all(type(v) is int for start in starts for v in start)
     if alignment is None:
@@ -326,4 +328,6 @@ def test_iter_chunk_toplefts_as_origin_aligned_grid_cells_with_clip_to() -> None
     ]
 
     bbox = BoundingBox((200, 200, 200), (10, 10, 10))
-    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []
+    assert (
+        list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []
+    )

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -196,3 +196,49 @@ def test_contains_bbox_with_normalized_bbox() -> None:
     # NormalizedBoundingBox.contains_bbox(BoundingBox)
     assert outer_normalized.contains_bbox(inner)
     assert not outer_normalized.contains_bbox(not_contained)
+
+
+def test_iter_overlapping_grid_cells() -> None:
+    # Box [10, 50) on every axis overlaps origin-aligned 32-grid cells 0 and 32.
+    bbox = BoundingBox((10, 10, 10), (40, 40, 40))
+    cells = list(bbox.iter_overlapping_grid_cells((32, 32, 32)))
+    assert all(type(v) is int for cell in cells for v in cell)
+    assert cells == [(x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)]
+
+
+def test_iter_overlapping_grid_cells_touching_border_excluded() -> None:
+    # Box exactly spanning one grid cell [32, 64) only overlaps that single cell;
+    # neighbouring cells that merely touch its borders are excluded (half-open).
+    bbox = BoundingBox((32, 32, 32), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [(32, 32, 32)]
+
+
+def test_iter_overlapping_grid_cells_non_origin_aligned() -> None:
+    # Box [1, 33) crosses the grid line at 32, so it overlaps cells 0 and 32.
+    bbox = BoundingBox((1, 1, 1), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+
+def test_iter_overlapping_grid_cells_clip_to() -> None:
+    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+
+def test_iter_overlapping_grid_cells_outside_clip_is_empty() -> None:
+    bbox = BoundingBox((200, 200, 200), (10, 10, 10))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == []
+
+
+def test_iter_overlapping_grid_cells_negative_coordinates() -> None:
+    # Box [-33, -1) crosses the grid lines at -32 and 0, so it overlaps the cells
+    # starting at -64 and -32 (the grid is aligned to the origin, not to the box).
+    bbox = BoundingBox((-33, -33, -33), (32, 32, 32))
+    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+        (x, y, z) for x in (-64, -32) for y in (-64, -32) for z in (-64, -32)
+    ]

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -198,47 +198,132 @@ def test_contains_bbox_with_normalized_bbox() -> None:
     assert not outer_normalized.contains_bbox(not_contained)
 
 
-def test_iter_overlapping_grid_cells() -> None:
+@pytest.mark.parametrize(
+    "topleft, size, chunk_shape, alignment, expected",
+    [
+        # Grid is aligned to the box topleft, ordered x-major, z-minor.
+        (
+            (0, 0, 0),
+            (20, 20, 20),
+            (16, 16, 16),
+            None,
+            [(x, y, z) for x in (0, 16) for y in (0, 16) for z in (0, 16)],
+        ),
+        # Unaligned topleft: starts are offset by the topleft, the last chunk of each
+        # axis sticks out of the box (starts are not clipped).
+        (
+            (5, 7, 9),
+            (20, 20, 20),
+            (16, 16, 16),
+            None,
+            [(x, y, z) for x in (5, 21) for y in (7, 23) for z in (9, 25)],
+        ),
+        # Chunk shape larger than the box -> exactly one chunk at the box topleft.
+        ((7, 3, 1), (5, 5, 5), (10, 10, 10), None, [(7, 3, 1)]),
+        # Negative coordinates.
+        (
+            (-33, -1, -64),
+            (40, 40, 40),
+            (32, 32, 32),
+            None,
+            [(x, y, z) for x in (-33, -1) for y in (-1, 31) for z in (-64, -32)],
+        ),
+        # With alignment the first start is moved back to the previous multiple of the
+        # alignment (topleft 10 -> 0 for alignment 16), so all borders between chunks
+        # are multiples of the alignment.
+        (
+            (10, 10, 10),
+            (60, 60, 60),
+            (32, 32, 32),
+            (16, 16, 16),
+            [(x, y, z) for x in (0, 32, 64) for y in (0, 32, 64) for z in (0, 32, 64)],
+        ),
+        # Per-axis alignment with negative coordinates: -5 % 8 == 3 -> -8,
+        # 3 % 4 == 3 -> 0, -7 % 2 == 1 -> -8.
+        (
+            (-5, 3, -7),
+            (20, 10, 10),
+            (16, 8, 4),
+            (8, 4, 2),
+            [(x, y, z) for x in (-8, 8) for y in (0, 8) for z in (-8, -4, 0)],
+        ),
+    ],
+)
+def test_iter_chunk_starts(
+    topleft: tuple[int, int, int],
+    size: tuple[int, int, int],
+    chunk_shape: tuple[int, int, int],
+    alignment: tuple[int, int, int] | None,
+    expected: list[tuple[int, int, int]],
+) -> None:
+    bbox = BoundingBox(topleft, size)
+    starts = list(bbox.iter_chunk_starts(chunk_shape, alignment))
+
+    assert starts == expected
+    # Yielded values are plain python int tuples (no numpy scalars).
+    assert all(type(v) is int for start in starts for v in start)
+    if alignment is None:
+        # Without chunk_border_alignments, `chunk()` shares the exact same grid.
+        assert starts == [tuple(c.topleft) for c in bbox.chunk(chunk_shape, alignment)]
+
+
+def test_iter_chunk_starts_alignment_divisibility_assertion() -> None:
+    bbox = BoundingBox((0, 0, 0), (10, 10, 10))
+    with pytest.raises(AssertionError):
+        list(bbox.iter_chunk_starts((32, 32, 32), (7, 7, 7)))
+
+
+def test_iter_chunk_starts_clip_to() -> None:
+    # Without chunk_border_alignments, clip_to just restricts which of the box's own
+    # (topleft-aligned) chunk starts are yielded.
+    bbox = BoundingBox((0, 0, 0), (100, 100, 100))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_chunk_starts((32, 32, 32), clip_to=clip)) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+
+def test_iter_chunk_starts_clip_to_outside_is_empty() -> None:
+    bbox = BoundingBox((200, 200, 200), (10, 10, 10))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_chunk_starts((32, 32, 32), clip_to=clip)) == []
+
+
+def test_iter_chunk_starts_as_origin_aligned_grid_cells() -> None:
+    # Passing chunk_border_alignments=chunk_shape makes the grid aligned to the
+    # coordinate origin instead of to the box's own topleft, which is useful to
+    # iterate the grid cells of an origin-aligned partitioning that overlap this box.
+
     # Box [10, 50) on every axis overlaps origin-aligned 32-grid cells 0 and 32.
     bbox = BoundingBox((10, 10, 10), (40, 40, 40))
-    cells = list(bbox.iter_overlapping_grid_cells((32, 32, 32)))
-    assert all(type(v) is int for cell in cells for v in cell)
+    cells = list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32)))
     assert cells == [(x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)]
 
-
-def test_iter_overlapping_grid_cells_touching_border_excluded() -> None:
     # Box exactly spanning one grid cell [32, 64) only overlaps that single cell;
     # neighbouring cells that merely touch its borders are excluded (half-open).
     bbox = BoundingBox((32, 32, 32), (32, 32, 32))
-    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [(32, 32, 32)]
+    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [(32, 32, 32)]
 
-
-def test_iter_overlapping_grid_cells_non_origin_aligned() -> None:
     # Box [1, 33) crosses the grid line at 32, so it overlaps cells 0 and 32.
     bbox = BoundingBox((1, 1, 1), (32, 32, 32))
-    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [
         (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
     ]
 
-
-def test_iter_overlapping_grid_cells_clip_to() -> None:
-    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
-    clip = BoundingBox((0, 0, 0), (40, 40, 40))
-    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == [
-        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
-    ]
-
-
-def test_iter_overlapping_grid_cells_outside_clip_is_empty() -> None:
-    bbox = BoundingBox((200, 200, 200), (10, 10, 10))
-    clip = BoundingBox((0, 0, 0), (40, 40, 40))
-    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32), clip_to=clip)) == []
-
-
-def test_iter_overlapping_grid_cells_negative_coordinates() -> None:
     # Box [-33, -1) crosses the grid lines at -32 and 0, so it overlaps the cells
     # starting at -64 and -32 (the grid is aligned to the origin, not to the box).
     bbox = BoundingBox((-33, -33, -33), (32, 32, 32))
-    assert list(bbox.iter_overlapping_grid_cells((32, 32, 32))) == [
+    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [
         (x, y, z) for x in (-64, -32) for y in (-64, -32) for z in (-64, -32)
     ]
+
+
+def test_iter_chunk_starts_as_origin_aligned_grid_cells_with_clip_to() -> None:
+    bbox = BoundingBox((10, 10, 10), (100, 100, 100))
+    clip = BoundingBox((0, 0, 0), (40, 40, 40))
+    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32), clip_to=clip)) == [
+        (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
+    ]
+
+    bbox = BoundingBox((200, 200, 200), (10, 10, 10))
+    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -249,7 +249,7 @@ def test_contains_bbox_with_normalized_bbox() -> None:
         ),
     ],
 )
-def test_iter_chunk_starts(
+def test_iter_chunk_toplefts(
     topleft: tuple[int, int, int],
     size: tuple[int, int, int],
     chunk_shape: tuple[int, int, int],
@@ -257,7 +257,7 @@ def test_iter_chunk_starts(
     expected: list[tuple[int, int, int]],
 ) -> None:
     bbox = BoundingBox(topleft, size)
-    starts = list(bbox.iter_chunk_starts(chunk_shape, alignment))
+    starts = list(bbox.iter_chunk_toplefts(chunk_shape, alignment))
 
     assert starts == expected
     # Yielded values are plain python int tuples (no numpy scalars).
@@ -267,63 +267,63 @@ def test_iter_chunk_starts(
         assert starts == [tuple(c.topleft) for c in bbox.chunk(chunk_shape, alignment)]
 
 
-def test_iter_chunk_starts_alignment_divisibility_assertion() -> None:
+def test_iter_chunk_toplefts_alignment_divisibility_assertion() -> None:
     bbox = BoundingBox((0, 0, 0), (10, 10, 10))
     with pytest.raises(AssertionError):
-        list(bbox.iter_chunk_starts((32, 32, 32), (7, 7, 7)))
+        list(bbox.iter_chunk_toplefts((32, 32, 32), (7, 7, 7)))
 
 
-def test_iter_chunk_starts_clip_to() -> None:
+def test_iter_chunk_toplefts_clip_to() -> None:
     # Without chunk_border_alignments, clip_to just restricts which of the box's own
     # (topleft-aligned) chunk starts are yielded.
     bbox = BoundingBox((0, 0, 0), (100, 100, 100))
     clip = BoundingBox((0, 0, 0), (40, 40, 40))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), clip_to=clip)) == [
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), clip_to=clip)) == [
         (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
     ]
 
 
-def test_iter_chunk_starts_clip_to_outside_is_empty() -> None:
+def test_iter_chunk_toplefts_clip_to_outside_is_empty() -> None:
     bbox = BoundingBox((200, 200, 200), (10, 10, 10))
     clip = BoundingBox((0, 0, 0), (40, 40, 40))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), clip_to=clip)) == []
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), clip_to=clip)) == []
 
 
-def test_iter_chunk_starts_as_origin_aligned_grid_cells() -> None:
+def test_iter_chunk_toplefts_as_origin_aligned_grid_cells() -> None:
     # Passing chunk_border_alignments=chunk_shape makes the grid aligned to the
     # coordinate origin instead of to the box's own topleft, which is useful to
     # iterate the grid cells of an origin-aligned partitioning that overlap this box.
 
     # Box [10, 50) on every axis overlaps origin-aligned 32-grid cells 0 and 32.
     bbox = BoundingBox((10, 10, 10), (40, 40, 40))
-    cells = list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32)))
+    cells = list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32)))
     assert cells == [(x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)]
 
     # Box exactly spanning one grid cell [32, 64) only overlaps that single cell;
     # neighbouring cells that merely touch its borders are excluded (half-open).
     bbox = BoundingBox((32, 32, 32), (32, 32, 32))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [(32, 32, 32)]
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32))) == [(32, 32, 32)]
 
     # Box [1, 33) crosses the grid line at 32, so it overlaps cells 0 and 32.
     bbox = BoundingBox((1, 1, 1), (32, 32, 32))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32))) == [
         (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
     ]
 
     # Box [-33, -1) crosses the grid lines at -32 and 0, so it overlaps the cells
     # starting at -64 and -32 (the grid is aligned to the origin, not to the box).
     bbox = BoundingBox((-33, -33, -33), (32, 32, 32))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32))) == [
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32))) == [
         (x, y, z) for x in (-64, -32) for y in (-64, -32) for z in (-64, -32)
     ]
 
 
-def test_iter_chunk_starts_as_origin_aligned_grid_cells_with_clip_to() -> None:
+def test_iter_chunk_toplefts_as_origin_aligned_grid_cells_with_clip_to() -> None:
     bbox = BoundingBox((10, 10, 10), (100, 100, 100))
     clip = BoundingBox((0, 0, 0), (40, 40, 40))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32), clip_to=clip)) == [
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32), clip_to=clip)) == [
         (x, y, z) for x in (0, 32) for y in (0, 32) for z in (0, 32)
     ]
 
     bbox = BoundingBox((200, 200, 200), (10, 10, 10))
-    assert list(bbox.iter_chunk_starts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []
+    assert list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []

--- a/webknossos/tests/geometry/test_bounding_box.py
+++ b/webknossos/tests/geometry/test_bounding_box.py
@@ -331,3 +331,27 @@ def test_iter_chunk_toplefts_as_origin_aligned_grid_cells_with_clip_to() -> None
     assert (
         list(bbox.iter_chunk_toplefts((32, 32, 32), (32, 32, 32), clip_to=clip)) == []
     )
+
+
+def test_iter_chunk_toplefts_clip_to_preserves_alignment_phase() -> None:
+    # Regression test: when chunk_border_alignments is strictly smaller than
+    # chunk_shape, clip_to must not shift the grid's phase (i.e. clip_to only
+    # restricts which chunks of the *same* grid are yielded, it doesn't define a
+    # different grid). Here the grid (without clip_to) is anchored at 4 with a
+    # period of 8 (4, 12, 20, ...); clipping to topleft 10 must still yield chunks
+    # from that grid (the one starting at 4, since [4, 12) overlaps 10), not a
+    # grid re-aligned to a multiple of the alignment (4) from the clipped start.
+    bbox = BoundingBox((5, 5, 5), (100, 100, 100))
+    clip = BoundingBox((10, 10, 10), (1000, 1000, 1000))
+
+    unclipped = list(bbox.iter_chunk_toplefts((8, 8, 8), (4, 4, 4)))
+    clipped = list(bbox.iter_chunk_toplefts((8, 8, 8), (4, 4, 4), clip_to=clip))
+
+    assert clipped[0] == (4, 4, 4)
+    # The clipped result is exactly the unclipped grid, filtered to the chunks
+    # that overlap `clip`.
+    assert clipped == [
+        start
+        for start in unclipped
+        if all(s + 8 > c_start for s, c_start in zip(start, clip.topleft))
+    ]

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -13,6 +13,19 @@ from .normalized_bounding_box import NormalizedBoundingBox
 from .vec3_int import Vec3Int, Vec3IntLike
 
 
+def _as_int3(value: Vec3IntLike) -> tuple[int, int, int]:
+    """Converts a `Vec3IntLike` to a plain 3-tuple of python ints.
+
+    This is a lighter-weight alternative to `Vec3Int(value)` for call sites
+    that don't need a `Vec3Int` (with its axis metadata) and only care about
+    the three plain int values, e.g. hot per-chunk grid computations.
+    """
+
+    result = tuple(int(v) for v in value)
+    assert len(result) == 3, f"Expected a Vec3IntLike with 3 entries, got {result}."
+    return cast(tuple[int, int, int], result)
+
+
 @attr.frozen
 class BoundingBox(NDBoundingBox):
     """An axis-aligned 3D bounding box with integer coordinates.
@@ -483,12 +496,15 @@ class BoundingBox(NDBoundingBox):
         chunk_border_alignments: Vec3IntLike | None = None,
         clip_to: "BoundingBox | None" = None,
     ) -> Iterator[tuple[int, int, int]]:
-        """Yield the topleft coordinate of every chunk of `chunk()`'s grid.
+        """Returns an iterator over the topleft coordinate of every chunk of
+        `chunk()`'s grid.
 
-        This is a fast, allocation-free variant of `chunk()`: it performs no
-        per-chunk `BoundingBox` allocation and does **not** clip the chunks to
-        this box (border chunks are therefore *not* shrunk – the caller can
-        clip/filter cheaply on the raw integers if needed).
+        This is a fast, allocation-free variant of `chunk()`: besides `self` and
+        `clip_to`, it doesn't touch any `Vec3Int`/`BoundingBox` (both the
+        computation below and the returned coordinates use plain python ints),
+        and it does **not** clip the chunks to this box (border chunks are
+        therefore *not* shrunk – the caller can clip/filter cheaply on the raw
+        integers if needed).
 
         `chunk()` shares the same grid (same cells, same order). Without
         `chunk_border_alignments`, the yielded starts equal the chunk toplefts,
@@ -517,54 +533,60 @@ class BoundingBox(NDBoundingBox):
             AssertionError: If chunk_border_alignments is provided and chunk_shape
                 is not divisible by it.
 
-        Yields:
-            tuple[int, int, int]: The topleft coordinate of each chunk.
+        Returns:
+            Iterator[tuple[int, int, int]]: An iterator over the topleft
+                coordinate of each chunk.
         """
 
-        chunk_shape = Vec3Int(chunk_shape)
+        steps = _as_int3(chunk_shape)
+        topleft = tuple(self.topleft)
+        bottomright = tuple(self.bottomright)
 
         if chunk_border_alignments is not None:
-            alignments = Vec3Int(chunk_border_alignments)
+            alignments = _as_int3(chunk_border_alignments)
             assert all(
                 step % alignment == 0
-                for step, alignment in zip(chunk_shape, alignments, strict=True)
-            ), f"{chunk_shape} not divisible by {alignments}"
+                for step, alignment in zip(steps, alignments, strict=True)
+            ), f"{steps} not divisible by {alignments}"
             # The start of the grid line at or before this box's topleft, on each
             # axis. This doesn't change the start of the first chunk (the grid is
             # intersected with the requested/clipped range below), but it fixes the
             # grid's phase so that all borders *between* chunks are aligned.
-            grid_starts = Vec3Int(
+            grid_starts = tuple(
                 start - start % alignment
-                for start, alignment in zip(self.topleft, alignments, strict=True)
+                for start, alignment in zip(topleft, alignments, strict=True)
             )
         else:
-            grid_starts = self.topleft
+            grid_starts = topleft
 
-        starts = self.topleft
-        ends = self.bottomright
+        starts = topleft
+        ends = bottomright
         if clip_to is not None:
-            starts = Vec3Int(
+            starts = tuple(
                 max(start, clip_start)
                 for start, clip_start in zip(starts, clip_to.topleft, strict=True)
             )
-            ends = Vec3Int(
+            ends = tuple(
                 min(end, clip_end)
                 for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
             )
 
         ranges = []
         for start, end, grid_start, step in zip(
-            starts, ends, grid_starts, chunk_shape, strict=True
+            starts, ends, grid_starts, steps, strict=True
         ):
             if start >= end:
                 # Empty overlap on at least one axis -> no chunks at all.
-                return
+                return iter(())
             # Move `start` back to the grid line at or before it, without changing
             # the grid's phase (matters only when chunk_border_alignments is given).
             first = start - (start - grid_start) % step
             ranges.append(range(first, end, step))
 
-        yield from product(*ranges)
+        # Returning the itertools.product iterator directly (instead of `yield
+        # from`-ing it from a generator function) avoids wrapping it in an
+        # extra generator frame, which measurably speeds up iteration.
+        return cast(Iterator[tuple[int, int, int]], product(*ranges))
 
     def offset(self, vector: Vec3IntLike) -> "BoundingBox":
         """Creates an offset copy of this bounding box by adding a vector to the topleft coordinate.

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -469,60 +469,76 @@ class BoundingBox(NDBoundingBox):
               chunks will be aligned to those values
         """
 
-        start = self.topleft.to_np()
-        chunk_shape = Vec3Int(chunk_shape).to_np()
+        chunk_shape = Vec3Int(chunk_shape)
 
-        start_adjust = np.array([0, 0, 0])
-        if chunk_border_alignments is not None:
-            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
-            assert np.all(chunk_shape % chunk_border_alignments_array == 0), (
-                f"{chunk_shape} not divisible by {chunk_border_alignments_array}"
+        for start in self.iter_chunk_starts(chunk_shape, chunk_border_alignments):
+            yield cast(
+                BoundingBox,
+                BoundingBox(start, chunk_shape).intersected_with(self),
             )
 
-            # Move the start to be aligned correctly. This doesn't actually change
-            # the start of the first chunk, because we'll intersect with `self`,
-            # but it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % chunk_border_alignments_array
-
-        for x in range(
-            start[0] - start_adjust[0], start[0] + self.size[0], chunk_shape[0]
-        ):
-            for y in range(
-                start[1] - start_adjust[1], start[1] + self.size[1], chunk_shape[1]
-            ):
-                for z in range(
-                    start[2] - start_adjust[2], start[2] + self.size[2], chunk_shape[2]
-                ):
-                    yield cast(
-                        BoundingBox,
-                        BoundingBox([x, y, z], chunk_shape).intersected_with(self),
-                    )
-
-    def iter_overlapping_grid_cells(
+    def iter_chunk_starts(
         self,
-        cell_shape: Vec3IntLike,
+        chunk_shape: Vec3IntLike,
+        chunk_border_alignments: Vec3IntLike | None = None,
         clip_to: "BoundingBox | None" = None,
     ) -> Iterator[tuple[int, int, int]]:
-        """Yield the topleft of every origin-aligned grid cell overlapping this box.
+        """Yield the topleft coordinate of every chunk of `chunk()`'s grid.
 
-        The grid is aligned to the coordinate origin (cell `k` on an axis spans
-        `[k * cell, (k + 1) * cell)`) and has cell size `cell_shape`. This differs
-        from `chunk()`, whose grid is aligned to the box's own topleft.
+        This is a fast, allocation-free variant of `chunk()`: it performs no
+        per-chunk `BoundingBox` allocation and does **not** clip the chunks to
+        this box (border chunks are therefore *not* shrunk – the caller can
+        clip/filter cheaply on the raw integers if needed).
 
-        Overlap uses half-open intervals: cells that only *touch* this box (or
-        `clip_to`) at a border are not returned. Unlike `chunk()`, this does not
-        allocate a `BoundingBox` per cell; it yields plain int tuples which is faster.
+        `chunk()` shares the same grid (same cells, same order). Without
+        `chunk_border_alignments`, the yielded starts equal the chunk toplefts,
+        i.e. `list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in
+        self.chunk(cs)]`. With `chunk_border_alignments`, the first grid line on
+        an axis may lie *before* this box's topleft; `chunk()` clips that first
+        chunk's topleft up to the box, whereas this method yields the unclipped
+        grid start.
+
+        Passing `chunk_border_alignments=chunk_shape` makes the grid aligned to
+        the coordinate origin instead of to this box's topleft (cell `k` on an
+        axis then spans `[k * chunk_shape, (k + 1) * chunk_shape)`), which is
+        useful to iterate the grid cells of an origin-aligned partitioning (e.g.
+        a chunked/sharded dataset) that overlap this box, optionally clipped to
+        another box via `clip_to`. Overlap uses half-open intervals: cells that
+        only *touch* this box (or `clip_to`) at a border are not yielded.
 
         Args:
-            cell_shape (Vec3IntLike): The size of the grid cells.
-            clip_to (BoundingBox | None): If given, only cells overlapping both this
-                box and `clip_to` are yielded.
+            chunk_shape (Vec3IntLike): The size of the chunks to generate.
+            chunk_border_alignments (Vec3IntLike | None): The alignment of the
+                chunk borders.
+            clip_to (BoundingBox | None): If given, only chunks overlapping both
+                this box and `clip_to` are yielded.
+
+        Raises:
+            AssertionError: If chunk_border_alignments is provided and chunk_shape
+                is not divisible by it.
 
         Yields:
-            tuple[int, int, int]: The topleft coordinate of each overlapping grid cell.
+            tuple[int, int, int]: The topleft coordinate of each chunk.
         """
 
-        cell_shape = Vec3Int(cell_shape)
+        chunk_shape = Vec3Int(chunk_shape)
+
+        if chunk_border_alignments is not None:
+            alignments = Vec3Int(chunk_border_alignments)
+            assert all(
+                step % alignment == 0
+                for step, alignment in zip(chunk_shape, alignments, strict=True)
+            ), f"{chunk_shape} not divisible by {alignments}"
+            # The start of the grid line at or before this box's topleft, on each
+            # axis. This doesn't change the start of the first chunk (the grid is
+            # intersected with the requested/clipped range below), but it fixes the
+            # grid's phase so that all borders *between* chunks are aligned.
+            grid_starts = Vec3Int(
+                start - start % alignment
+                for start, alignment in zip(self.topleft, alignments, strict=True)
+            )
+        else:
+            grid_starts = self.topleft
 
         starts = self.topleft
         ends = self.bottomright
@@ -537,11 +553,16 @@ class BoundingBox(NDBoundingBox):
             )
 
         ranges = []
-        for start, end, cell in zip(starts, ends, cell_shape, strict=True):
+        for start, end, grid_start, step in zip(
+            starts, ends, grid_starts, chunk_shape, strict=True
+        ):
             if start >= end:
-                # Empty overlap on at least one axis -> no cells at all.
+                # Empty overlap on at least one axis -> no chunks at all.
                 return
-            ranges.append(range((start // cell) * cell, end, cell))
+            # Move `start` back to the grid line at or before it, without changing
+            # the grid's phase (matters only when chunk_border_alignments is given).
+            first = start - (start - grid_start) % step
+            ranges.append(range(first, end, step))
 
         yield from product(*ranges)
 

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -552,40 +552,36 @@ class BoundingBox(NDBoundingBox):
                 step % alignment == 0
                 for step, alignment in zip(chunk_shape, alignments, strict=True)
             ), f"{chunk_shape} not divisible by {alignments}"
-            # The start of the grid line at or before this box's topleft, on each
-            # axis. This doesn't change the start of the first chunk (the grid is
-            # intersected with the requested/clipped range below), but it fixes the
-            # grid's phase so that all borders *between* chunks are aligned.
-            grid_starts = Vec3Int(
+            starts = Vec3Int(
                 start - start % alignment
                 for start, alignment in zip(self.topleft, alignments, strict=True)
             )
         else:
-            grid_starts = self.topleft
+            starts = self.topleft
 
-        starts = self.topleft
         ends = self.bottomright
         if clip_to is not None:
             starts = Vec3Int(
                 max(start, clip_start)
                 for start, clip_start in zip(starts, clip_to.topleft, strict=True)
             )
+            # After clipping the start might no longer be grid/shard aligned, fix this if needed.
+            if chunk_border_alignments is not None:
+                starts = Vec3Int(
+                    start - start % alignment
+                    for start, alignment in zip(starts, alignments, strict=True)
+                )
             ends = Vec3Int(
                 min(end, clip_end)
                 for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
             )
 
         ranges = []
-        for start, end, grid_start, step in zip(
-            starts, ends, grid_starts, chunk_shape, strict=True
-        ):
+        for start, end, step in zip(starts, ends, chunk_shape, strict=True):
             if start >= end:
                 # Empty overlap on at least one axis -> no chunks at all.
                 return iter(())
-            # Move `start` back to the grid line at or before it, without changing
-            # the grid's phase (matters only when chunk_border_alignments is given).
-            first = start - (start - grid_start) % step
-            ranges.append(range(first, end, step))
+            ranges.append(range(start, end, step))
 
         # Returning the itertools.product iterator directly (instead of `yield
         # from`-ing it from a generator function) avoids wrapping it in an

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -511,7 +511,7 @@ class BoundingBox(NDBoundingBox):
 
         Overlap uses half-open intervals: cells that only *touch* this box (or
         `clip_to`) at a border are not returned. Unlike `chunk()`, this does not
-        allocate a `BoundingBox` per cell; it yields plain int tuples.
+        allocate a `BoundingBox` per cell; it yields plain int tuples which is faster.
 
         Args:
             cell_shape (Vec3IntLike): The size of the grid cells.

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -469,34 +469,13 @@ class BoundingBox(NDBoundingBox):
               chunks will be aligned to those values
         """
 
-        start = self.topleft.to_np()
-        chunk_shape = Vec3Int(chunk_shape).to_np()
+        chunk_shape = Vec3Int(chunk_shape)
 
-        start_adjust = np.array([0, 0, 0])
-        if chunk_border_alignments is not None:
-            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
-            assert np.all(chunk_shape % chunk_border_alignments_array == 0), (
-                f"{chunk_shape} not divisible by {chunk_border_alignments_array}"
+        for start in self.iter_chunk_toplefts(chunk_shape, chunk_border_alignments):
+            yield cast(
+                BoundingBox,
+                BoundingBox(start, chunk_shape).intersected_with(self),
             )
-
-            # Move the start to be aligned correctly. This doesn't actually change
-            # the start of the first chunk, because we'll intersect with `self`,
-            # but it'll lead to all chunk borders being aligned correctly.
-            start_adjust = start % chunk_border_alignments_array
-
-        for x in range(
-            start[0] - start_adjust[0], start[0] + self.size[0], chunk_shape[0]
-        ):
-            for y in range(
-                start[1] - start_adjust[1], start[1] + self.size[1], chunk_shape[1]
-            ):
-                for z in range(
-                    start[2] - start_adjust[2], start[2] + self.size[2], chunk_shape[2]
-                ):
-                    yield cast(
-                        BoundingBox,
-                        BoundingBox([x, y, z], chunk_shape).intersected_with(self),
-                    )
 
     def iter_chunk_toplefts(
         self,

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -471,13 +471,13 @@ class BoundingBox(NDBoundingBox):
 
         chunk_shape = Vec3Int(chunk_shape)
 
-        for start in self.iter_chunk_starts(chunk_shape, chunk_border_alignments):
+        for start in self.iter_chunk_toplefts(chunk_shape, chunk_border_alignments):
             yield cast(
                 BoundingBox,
                 BoundingBox(start, chunk_shape).intersected_with(self),
             )
 
-    def iter_chunk_starts(
+    def iter_chunk_toplefts(
         self,
         chunk_shape: Vec3IntLike,
         chunk_border_alignments: Vec3IntLike | None = None,
@@ -492,7 +492,7 @@ class BoundingBox(NDBoundingBox):
 
         `chunk()` shares the same grid (same cells, same order). Without
         `chunk_border_alignments`, the yielded starts equal the chunk toplefts,
-        i.e. `list(self.iter_chunk_starts(cs)) == [tuple(c.topleft) for c in
+        i.e. `list(self.iter_chunk_toplefts(cs)) == [tuple(c.topleft) for c in
         self.chunk(cs)]`. With `chunk_border_alignments`, the first grid line on
         an axis may lie *before* this box's topleft; `chunk()` clips that first
         chunk's topleft up to the box, whereas this method yields the unclipped

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -1,6 +1,7 @@
 import json
 import re
-from collections.abc import Callable, Generator, Iterable
+from collections.abc import Callable, Generator, Iterable, Iterator
+from itertools import product
 from typing import Union, cast, overload
 
 import attr
@@ -496,6 +497,53 @@ class BoundingBox(NDBoundingBox):
                         BoundingBox,
                         BoundingBox([x, y, z], chunk_shape).intersected_with(self),
                     )
+
+    def iter_overlapping_grid_cells(
+        self,
+        cell_shape: Vec3IntLike,
+        clip_to: "BoundingBox | None" = None,
+    ) -> Iterator[tuple[int, int, int]]:
+        """Yield the topleft of every origin-aligned grid cell overlapping this box.
+
+        The grid is aligned to the coordinate origin (cell `k` on an axis spans
+        `[k * cell, (k + 1) * cell)`) and has cell size `cell_shape`. This differs
+        from `chunk()`, whose grid is aligned to the box's own topleft.
+
+        Overlap uses half-open intervals: cells that only *touch* this box (or
+        `clip_to`) at a border are not returned. Unlike `chunk()`, this does not
+        allocate a `BoundingBox` per cell; it yields plain int tuples.
+
+        Args:
+            cell_shape (Vec3IntLike): The size of the grid cells.
+            clip_to (BoundingBox | None): If given, only cells overlapping both this
+                box and `clip_to` are yielded.
+
+        Yields:
+            tuple[int, int, int]: The topleft coordinate of each overlapping grid cell.
+        """
+
+        cell_shape = Vec3Int(cell_shape)
+
+        starts = self.topleft
+        ends = self.bottomright
+        if clip_to is not None:
+            starts = Vec3Int(
+                max(start, clip_start)
+                for start, clip_start in zip(starts, clip_to.topleft, strict=True)
+            )
+            ends = Vec3Int(
+                min(end, clip_end)
+                for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
+            )
+
+        ranges = []
+        for start, end, cell in zip(starts, ends, cell_shape, strict=True):
+            if start >= end:
+                # Empty overlap on at least one axis -> no cells at all.
+                return
+            ranges.append(range((start // cell) * cell, end, cell))
+
+        yield from product(*ranges)
 
     def offset(self, vector: Vec3IntLike) -> "BoundingBox":
         """Creates an offset copy of this bounding box by adding a vector to the topleft coordinate.

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -13,19 +13,6 @@ from .normalized_bounding_box import NormalizedBoundingBox
 from .vec3_int import Vec3Int, Vec3IntLike
 
 
-def _as_int3(value: Vec3IntLike) -> tuple[int, int, int]:
-    """Converts a `Vec3IntLike` to a plain 3-tuple of python ints.
-
-    This is a lighter-weight alternative to `Vec3Int(value)` for call sites
-    that don't need a `Vec3Int` (with its axis metadata) and only care about
-    the three plain int values, e.g. hot per-chunk grid computations.
-    """
-
-    result = tuple(int(v) for v in value)
-    assert len(result) == 3, f"Expected a Vec3IntLike with 3 entries, got {result}."
-    return cast(tuple[int, int, int], result)
-
-
 @attr.frozen
 class BoundingBox(NDBoundingBox):
     """An axis-aligned 3D bounding box with integer coordinates.
@@ -482,13 +469,34 @@ class BoundingBox(NDBoundingBox):
               chunks will be aligned to those values
         """
 
-        chunk_shape = Vec3Int(chunk_shape)
+        start = self.topleft.to_np()
+        chunk_shape = Vec3Int(chunk_shape).to_np()
 
-        for start in self.iter_chunk_toplefts(chunk_shape, chunk_border_alignments):
-            yield cast(
-                BoundingBox,
-                BoundingBox(start, chunk_shape).intersected_with(self),
+        start_adjust = np.array([0, 0, 0])
+        if chunk_border_alignments is not None:
+            chunk_border_alignments_array = Vec3Int(chunk_border_alignments).to_np()
+            assert np.all(chunk_shape % chunk_border_alignments_array == 0), (
+                f"{chunk_shape} not divisible by {chunk_border_alignments_array}"
             )
+
+            # Move the start to be aligned correctly. This doesn't actually change
+            # the start of the first chunk, because we'll intersect with `self`,
+            # but it'll lead to all chunk borders being aligned correctly.
+            start_adjust = start % chunk_border_alignments_array
+
+        for x in range(
+            start[0] - start_adjust[0], start[0] + self.size[0], chunk_shape[0]
+        ):
+            for y in range(
+                start[1] - start_adjust[1], start[1] + self.size[1], chunk_shape[1]
+            ):
+                for z in range(
+                    start[2] - start_adjust[2], start[2] + self.size[2], chunk_shape[2]
+                ):
+                    yield cast(
+                        BoundingBox,
+                        BoundingBox([x, y, z], chunk_shape).intersected_with(self),
+                    )
 
     def iter_chunk_toplefts(
         self,
@@ -499,12 +507,10 @@ class BoundingBox(NDBoundingBox):
         """Returns an iterator over the topleft coordinate of every chunk of
         `chunk()`'s grid.
 
-        This is a fast, allocation-free variant of `chunk()`: besides `self` and
-        `clip_to`, it doesn't touch any `Vec3Int`/`BoundingBox` (both the
-        computation below and the returned coordinates use plain python ints),
-        and it does **not** clip the chunks to this box (border chunks are
-        therefore *not* shrunk – the caller can clip/filter cheaply on the raw
-        integers if needed).
+        This is a fast, allocation-free variant of `chunk()`: it performs no
+        per-chunk `BoundingBox` allocation and does **not** clip the chunks to
+        this box (border chunks are therefore *not* shrunk – the caller can
+        clip/filter cheaply on the raw integers if needed).
 
         `chunk()` shares the same grid (same cells, same order). Without
         `chunk_border_alignments`, the yielded starts equal the chunk toplefts,
@@ -538,42 +544,40 @@ class BoundingBox(NDBoundingBox):
                 coordinate of each chunk.
         """
 
-        steps = _as_int3(chunk_shape)
-        topleft = tuple(self.topleft)
-        bottomright = tuple(self.bottomright)
+        chunk_shape = Vec3Int(chunk_shape)
 
         if chunk_border_alignments is not None:
-            alignments = _as_int3(chunk_border_alignments)
+            alignments = Vec3Int(chunk_border_alignments)
             assert all(
                 step % alignment == 0
-                for step, alignment in zip(steps, alignments, strict=True)
-            ), f"{steps} not divisible by {alignments}"
+                for step, alignment in zip(chunk_shape, alignments, strict=True)
+            ), f"{chunk_shape} not divisible by {alignments}"
             # The start of the grid line at or before this box's topleft, on each
             # axis. This doesn't change the start of the first chunk (the grid is
             # intersected with the requested/clipped range below), but it fixes the
             # grid's phase so that all borders *between* chunks are aligned.
-            grid_starts = tuple(
+            grid_starts = Vec3Int(
                 start - start % alignment
-                for start, alignment in zip(topleft, alignments, strict=True)
+                for start, alignment in zip(self.topleft, alignments, strict=True)
             )
         else:
-            grid_starts = topleft
+            grid_starts = self.topleft
 
-        starts = topleft
-        ends = bottomright
+        starts = self.topleft
+        ends = self.bottomright
         if clip_to is not None:
-            starts = tuple(
+            starts = Vec3Int(
                 max(start, clip_start)
                 for start, clip_start in zip(starts, clip_to.topleft, strict=True)
             )
-            ends = tuple(
+            ends = Vec3Int(
                 min(end, clip_end)
                 for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
             )
 
         ranges = []
         for start, end, grid_start, step in zip(
-            starts, ends, grid_starts, steps, strict=True
+            starts, ends, grid_starts, chunk_shape, strict=True
         ):
             if start >= end:
                 # Empty overlap on at least one axis -> no chunks at all.

--- a/webknossos/webknossos/geometry/bounding_box.py
+++ b/webknossos/webknossos/geometry/bounding_box.py
@@ -552,36 +552,40 @@ class BoundingBox(NDBoundingBox):
                 step % alignment == 0
                 for step, alignment in zip(chunk_shape, alignments, strict=True)
             ), f"{chunk_shape} not divisible by {alignments}"
-            starts = Vec3Int(
+            # The start of the grid line at or before this box's topleft, on each
+            # axis. This doesn't change the start of the first chunk (the grid is
+            # intersected with the requested/clipped range below), but it fixes the
+            # grid's phase so that all borders *between* chunks are aligned.
+            grid_starts = Vec3Int(
                 start - start % alignment
                 for start, alignment in zip(self.topleft, alignments, strict=True)
             )
         else:
-            starts = self.topleft
+            grid_starts = self.topleft
 
+        starts = self.topleft
         ends = self.bottomright
         if clip_to is not None:
             starts = Vec3Int(
                 max(start, clip_start)
                 for start, clip_start in zip(starts, clip_to.topleft, strict=True)
             )
-            # After clipping the start might no longer be grid/shard aligned, fix this if needed.
-            if chunk_border_alignments is not None:
-                starts = Vec3Int(
-                    start - start % alignment
-                    for start, alignment in zip(starts, alignments, strict=True)
-                )
             ends = Vec3Int(
                 min(end, clip_end)
                 for end, clip_end in zip(ends, clip_to.bottomright, strict=True)
             )
 
         ranges = []
-        for start, end, step in zip(starts, ends, chunk_shape, strict=True):
+        for start, end, grid_start, step in zip(
+            starts, ends, grid_starts, chunk_shape, strict=True
+        ):
             if start >= end:
                 # Empty overlap on at least one axis -> no chunks at all.
                 return iter(())
-            ranges.append(range(start, end, step))
+            # Move `start` back to the grid line at or before it, without changing
+            # the grid's phase (matters only when chunk_border_alignments is given).
+            first = start - (start - grid_start) % step
+            ranges.append(range(first, end, step))
 
         # Returning the itertools.product iterator directly (instead of `yield
         # from`-ing it from a generator function) avoids wrapping it in an


### PR DESCRIPTION
- Adds `BoundingBox.iter_chunk_toplefts(chunk_shape, chunk_border_alignments=None, clip_to=None)`:
  - Shares the same grid as `chunk()`, but yields plain `int` tuples instead of allocating a `BoundingBox` per chunk, and does not clip chunk starts to the box.
  - New `clip_to: BoundingBox | None` parameter: only chunk starts overlapping both this box and `clip_to` are yielded.
  - Passing `chunk_border_alignments=chunk_shape` makes the grid aligned to the coordinate origin rather than to this box's topleft — useful for iterating the grid cells of an origin-aligned partitioning (e.g. a chunked/sharded dataset) that overlap this box.
- `BoundingBox.chunk(...)` now uses `BoundingBox.iter_chunk_toplefts(...)` internally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)