### PR TITLE
Add support for new bigint segmentId format and HTTP API v15

### DIFF
--- a/docs/src/webknossos-py/spec/datasource_properties.md
+++ b/docs/src/webknossos-py/spec/datasource_properties.md
@@ -81,9 +81,24 @@ When `category` is `"segmentation"`, the following additional fields are availab
 
 | Field | Type | Required | Default | Description |
 |---|---|---|---|---|
-| `largestSegmentId` | `integer` | No | `null` | Highest segment ID present in the layer. Used by WEBKNOSSOS for ID management. |
+| `largestSegmentId` | `integer` or [BigIntEnvelope](#bigintenvelope) | No | `null` | Highest segment ID present in the layer. Used by WEBKNOSSOS for ID management. Values above `2^53 - 1` are written in a `BigIntEnvelope` instead of a number for compatibility with JavaScript. |
 | `mappings` | `string[]` | No | `[]` | List of available ID mapping names (e.g. for agglomerate mappings). |
 | `attachments` | [AttachmentsProperties](#attachmentsproperties) | No | `null` | References to auxiliary data files associated with this segmentation layer. Omitted if all sub-fields are empty. |
+
+#### BigIntEnvelope
+
+Segment IDs above `2^53 - 1` cannot be represented by JavaScript’s `number` type, so for compatibility they are wrapped in this envelope format in JSON instead of using a plain number:
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `customJsonEncoding` | `"bigint"` | Yes | Discriminator identifying this envelope. |
+| `value` | `string` | Yes | The id as a decimal string. |
+
+```json
+{ "largestSegmentId": { "customJsonEncoding": "bigint", "value": "18446744073709551615" } }
+```
+
+Values that fit safely (`<= 9007199254740991`) are still written as a plain integer. Both forms are always accepted when reading.
 
 ### N-Dimensional / 4D Layer Fields
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`; this is now understood transparently wherever segment ids occur (e.g. `largest_segment_id`, mesh `segment_id`).
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,7 +15,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
-- Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`; this is now understood transparently wherever segment ids occur (e.g. `largest_segment_id`, mesh `segment_id`).
+- Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
 
 ### Changed
 

--- a/webknossos/tests/client/test_context.py
+++ b/webknossos/tests/client/test_context.py
@@ -39,11 +39,14 @@ def test_login() -> None:
 
 
 @pytest.mark.parametrize(
-    "api_version,api_client_class", [(13, WkApiClientV13), (14, WkApiClient)]
+    "api_version,api_client_class",
+    [(13, WkApiClientV13), (14, WkApiClient), (15, WkApiClient)],
 )
 def test_webknossos_context_api_version(
     api_version: int, api_client_class: type
 ) -> None:
     with webknossos_context(api_version=api_version):
         assert _get_context().api_version == api_version
-        assert isinstance(_get_context().api_client, api_client_class)
+        api_client = _get_context().api_client
+        assert isinstance(api_client, api_client_class)
+        assert api_client.webknossos_api_version == api_version

--- a/webknossos/tests/client/test_context.py
+++ b/webknossos/tests/client/test_context.py
@@ -1,6 +1,6 @@
 import pytest
 
-from webknossos.client.api_client import WkApiClient, WkApiClientV13
+from webknossos.client.api_client import WkApiClient, WkApiClientV13, WkApiClientV14
 from webknossos.client.context import (
     _get_context,
     _WebknossosContext,
@@ -40,7 +40,7 @@ def test_login() -> None:
 
 @pytest.mark.parametrize(
     "api_version,api_client_class",
-    [(13, WkApiClientV13), (14, WkApiClient), (15, WkApiClient)],
+    [(13, WkApiClientV13), (14, WkApiClientV14), (15, WkApiClient)],
 )
 def test_webknossos_context_api_version(
     api_version: int, api_client_class: type

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -3226,6 +3226,77 @@ def test_get_largest_segment_id() -> None:
     assure_exported_properties(ds)
 
 
+def _largest_segment_id_on_disk(ds: Dataset, layer_name: str) -> int | dict[str, str]:
+    properties = json.loads((ds.path / PROPERTIES_FILE_NAME).read_text())
+    layer = next(
+        layer for layer in properties["dataLayers"] if layer["name"] == layer_name
+    )
+    return layer["largestSegmentId"]
+
+
+def test_largest_segment_id_bigint_envelope() -> None:
+    # Segment ids above 2**53 - 1 (the largest integer JS can represent exactly)
+    # are written as {"customJsonEncoding": "bigint", "value": "<decimal string>"}
+    # instead of a plain JSON number, see _bigint_envelope.py.
+    js_max_safe_integer = 2**53 - 1
+    huge_segment_id = 2**64 - 1  # full uint64 range
+
+    ds_path = prepare_dataset_path(DataFormat.WKW, TESTOUTPUT_DIR)
+    ds = Dataset(ds_path, voxel_size=(1, 1, 1))
+    segmentation_layer = ds.add_layer(
+        "segmentation",
+        SEGMENTATION_CATEGORY,
+        dtype="uint64",
+        largest_segment_id=huge_segment_id,
+    ).as_segmentation_layer()
+
+    assert segmentation_layer.largest_segment_id == huge_segment_id
+    assert _largest_segment_id_on_disk(ds, "segmentation") == {
+        "customJsonEncoding": "bigint",
+        "value": str(huge_segment_id),
+    }
+    assure_exported_properties(ds)
+
+    # a value that still fits into a JS-safe integer keeps the plain number format
+    segmentation_layer.largest_segment_id = js_max_safe_integer
+    assert _largest_segment_id_on_disk(ds, "segmentation") == js_max_safe_integer
+    assure_exported_properties(ds)
+
+    # one above the threshold switches back to the envelope
+    segmentation_layer.largest_segment_id = js_max_safe_integer + 1
+    assert _largest_segment_id_on_disk(ds, "segmentation") == {
+        "customJsonEncoding": "bigint",
+        "value": str(js_max_safe_integer + 1),
+    }
+    assure_exported_properties(ds)
+
+
+def test_read_largest_segment_id_bigint_envelope() -> None:
+    # A datasource-properties.json written by a newer WEBKNOSSOS version may
+    # already contain the envelope; the python client must understand it too.
+    huge_segment_id = 2**64 - 1
+
+    ds_path = prepare_dataset_path(DataFormat.WKW, TESTOUTPUT_DIR)
+    ds = Dataset(ds_path, voxel_size=(1, 1, 1))
+    ds.add_layer(
+        "segmentation", SEGMENTATION_CATEGORY, dtype="uint64", largest_segment_id=1
+    )
+
+    properties_path = ds.path / PROPERTIES_FILE_NAME
+    properties = json.loads(properties_path.read_text())
+    for layer in properties["dataLayers"]:
+        if layer["name"] == "segmentation":
+            layer["largestSegmentId"] = {
+                "customJsonEncoding": "bigint",
+                "value": str(huge_segment_id),
+            }
+    properties_path.write_text(json.dumps(properties))
+
+    reopened_ds = Dataset.open(ds.path)
+    segmentation_layer = reopened_ds.get_segmentation_layer("segmentation")
+    assert segmentation_layer.largest_segment_id == huge_segment_id
+
+
 def test_refresh_largest_segment_id() -> None:
     ds_path = prepare_dataset_path(DataFormat.WKW, TESTOUTPUT_DIR)
     ds = Dataset(ds_path, voxel_size=(1, 1, 1))

--- a/webknossos/webknossos/client/api_client/__init__.py
+++ b/webknossos/webknossos/client/api_client/__init__.py
@@ -1,13 +1,19 @@
-from .datastore_api_client import DatastoreApiClient, DatastoreApiClientV13
+from .datastore_api_client import (
+    DatastoreApiClient,
+    DatastoreApiClientV13,
+    DatastoreApiClientV14,
+)
 from .errors import ApiClientError
 from .tracingstore_api_client import TracingStoreApiClient
-from .wk_api_client import WkApiClient, WkApiClientV13
+from .wk_api_client import WkApiClient, WkApiClientV13, WkApiClientV14
 
 __all__ = [
     "WkApiClient",
     "WkApiClientV13",
+    "WkApiClientV14",
     "DatastoreApiClient",
     "DatastoreApiClientV13",
+    "DatastoreApiClientV14",
     "ApiClientError",
     "TracingStoreApiClient",
 ]

--- a/webknossos/webknossos/client/api_client/_abstract_api_client.py
+++ b/webknossos/webknossos/client/api_client/_abstract_api_client.py
@@ -25,7 +25,7 @@ class AbstractApiClient(ABC):
         self,
         timeout_seconds: float,
         headers: dict[str, str] | None = None,
-        webknossos_api_version: int = 14,
+        webknossos_api_version: int = 15,
     ):
         self.headers = headers
         self.timeout_seconds = timeout_seconds

--- a/webknossos/webknossos/client/api_client/_serialization.py
+++ b/webknossos/webknossos/client/api_client/_serialization.py
@@ -6,6 +6,10 @@ from attrs import fields as attr_fields
 from attrs import has as is_attr_class
 
 from ...dataset_properties import DatasetProperties
+from ...dataset_properties._bigint_envelope import (
+    structure_int_or_bigint_envelope,
+    unstructure_int_maybe_as_bigint_envelope,
+)
 from ...dataset_properties.structuring import get_dataset_converter
 from ...utils import snake_to_camel_case
 from .models import ApiUnusableDataSource
@@ -19,13 +23,24 @@ api_client_converter = cattrs.Converter()
 # However, the case conversion should happen only for the attrs classes,
 # and not for dicts that may contain user data (e.g. user experiences)
 
+# Fields that may exceed the JS-safe integer range and are therefore
+# (un-)wrapped from/to the bigint envelope, see _bigint_envelope.py. Names are
+# unique enough across apiclient.models that matching by name (rather than
+# per-class) is sufficient.
+_BIGINT_ENVELOPE_FIELD_NAMES = {"largest_segment_id", "segment_id"}
+
 
 def attr_to_camel_case_structure(cl: type[T]) -> Callable[[Mapping[str, Any], Any], T]:
     return cattrs.gen.make_dict_structure_fn(
         cl,
         api_client_converter,
         **{
-            a.name: cattrs.gen.override(rename=snake_to_camel_case(a.name))
+            a.name: cattrs.gen.override(
+                rename=snake_to_camel_case(a.name),
+                struct_hook=structure_int_or_bigint_envelope
+                if a.name in _BIGINT_ENVELOPE_FIELD_NAMES
+                else None,
+            )
             # https://github.com/python/mypy/issues/16254
             for a in attr_fields(cl)  # type: ignore[arg-type,misc]
         },
@@ -37,7 +52,12 @@ def attr_to_camel_case_unstructure(cl: type[T]) -> Callable[[T], dict[str, Any]]
         cl,
         api_client_converter,
         **{
-            a.name: cattrs.gen.override(rename=snake_to_camel_case(a.name))
+            a.name: cattrs.gen.override(
+                rename=snake_to_camel_case(a.name),
+                unstruct_hook=unstructure_int_maybe_as_bigint_envelope
+                if a.name in _BIGINT_ENVELOPE_FIELD_NAMES
+                else None,
+            )
             # https://github.com/python/mypy/issues/16254
             for a in attr_fields(cl)  # type: ignore[arg-type,misc]
         },

--- a/webknossos/webknossos/client/api_client/_serialization.py
+++ b/webknossos/webknossos/client/api_client/_serialization.py
@@ -23,10 +23,8 @@ api_client_converter = cattrs.Converter()
 # However, the case conversion should happen only for the attrs classes,
 # and not for dicts that may contain user data (e.g. user experiences)
 
-# Fields that may exceed the JS-safe integer range and are therefore
-# (un-)wrapped from/to the bigint envelope, see _bigint_envelope.py. Names are
-# unique enough across apiclient.models that matching by name (rather than
-# per-class) is sufficient.
+# Fields that may exceed the JS-safe integer range are wrapped/unwrapped in special biging envelope in JSON.
+# Matching on field names for this is currently sufficient.
 _BIGINT_ENVELOPE_FIELD_NAMES = {"largest_segment_id", "segment_id"}
 
 

--- a/webknossos/webknossos/client/api_client/_serialization.py
+++ b/webknossos/webknossos/client/api_client/_serialization.py
@@ -23,7 +23,7 @@ api_client_converter = cattrs.Converter()
 # However, the case conversion should happen only for the attrs classes,
 # and not for dicts that may contain user data (e.g. user experiences)
 
-# Fields that may exceed the JS-safe integer range are wrapped/unwrapped in special biging envelope in JSON.
+# Fields that may exceed the JS-safe integer range are wrapped/unwrapped in special bigint envelope in JSON.
 # Matching on field names for this is currently sufficient.
 _BIGINT_ENVELOPE_FIELD_NAMES = {"largest_segment_id", "segment_id"}
 

--- a/webknossos/webknossos/client/api_client/datastore_api_client.py
+++ b/webknossos/webknossos/client/api_client/datastore_api_client.py
@@ -27,8 +27,9 @@ class DatastoreApiClient(AbstractApiClient):
         datastore_base_url: str,
         timeout_seconds: float,
         headers: dict[str, str] | None = None,
+        webknossos_api_version: int = 15,
     ):
-        super().__init__(timeout_seconds, headers)
+        super().__init__(timeout_seconds, headers, webknossos_api_version)
         self.datastore_base_url = datastore_base_url.rstrip("/")
 
     @property

--- a/webknossos/webknossos/client/api_client/datastore_api_client.py
+++ b/webknossos/webknossos/client/api_client/datastore_api_client.py
@@ -27,9 +27,8 @@ class DatastoreApiClient(AbstractApiClient):
         datastore_base_url: str,
         timeout_seconds: float,
         headers: dict[str, str] | None = None,
-        webknossos_api_version: int = 15,
     ):
-        super().__init__(timeout_seconds, headers, webknossos_api_version)
+        super().__init__(timeout_seconds, headers)
         self.datastore_base_url = datastore_base_url.rstrip("/")
 
     @property
@@ -246,3 +245,19 @@ class DatastoreApiClientV13(DatastoreApiClient):
 
     def attachment_finish_upload(self, *, upload_id: str, retry_count: int) -> None:
         raise NotImplementedError("attachment upload requires API version 14+")
+
+
+class DatastoreApiClientV14(DatastoreApiClient):
+    def __init__(
+        self,
+        *,
+        datastore_base_url: str,
+        timeout_seconds: float,
+        headers: dict[str, str] | None = None,
+    ):
+        super().__init__(
+            datastore_base_url=datastore_base_url,
+            timeout_seconds=timeout_seconds,
+            headers=headers,
+        )
+        self.webknossos_api_version = 14

--- a/webknossos/webknossos/client/api_client/wk_api_client.py
+++ b/webknossos/webknossos/client/api_client/wk_api_client.py
@@ -60,9 +60,8 @@ class WkApiClient(AbstractApiClient):
         base_wk_url: str,
         timeout_seconds: float,
         headers: dict[str, str] | None = None,
-        webknossos_api_version: int = 15,
     ):
-        super().__init__(timeout_seconds, headers, webknossos_api_version)
+        super().__init__(timeout_seconds, headers)
         self.base_wk_url = base_wk_url.rstrip("/")
 
     @property
@@ -512,3 +511,19 @@ class WkApiClientV13(WkApiClient):
             headers=headers,
         )
         self.webknossos_api_version = 13
