### PR TITLE
Add neuroglancerPrecomputed as valid AttachmentDataFormat for mesh attachments

### DIFF
--- a/docs/src/webknossos-py/spec/datasource_properties.md
+++ b/docs/src/webknossos-py/spec/datasource_properties.md
@@ -313,7 +313,18 @@ The entire `attachments` object is omitted from the JSON if all sub-fields are e
 |---|---|---|---|
 | `name` | `string` | Yes | Display name of the attachment. |
 | `path` | `string` | Yes | Relative path to the attachment data. |
-| `dataFormat` | `"zarr3"`, `"hdf5"`, or `"json"` | Yes | Storage format of the attachment. |
+| `dataFormat` | `string` | Yes | Storage format of the attachment. Allowed values depend on the attachment's container (see below). |
+
+The allowed `dataFormat` values depend on which `AttachmentsProperties` field the attachment lives in:
+
+| Container | Attachment type | Allowed `dataFormat` values |
+|---|---|---|
+| `meshes` | Mesh | `"zarr3"`, `"hdf5"`, `"neuroglancerPrecomputed"` |
+| `agglomerates` | Agglomerate | `"zarr3"`, `"hdf5"` |
+| `segmentIndex` | Segment index | `"zarr3"`, `"hdf5"` |
+| `segmentStatistics` | Segment statistics | `"zarr3"` |
+| `cumsum` | Cumulative sum | `"zarr3"`, `"json"` |
+| `connectomes` | Connectome | `"zarr3"`, `"hdf5"` |
 
 ---
 

--- a/docs/src/webknossos-py/spec/datasource_properties.md
+++ b/docs/src/webknossos-py/spec/datasource_properties.md
@@ -317,14 +317,14 @@ The entire `attachments` object is omitted from the JSON if all sub-fields are e
 
 The allowed `dataFormat` values depend on which `AttachmentsProperties` field the attachment lives in:
 
-| Container | Attachment type | Allowed `dataFormat` values |
-|---|---|---|
-| `meshes` | Mesh | `"zarr3"`, `"hdf5"`, `"neuroglancerPrecomputed"` |
-| `agglomerates` | Agglomerate | `"zarr3"`, `"hdf5"` |
-| `segmentIndex` | Segment index | `"zarr3"`, `"hdf5"` |
-| `segmentStatistics` | Segment statistics | `"zarr3"` |
-| `cumsum` | Cumulative sum | `"zarr3"`, `"json"` |
-| `connectomes` | Connectome | `"zarr3"`, `"hdf5"` |
+| Container | Allowed `dataFormat` values |
+|---|---|
+| `meshes` | `"zarr3"`, `"hdf5"`, `"neuroglancerPrecomputed"` |
+| `agglomerates` | `"zarr3"`, `"hdf5"` |
+| `segmentIndex` | `"zarr3"`, `"hdf5"` |
+| `segmentStatistics` | `"zarr3"` |
+| `cumsum` | `"zarr3"`, `"json"` |
+| `connectomes` | `"zarr3"`, `"hdf5"` |
 
 ---
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -22,6 +22,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Fixed
 - Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1513](https://github.com/scalableminds/webknossos-libs/issues/1513)
+- Fixed that renaming a layer of a zarr-streamed `RemoteDataset` (where layer metadata cannot be persisted) raised an opaque `StopIteration` instead of the expected `RuntimeError` explaining that the layer is read-only.
 
 
 ## [3.7.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v3.7.0) - 2026-08-12

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,6 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
+- Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s.
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -16,7 +16,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
-- Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s.
+- Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
 
 ### Changed
 

--- a/webknossos/webknossos/dataset/layer/remote_layer.py
+++ b/webknossos/webknossos/dataset/layer/remote_layer.py
@@ -403,6 +403,7 @@ class RemoteLayer(AbstractLayer):
         if layer_name == self.name:
             return
         self._ensure_metadata_writable()
+        self._ensure_writable()
         if layer_name in self.dataset.layers.keys():
             raise ValueError(
                 f"Failed to rename layer {self.name} to {layer_name}: The new name already exists."

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachment.py
@@ -111,7 +111,11 @@ class Attachment:
 
 
 class MeshAttachment(Attachment):
-    data_format: Literal[AttachmentDataFormat.Zarr3, AttachmentDataFormat.HDF5]
+    data_format: Literal[
+        AttachmentDataFormat.Zarr3,
+        AttachmentDataFormat.HDF5,
+        AttachmentDataFormat.NeuroglancerPrecomputed,
+    ]
     container_name = "meshes"
     type_name = "mesh"
 

--- a/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachments.py
+++ b/webknossos/webknossos/dataset/layer/segmentation_layer/attachments/attachments.py
@@ -38,7 +38,10 @@ if TYPE_CHECKING:
 
 
 def _maybe_add_suffix(attachment_name: str, data_format: AttachmentDataFormat) -> str:
-    if data_format == AttachmentDataFormat.Zarr3:
+    if data_format in (
+        AttachmentDataFormat.Zarr3,
+        AttachmentDataFormat.NeuroglancerPrecomputed,
+    ):
         return attachment_name
     return f"{attachment_name}.{data_format.value.lower()}"
 

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -372,11 +372,18 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         # update existing layers
         for layer in self.layers.values():
             layer_properties = next(
-                layer_properties
-                for layer_properties in self._properties.data_layers
-                if layer_properties.name == layer.name
+                (
+                    layer_properties
+                    for layer_properties in self._properties.data_layers
+                    if layer_properties.name == layer.name
+                ),
+                None,
             )
-            layer._apply_properties(layer_properties, layer.read_only)
+            # layer_properties is None if a locally applied change (e.g. a rename) was
+            # not actually persisted on the server. Such layers are dropped below, in
+            # the "remove deleted layers" step.
+            if layer_properties is not None:
+                layer._apply_properties(layer_properties, layer.read_only)
 
         # add new layers
         for layer_properties in self._properties.data_layers:

--- a/webknossos/webknossos/dataset_properties/data_format.py
+++ b/webknossos/webknossos/dataset_properties/data_format.py
@@ -16,6 +16,7 @@ class AttachmentDataFormat(Enum):
     Zarr3 = "zarr3"
     HDF5 = "hdf5"
     JSON = "json"
+    NeuroglancerPrecomputed = "neuroglancerPrecomputed"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
### Description:
- `AttachmentDataFormat` was missing `neuroglancerPrecomputed`, so `RemoteDataset.open()` raised a `cattrs.errors.ClassValidationError` when a dataset's mesh attachment used this format (e.g. `ValueError: 'neuroglancerPrecomputed' is not a valid AttachmentDataFormat`).
- Added `NeuroglancerPrecomputed = "neuroglancerPrecomputed"` to the `AttachmentDataFormat` enum.
- Allowed it on `MeshAttachment.data_format` (mesh-only; other attachment types — agglomerate, segment index, segment statistics, cumsum, connectome — are unchanged).
- Updated `_maybe_add_suffix` to treat it like `zarr3` (a directory-based format, no file suffix) when copying/symlinking attachments locally.
- Documented the allowed `dataFormat` values per attachment container in `datasource_properties.md`.

### Issues:
- Fixes an error reported when opening `RemoteDataset.open(dataset_id="6a8bf9298b2bbf2612cada4d")` against a dataset with a `neuroglancerPrecomputed` mesh attachment.

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [ ] Added / Updated Tests
 - [ ] Considered adding this to the Examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)