### PR TITLE
correct mapping type type hint

### DIFF
--- a/webknossos/webknossos/annotation/annotation.py
+++ b/webknossos/webknossos/annotation/annotation.py
@@ -1467,7 +1467,7 @@ class RemoteAnnotation(Annotation):
         mesh_file_name: str | None = None,
         lod: int = 0,
         mapping_name: str | None = None,
-        mapping_type: Literal["agglomerate", "json"] | None = None,
+        mapping_type: Literal["AGGLOMERATE", "JSON"] | None = None,
         mag: MagLike | None = None,
         seed_position: Vec3IntLike | None = None,
         token: str | None = None,

--- a/webknossos/webknossos/client/api_client/models.py
+++ b/webknossos/webknossos/client/api_client/models.py
@@ -505,7 +505,7 @@ class ApiAdHocMeshInfo:
     lod: int
     segment_id: int  # if mapping name is set, this is an agglomerate id
     mapping_name: str | None
-    mapping_type: Literal["json", "agglomerate"] | None
+    mapping_type: Literal["JSON", "AGGLOMERATE"] | None
     mag: tuple[int, int, int]
     seed_position: tuple[int, int, int]
 

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/remote_segmentation_layer.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/remote_segmentation_layer.py
@@ -43,7 +43,7 @@ class RemoteSegmentationLayer(
         datastore_url: str | None = None,
         lod: int = 0,
         mapping_name: str | None = None,
-        mapping_type: Literal["agglomerate", "json"] | None = None,
+        mapping_type: Literal["AGGLOMERATE", "JSON"] | None = None,
         mag: MagLike | None = None,
         seed_position: Vec3IntLike | None = None,
         token: str | None = None,

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -856,7 +856,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         )
 
     def download_mesh(
-        self,π
+        self,
         segment_id: int,
         output_dir: PathLike | UPath | str,
         *,

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -856,7 +856,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         )
 
     def download_mesh(
-        self,
+        self,π
         segment_id: int,
         output_dir: PathLike | UPath | str,
         *,
@@ -865,7 +865,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         datastore_url: str | None = None,
         lod: int = 0,
         mapping_name: str | None = None,
-        mapping_type: Literal["agglomerate", "json"] | None = None,
+        mapping_type: Literal["AGGLOMERATE", "JSON"] | None = None,
         mag: MagLike | None = None,
         seed_position: Vec3Int | None = None,
         token: str | None = None,


### PR DESCRIPTION
### Description:
Noticed that the type hint of mapping type in the libs is not in sync with the WK spelling. Noticed in https://github.com/scalableminds/webknossos/pull/9856. When https://github.com/scalableminds/webknossos/pull/9856 is merged and this PR, the type hint should be accurate now.

Previously, this didn't really matter afaik as the only route using this in the wklibs is the adhoc mesh api call and for this wk only decides `mappingType == "JSON"` and else it assumes agglomerate / hdf5 type. So no problemo there.

 
### Issues:
- fixes mismatch in type hint noticed in https://github.com/scalableminds/webknossos/pull/9856

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - ~[ ] Updated Changelog~ -> think thats not note worthy