+
+
+class WkApiClientV14(WkApiClient):
+    def __init__(
+        self,
+        *,
+        base_wk_url: str,
+        timeout_seconds: float,
+        headers: dict[str, str] | None = None,
+    ):
+        super().__init__(
+            base_wk_url=base_wk_url,
+            timeout_seconds=timeout_seconds,
+            headers=headers,
+        )
+        self.webknossos_api_version = 14

--- a/webknossos/webknossos/client/api_client/wk_api_client.py
+++ b/webknossos/webknossos/client/api_client/wk_api_client.py
@@ -60,8 +60,9 @@ class WkApiClient(AbstractApiClient):
         base_wk_url: str,
         timeout_seconds: float,
         headers: dict[str, str] | None = None,
+        webknossos_api_version: int = 15,
     ):
-        super().__init__(timeout_seconds, headers)
+        super().__init__(timeout_seconds, headers, webknossos_api_version)
         self.base_wk_url = base_wk_url.rstrip("/")
 
     @property

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -68,9 +68,11 @@ from ._defaults import DEFAULT_HTTP_TIMEOUT, DEFAULT_WEBKNOSSOS_URL
 from .api_client import (
     DatastoreApiClient,
     DatastoreApiClientV13,
+    DatastoreApiClientV14,
     TracingStoreApiClient,
     WkApiClient,
     WkApiClientV13,
+    WkApiClientV14,
 )
 
 load_dotenv()
