### PR TITLE
Fix UnexpectedStatusError/CannotHandleResponseError breaking when unpickled

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -20,6 +20,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Fixed
 - Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1513](https://github.com/scalableminds/webknossos-libs/issues/1513)
+- Fixed that `UnexpectedStatusError` and `CannotHandleResponseError` raised an `AttributeError` when unpickled (e.g. when raised inside a `ProcessPoolExecutor` worker), instead of reproducing the original error.
 
 
 ## [3.7.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.7.0) - 2026-08-12

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -1406,7 +1406,7 @@ def test_open_dataset_without_num_channels_in_properties() -> None:
 @pytest.mark.skip_on_windows
 def test_explore_and_add_remote() -> None:
     remote_ds = RemoteDataset.explore_and_add_remote(
-        "http://localhost:9000/data/v9/zarr/Organization_X/l4_sample/",
+        "http://localhost:9000/data/zarr/Organization_X/l4_sample/",
         "added_remote_ds",
         folder=RemoteFolder.get_by_path("Organization_X"),
     )

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -1407,7 +1407,7 @@ def test_open_dataset_without_num_channels_in_properties() -> None:
 def test_explore_and_add_remote() -> None:
     remote_ds = RemoteDataset.explore_and_add_remote(
         # l4_sample from the test database
-        "http://localhost:9000/data/zarr/59e9cfbdba632ac2ab8b23b5/",
+        "http://localhost:9000/data/v15/zarr/59e9cfbdba632ac2ab8b23b5/",
         "added_remote_ds",
         folder=RemoteFolder.get_by_path("Organization_X"),
     )

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -1406,7 +1406,8 @@ def test_open_dataset_without_num_channels_in_properties() -> None:
 @pytest.mark.skip_on_windows
 def test_explore_and_add_remote() -> None:
     remote_ds = RemoteDataset.explore_and_add_remote(
-        "http://localhost:9000/data/zarr/Organization_X/l4_sample/",
+        # l4_sample from the test database
+        "http://localhost:9000/data/zarr/59e9cfbdba632ac2ab8b23b5/",
         "added_remote_ds",
         folder=RemoteFolder.get_by_path("Organization_X"),
     )

--- a/webknossos/webknossos/client/api_client/errors.py
+++ b/webknossos/webknossos/client/api_client/errors.py
@@ -1,7 +1,20 @@
+from typing import Any
+
 import httpx
 
 
+def _reconstruct_api_client_error(cls: type, args: tuple) -> "ApiClientError":
+    # Bypasses the subclasses' __init__ (which requires a live httpx.Response)
+    # since pickle reconstructs exceptions from their formatted message only.
+    exc: ApiClientError = Exception.__new__(cls)
+    Exception.__init__(exc, *args)
+    return exc
+
+
 class ApiClientError(Exception):
+    def __reduce__(self) -> tuple[Any, ...]:
+        return (_reconstruct_api_client_error, (self.__class__, self.args))
+
     def message_for_response_body(self, response: httpx.Response) -> str:
         response_limit_chars = 2000
 


### PR DESCRIPTION
## Summary

`UnexpectedStatusError` and `CannotHandleResponseError` (`webknossos/webknossos/client/api_client/errors.py`) crashed with `AttributeError: 'str' object has no attribute 'request'` whenever they were unpickled — for example when raised inside a `ProcessPoolExecutor`/`multiprocessing` worker and shipped back to the parent process.

## Root cause

Both exceptions require a live `httpx.Response` in `__init__` to build their message. `BaseException`'s default `__reduce__` pickles only `self.args` (the already-formatted message string) and reconstructs the exception on unpickling via `cls(*self.args)`. So unpickling called e.g. `UnexpectedStatusError(msg_string)`, which set `response` to that string. `request_label` then accessed `response.request`, raising the `AttributeError` seen in the reported traceback:

```
File ".../errors.py", line 19, in request_label
    if response.request is None:
       ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'request'
```

## Fix

Added a `__reduce__` override on `ApiClientError` that reconstructs the exception via plain `Exception.__init__`, using the already-formatted message and bypassing the subclasses' custom `__init__` (which needs a live response object) during unpickling. This covers both `UnexpectedStatusError` and `CannotHandleResponseError` since they both inherit from `ApiClientError`.

## Testing

- Verified a direct `pickle.dumps`/`pickle.loads` round-trip on both exception types preserves subclass identity and message.
- Reproduced the original failure mode with a `ProcessPoolExecutor` worker raising `UnexpectedStatusError`; confirmed it is now caught correctly in the parent process with the full message intact.
- Ran `./precommit.sh` (ruff format, lint, mypy across `webknossos`, `tests`, `examples`, `script_collection`) — all pass.
- Added a `Changelog.md` entry under `Unreleased > Fixed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)