### PR TITLE
Fix TensorStore rejecting UNC paths from Windows mapped network drives

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,6 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
+- Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1501](https://github.com/scalableminds/webknossos-libs/issues/1501)
 
 
 ## [3.7.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.7.0) - 2026-08-12

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
-- Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1501](https://github.com/scalableminds/webknossos-libs/issues/1501)
+- Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1513](https://github.com/scalableminds/webknossos-libs/issues/1513)
 
 
 ## [3.7.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.7.0) - 2026-08-12

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -5,7 +5,13 @@ import pytest
 from upath import UPath
 
 from tests.utils import TestTemporaryDirectoryNonLocal
-from webknossos.utils import call_with_retries, copytree, dump_path, enrich_path
+from webknossos.utils import (
+    call_with_retries,
+    cheap_resolve,
+    copytree,
+    dump_path,
+    enrich_path,
+)
 
 
 def test_call_with_retries_success() -> None:
@@ -71,6 +77,68 @@ def test_call_with_retries_direct_failure(mock_sleep: Mock) -> None:
 
     assert mock_fn.call_count == 1  # Only called once, no retries
     assert mock_sleep.call_count == 0  # Sleep not called since it failed immediately
+
+
+def test_cheap_resolve_normalizes_relative_and_dots(tmp_upath: UPath) -> None:
+    tmp_upath = UPath(tmp_upath.resolve())
+
+    real_dir = tmp_upath / "real"
+    real_dir.mkdir()
+
+    # relative segments and `.`/`..` are normalized away
+    dotted = real_dir / ".." / "real" / "." / "sub"
+    assert cheap_resolve(dotted) == real_dir / "sub"
+
+    # a relative path is made absolute
+    assert cheap_resolve(UPath("real")).is_absolute()
+
+
+@pytest.mark.skip_on_windows
+def test_cheap_resolve_follows_symlinks(tmp_upath: UPath) -> None:
+    tmp_upath = UPath(tmp_upath.resolve())
+
+    real_dir = tmp_upath / "real"
+    real_dir.mkdir()
+    (real_dir / "sub").mkdir()
+
+    # absolute symlink target
+    abs_link = tmp_upath / "abs_link"
+    abs_link.symlink_to(real_dir)
+    assert cheap_resolve(abs_link / "sub") == real_dir / "sub"
+
+    # relative symlink target
+    rel_link = tmp_upath / "rel_link"
+    rel_link.symlink_to(UPath("real"))
+    assert cheap_resolve(rel_link / "sub") == real_dir / "sub"
+
+    # symlink reached via a `..`-containing path
+    dotted = tmp_upath / "abs_link" / ".." / "abs_link" / "sub"
+    assert cheap_resolve(dotted) == real_dir / "sub"
+
+    # multi-hop symlink chain
+    chained_link = tmp_upath / "chained_link"
+    chained_link.symlink_to(abs_link)
+    assert cheap_resolve(chained_link / "sub") == real_dir / "sub"
+
+
+@pytest.mark.skip_on_windows
+def test_cheap_resolve_detects_symlink_loop(tmp_upath: UPath) -> None:
+    tmp_upath = UPath(tmp_upath.resolve())
+
+    link_a = tmp_upath / "a"
+    link_b = tmp_upath / "b"
+    link_a.symlink_to(link_b)
+    link_b.symlink_to(link_a)
+
+    with pytest.raises(OSError):
+        cheap_resolve(link_a / "sub")
+
+
+def test_cheap_resolve_nonexistent_path_is_not_strict(tmp_upath: UPath) -> None:
+    tmp_upath = UPath(tmp_upath.resolve())
+
+    path = tmp_upath / "does_not_exist" / "sub"
+    assert cheap_resolve(path) == path
 
 
 def test_dump_path(tmp_upath: UPath) -> None:

--- a/webknossos/tests/test_utils.py
+++ b/webknossos/tests/test_utils.py
@@ -6,6 +6,7 @@ from upath import UPath
 
 from tests.utils import TestTemporaryDirectoryNonLocal
 from webknossos.utils import (
+    _strip_extended_path_prefix,
     call_with_retries,
     cheap_resolve,
     copytree,
@@ -139,6 +140,16 @@ def test_cheap_resolve_nonexistent_path_is_not_strict(tmp_upath: UPath) -> None:
 
     path = tmp_upath / "does_not_exist" / "sub"
     assert cheap_resolve(path) == path
+
+
+def test_strip_extended_path_prefix() -> None:
+    assert _strip_extended_path_prefix("\\\\?\\C:\\Users\\foo") == "C:\\Users\\foo"
+    assert (
+        _strip_extended_path_prefix("\\\\?\\UNC\\server\\share\\foo")
+        == "\\\\server\\share\\foo"
+    )
+    assert _strip_extended_path_prefix("C:\\Users\\foo") == "C:\\Users\\foo"
+    assert _strip_extended_path_prefix("/home/foo") == "/home/foo"
 
 
 def test_dump_path(tmp_upath: UPath) -> None:

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -330,12 +330,27 @@ def _resolve_local_path(path: UPath, _seen: frozenset[str] = frozenset()) -> UPa
             if key in _seen:
                 raise OSError(f"Symlink loop detected while resolving {path!r}")
             target = candidate.readlink()
+            target = target.with_segments(_strip_extended_path_prefix(str(target)))
             if not target.is_absolute():
                 target = resolved / target
             resolved = _resolve_local_path(target, _seen | {key})
         else:
             resolved = candidate
     return resolved
+
+
+def _strip_extended_path_prefix(path_str: str) -> str:
+    """Strips a Windows extended-length path prefix (`\\\\?\\` / `\\\\?\\UNC\\`).
+    `Path.readlink()` on Windows can return an absolute symlink target in this
+    form even for a plain drive-letter target; stripping it here keeps
+    `_resolve_local_path`'s output consistent with the pre-existing
+    (non-extended-prefix) path style used elsewhere in this codebase.
+    """
+    if path_str.startswith("\\\\?\\UNC\\"):
+        return "\\\\" + path_str[len("\\\\?\\UNC\\") :]
+    if path_str.startswith("\\\\?\\"):
+        return path_str[len("\\\\?\\") :]
+    return path_str
 
 
 def is_writable_path(path: UPath) -> bool:

--- a/webknossos/webknossos/utils.py
+++ b/webknossos/webknossos/utils.py
@@ -305,7 +305,37 @@ def cheap_resolve(path: UPath) -> UPath:
 
     if isinstance(path, HTTPPath):
         return path.resolve(follow_redirects=False, strict=False)
+    if is_fs_path(path):
+        return _resolve_local_path(path)
     return path.resolve()
+
+
+def _resolve_local_path(path: UPath, _seen: frozenset[str] = frozenset()) -> UPath:
+    r"""Resolves a local filesystem path, following real symlinks, without
+    invoking OS-level path canonicalization. `Path.resolve()` on Windows uses
+    `GetFinalPathNameByHandle`, which conflates symlink/junction resolution
+    with canonicalizing mapped/substituted drive letters into UNC form
+    (`\\server\share\...`), which TensorStore's local file driver rejects.
+    Walking the path one component at a time and only touching the filesystem
+    to follow actual symlinks avoids that conversion, since a mapped drive
+    letter is a drive-mapping-table entry, not something a component-wise
+    symlink check ever queries.
+    """
+    abs_path = path.with_segments(os.path.abspath(str(path)))
+    resolved = abs_path.with_segments(abs_path.parts[0])
+    for part in abs_path.parts[1:]:
+        candidate = resolved / part
+        if candidate.is_symlink():
+            key = str(candidate)
+            if key in _seen:
+                raise OSError(f"Symlink loop detected while resolving {path!r}")
+            target = candidate.readlink()
+            if not target.is_absolute():
+                target = resolved / target
+            resolved = _resolve_local_path(target, _seen | {key})
+        else:
+            resolved = candidate
+    return resolved
 
 
 def is_writable_path(path: UPath) -> bool:


### PR DESCRIPTION
## Problem

Fixes #1501.

When creating/opening a local WebKnossos dataset on a Windows **mapped network drive** (e.g. `Z:\ATLAS-examples\...`), `cheap_resolve()` (`webknossos/utils.py`) resolved the path via plain `Path.resolve()`. On Windows this goes through `GetFinalPathNameByHandle`, which conflates two unrelated behaviors: following real symlinks/junctions, and canonicalizing a substituted/mapped drive letter into its UNC form (`\\server\share\...`). That UNC path ends up in the TensorStore kvstore spec (`{"driver": "file", "path": ...}`), and TensorStore's local file driver rejects UNC paths outright — breaking dataset creation, downsampling, and upload for anyone working directly on a mapped drive.

## Fix

`cheap_resolve()` is the single chokepoint used by 14 call sites (dataset/layer root resolution, mag directory creation, attachment paths, `datasource-properties.json` serialization via `dump_path`/`enrich_path`, and foreign-mag detection). Several of those call sites genuinely depend on real symlink-following (webKnossos represents foreign/linked mags and attachments as local symlinks), so simply switching to `os.path.abspath` everywhere wasn't an option without touching several identity-comparison call sites.

Instead, `cheap_resolve()` now resolves local filesystem paths via a new `_resolve_local_path()` helper that walks the path one component at a time, only touching the filesystem to check/follow actual symlinks (`is_symlink()` / `readlink()`) — never calling `Path.resolve()`/any OS-level "final path name" API. Since a mapped/substituted drive letter is a drive-mapping-table concept (not a filesystem reparse point), this walk never triggers that canonicalization, while still correctly following real symlinks. This means **all 14 existing call sites are unchanged** — only the local-path resolution strategy inside `cheap_resolve()` itself changed.

**Known limitation:** on Windows, `Path.is_symlink()` recognizes NTFS symlinks but not junction points (a different reparse-point type), so a dataset using junctions rather than symlinks for foreign mags wouldn't be dereferenced by this walk. This matches what the rest of the codebase already creates (`Path.symlink_to()`), so it isn't a regression.

## Testing

- Added tests in `tests/test_utils.py` covering: `.`/`..`/relative normalization, symlink-following (absolute target, relative target, chained symlinks, reached via a `..`-containing path), symlink-loop detection, and non-strict handling of nonexistent paths.
- Verified the manual walk produces identical results to `Path.resolve()` for all symlink scenarios tested (POSIX sandbox — no Windows machine available to reproduce the UNC conversion directly, but the fix is grounded in documented `Path.resolve()`/`GetFinalPathNameByHandle` behavior on Windows).
- Ran the existing foreign-mag/symlink/attachment-copy test suites (`tests/dataset/test_attachments.py`, `tests/dataset/test_dataset.py`) to confirm no regression: 68/68 pass.
- `./precommit.sh` (format, lint, typecheck): clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)