@@ -138,33 +140,25 @@ class _WebknossosContext:
 
     @cached_property
     def api_client(self) -> WkApiClient:
-        if self.api_version == 13:
-            return WkApiClientV13(
-                base_wk_url=self.url,
-                headers={} if self.token is None else {"X-Auth-Token": self.token},
-                timeout_seconds=self.timeout,
-            )
-        # The v14 client can fully handle v15 server, so no special code is needed there.
-        return WkApiClient(
+        cls: type[WkApiClient] = {
+            13: WkApiClientV13,
+            14: WkApiClientV14,
+        }.get(self.api_version, WkApiClient)
+        return cls(
             base_wk_url=self.url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},
             timeout_seconds=self.timeout,
-            webknossos_api_version=self.api_version,
         )
 
     def get_datastore_api_client(self, datastore_url: str) -> DatastoreApiClient:
-        if self.api_version == 13:
-            return DatastoreApiClientV13(
-                datastore_base_url=datastore_url,
-                headers={} if self.token is None else {"X-Auth-Token": self.token},
-                timeout_seconds=self.timeout,
-            )
-        # The v14 client can fully handle v15 server, so no special code is needed there.
-        return DatastoreApiClient(
+        cls: type[DatastoreApiClient] = {
+            13: DatastoreApiClientV13,
+            14: DatastoreApiClientV14,
+        }.get(self.api_version, DatastoreApiClient)
+        return cls(
             datastore_base_url=datastore_url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},
             timeout_seconds=self.timeout,
-            webknossos_api_version=self.api_version,
         )
 
     def get_tracingstore_api_client(self) -> TracingStoreApiClient:

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -144,6 +144,7 @@ class _WebknossosContext:
                 headers={} if self.token is None else {"X-Auth-Token": self.token},
                 timeout_seconds=self.timeout,
             )
+        # The v14 client can fully handle v15 server, so no special code is needed there.
         return WkApiClient(
             base_wk_url=self.url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},
@@ -158,6 +159,7 @@ class _WebknossosContext:
                 headers={} if self.token is None else {"X-Auth-Token": self.token},
                 timeout_seconds=self.timeout,
             )
+        # The v14 client can fully handle v15 server, so no special code is needed there.
         return DatastoreApiClient(
             datastore_base_url=datastore_url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},

--- a/webknossos/webknossos/client/context.py
+++ b/webknossos/webknossos/client/context.py
@@ -75,7 +75,7 @@ from .api_client import (
 
 load_dotenv()
 
-LIBRARY_SUPPORTED_API_VERSIONS = {13, 14}
+LIBRARY_SUPPORTED_API_VERSIONS = {13, 14, 15}
 
 
 @cache
@@ -138,19 +138,31 @@ class _WebknossosContext:
 
     @cached_property
     def api_client(self) -> WkApiClient:
-        cls = WkApiClientV13 if self.api_version == 13 else WkApiClient
-        return cls(
+        if self.api_version == 13:
+            return WkApiClientV13(
+                base_wk_url=self.url,
+                headers={} if self.token is None else {"X-Auth-Token": self.token},
+                timeout_seconds=self.timeout,
+            )
+        return WkApiClient(
             base_wk_url=self.url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},
             timeout_seconds=self.timeout,
+            webknossos_api_version=self.api_version,
         )
 
     def get_datastore_api_client(self, datastore_url: str) -> DatastoreApiClient:
-        cls = DatastoreApiClientV13 if self.api_version == 13 else DatastoreApiClient
-        return cls(
+        if self.api_version == 13:
+            return DatastoreApiClientV13(
+                datastore_base_url=datastore_url,
+                headers={} if self.token is None else {"X-Auth-Token": self.token},
+                timeout_seconds=self.timeout,
+            )
+        return DatastoreApiClient(
             datastore_base_url=datastore_url,
             headers={} if self.token is None else {"X-Auth-Token": self.token},
             timeout_seconds=self.timeout,
+            webknossos_api_version=self.api_version,
         )
 
     def get_tracingstore_api_client(self) -> TracingStoreApiClient:

--- a/webknossos/webknossos/dataset_properties/_bigint_envelope.py
+++ b/webknossos/webknossos/dataset_properties/_bigint_envelope.py
@@ -1,19 +1,15 @@
-"""Codec for WEBKNOSSOS's "bigint envelope" JSON format.
+"""Codec for WEBKNOSSOS’s “bigint envelope” JSON format.
 
-Segment/agglomerate ids can use the full uint64 range, which JavaScript's
-`number` type (and thus plain JSON numbers, as consumed by JS-based tools)
-cannot represent exactly beyond 2**53 - 1. Starting with API version 15,
-WEBKNOSSOS therefore wraps such ids in a self-describing envelope instead of
-emitting them as a plain JSON number, e.g.:
+Segment ids can use the full uint64 range, while JavaScript number can only
+handle 2**53 - 1. WEBKNOSSOS therefore wraps such ids in an envelope in JSON:
 
     {"customJsonEncoding": "bigint", "value": "18446744073709551615"}
 
 Plain JSON numbers are still accepted (and, for values that fit safely,
-emitted) for backwards compatibility with older API versions and with
-datasource-properties.json files written before this format was introduced.
+emitted)
 
-Python's `int` is arbitrary-precision, so the decoded value needs no special
-handling on the Python side - only the envelope itself needs to be
+Python’s `int` is arbitrary-precision, so the decoded value needs no special
+handling on the Python side. Only the envelope itself needs to be
 recognized and unwrapped/wrapped.
 """
 
@@ -23,13 +19,11 @@ _ENCODING_KEY = "customJsonEncoding"
 _ENCODING_VALUE = "bigint"
 
 # The largest integer JavaScript can represent exactly. Values up to this are
-# still written as a plain JSON number for backwards compatibility.
+# still written as plain JSON number.
 _JS_MAX_SAFE_INTEGER = 2**53 - 1
 
 
 def structure_int_or_bigint_envelope(value: Any, _type: Any = None) -> int | None:
-    """Parses an int that may be encoded as a plain JSON number or as the
-    bigint envelope shown above."""
     if value is None:
         return None
     if isinstance(value, dict) and value.get(_ENCODING_KEY) == _ENCODING_VALUE:
@@ -38,9 +32,6 @@ def structure_int_or_bigint_envelope(value: Any, _type: Any = None) -> int | Non
 
 
 def unstructure_int_maybe_as_bigint_envelope(value: int | None) -> Any:
-    """Inverse of `structure_int_or_bigint_envelope`: keeps values that fit
-    into a JS-safe integer as plain ints, and wraps larger values in the
-    bigint envelope to avoid losing precision."""
     if value is None:
         return None
     if value > _JS_MAX_SAFE_INTEGER:

--- a/webknossos/webknossos/dataset_properties/_bigint_envelope.py
+++ b/webknossos/webknossos/dataset_properties/_bigint_envelope.py
@@ -1,0 +1,48 @@
+"""Codec for WEBKNOSSOS's "bigint envelope" JSON format.
+
+Segment/agglomerate ids can use the full uint64 range, which JavaScript's
+`number` type (and thus plain JSON numbers, as consumed by JS-based tools)
+cannot represent exactly beyond 2**53 - 1. Starting with API version 15,
+WEBKNOSSOS therefore wraps such ids in a self-describing envelope instead of
+emitting them as a plain JSON number, e.g.:
+
+    {"customJsonEncoding": "bigint", "value": "18446744073709551615"}
+
+Plain JSON numbers are still accepted (and, for values that fit safely,
+emitted) for backwards compatibility with older API versions and with
+datasource-properties.json files written before this format was introduced.
+
+Python's `int` is arbitrary-precision, so the decoded value needs no special
+handling on the Python side - only the envelope itself needs to be
+recognized and unwrapped/wrapped.
+"""
+
+from typing import Any
+
+_ENCODING_KEY = "customJsonEncoding"
+_ENCODING_VALUE = "bigint"
+
+# The largest integer JavaScript can represent exactly. Values up to this are
+# still written as a plain JSON number for backwards compatibility.
+_JS_MAX_SAFE_INTEGER = 2**53 - 1
+
+
+def structure_int_or_bigint_envelope(value: Any, _type: Any = None) -> int | None:
+    """Parses an int that may be encoded as a plain JSON number or as the
+    bigint envelope shown above."""
+    if value is None:
+        return None
+    if isinstance(value, dict) and value.get(_ENCODING_KEY) == _ENCODING_VALUE:
+        return int(value["value"])
+    return int(value)
+
+
+def unstructure_int_maybe_as_bigint_envelope(value: int | None) -> Any:
+    """Inverse of `structure_int_or_bigint_envelope`: keeps values that fit
+    into a JS-safe integer as plain ints, and wraps larger values in the
+    bigint envelope to avoid losing precision."""
+    if value is None:
+        return None
+    if value > _JS_MAX_SAFE_INTEGER:
+        return {_ENCODING_KEY: _ENCODING_VALUE, "value": str(value)}
+    return value

--- a/webknossos/webknossos/dataset_properties/structuring.py
+++ b/webknossos/webknossos/dataset_properties/structuring.py
@@ -20,6 +20,10 @@ from ..dataset_properties import (
     SegmentationLayerProperties,
     length_unit_from_str,
 )
+from ..dataset_properties._bigint_envelope import (
+    structure_int_or_bigint_envelope,
+    unstructure_int_maybe_as_bigint_envelope,
+)
 from ..dataset_properties.dataset_properties import DEFAULT_LENGTH_UNIT_STR
 from ..geometry import Mag, NormalizedBoundingBox, Vec3Float, Vec3Int
 from ..utils import snake_to_camel_case
@@ -240,6 +244,8 @@ def get_dataset_converter() -> cattr.Converter:
             ),
         )
 
+    # largest_segment_id may exceed the JS-safe integer range and is then
+    # (un-)wrapped from/to the bigint envelope, see _bigint_envelope.py.
     for cls in [
         LayerProperties,
         SegmentationLayerProperties,
@@ -252,7 +258,11 @@ def get_dataset_converter() -> cattr.Converter:
                     dataset_converter,
                     **{
                         a.name: override(
-                            omit_if_default=True, rename=snake_to_camel_case(a.name)
+                            omit_if_default=True,
+                            rename=snake_to_camel_case(a.name),
+                            unstruct_hook=unstructure_int_maybe_as_bigint_envelope
+                            if a.name == "largest_segment_id"
+                            else None,
                         )
                         for a in attr.fields(cls)  # type: ignore
                     },
@@ -266,7 +276,12 @@ def get_dataset_converter() -> cattr.Converter:
                     cls,
                     dataset_converter,
                     **{
-                        a.name: override(rename=snake_to_camel_case(a.name))
+                        a.name: override(
+                            rename=snake_to_camel_case(a.name),
+                            struct_hook=structure_int_or_bigint_envelope
+                            if a.name == "largest_segment_id"
+                            else None,
+                        )
                         for a in attr.fields(cls)  # type: ignore
                     },
                 )

--- a/webknossos/webknossos/dataset_properties/structuring.py
+++ b/webknossos/webknossos/dataset_properties/structuring.py
@@ -244,8 +244,6 @@ def get_dataset_converter() -> cattr.Converter:
             ),
         )
 
-    # largest_segment_id may exceed the JS-safe integer range and is then
-    # (un-)wrapped from/to the bigint envelope, see _bigint_envelope.py.
     for cls in [
         LayerProperties,
         SegmentationLayerProperties,


### PR DESCRIPTION
### Description:
- WK now supports full uint64 range for segment ids, and introduced an envelope format for large segment ids in JSON (both API responses, now API v15 and datasource-properties.json files on disk)
- This PR adapts the libs to those changes.

### Corresponding WEBKNOSSOS PR:
- https://github.com/scalableminds/webknossos/pull/9765

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests
