### PR TITLE
Add mag override to add_mag_as_copy

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,10 +17,13 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
 - Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
+- Added a `mag` keyword to `Layer.add_mag_as_copy` and `RemoteLayer.add_mag_as_copy` to register the copied data under a different resolution level than it has in the source dataset, matching the existing `mag` keyword of `add_mag_as_ref`.
 
 ### Changed
+- `Layer.add_mag_as_ref` and `RemoteLayer.add_mag_as_ref` now extend the layer bounding box by the foreign bounding box rescaled to the target mag when the `mag` keyword overrides the source mag. Previously the unscaled foreign bounding box was used, which did not match where the referenced voxels actually are in Mag(1).
 
 ### Fixed
+- Fixed that changing a layer's bounding box resized the arrays of read-only mags, which modified the array metadata of the foreign dataset that a mag added with `add_mag_as_ref` points to.
 - Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1513](https://github.com/scalableminds/webknossos-libs/issues/1513)
 - Fixed that renaming a layer of a zarr-streamed `RemoteDataset` (where layer metadata cannot be persisted) raised an opaque `StopIteration` instead of the expected `RuntimeError` explaining that the layer is read-only. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
 - Fixed that `UnexpectedStatusError` and `CannotHandleResponseError` raised an `AttributeError` when unpickled (e.g. when raised inside a `ProcessPoolExecutor` worker), instead of reproducing the original error. [#1517](https://github.com/scalableminds/webknossos-libs/pull/1517)

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,13 +17,13 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
 - Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
-- Added a `mag` keyword to `Layer.add_mag_as_copy` and `RemoteLayer.add_mag_as_copy` to register the copied data under a different resolution level than it has in the source dataset, matching the existing `mag` keyword of `add_mag_as_ref`.
+- Added a `mag` keyword to `Layer.add_mag_as_copy` and `RemoteLayer.add_mag_as_copy` to register the copied data under a different resolution level than it has in the source dataset, matching the existing `mag` keyword of `add_mag_as_ref`. [#1526](https://github.com/scalableminds/webknossos-libs/pull/1526)
 
 ### Changed
-- `Layer.add_mag_as_ref` and `RemoteLayer.add_mag_as_ref` now extend the layer bounding box by the foreign bounding box rescaled to the target mag when the `mag` keyword overrides the source mag. Previously the unscaled foreign bounding box was used, which did not match where the referenced voxels actually are in Mag(1).
+- `Layer.add_mag_as_ref` and `RemoteLayer.add_mag_as_ref` now extend the layer bounding box by the foreign bounding box rescaled to the target mag when the `mag` keyword overrides the source mag. Previously the unscaled foreign bounding box was used, which did not match where the referenced voxels actually are in Mag(1). [#1526](https://github.com/scalableminds/webknossos-libs/pull/1526)
 
 ### Fixed
-- Fixed that changing a layer's bounding box resized the arrays of read-only mags, which modified the array metadata of the foreign dataset that a mag added with `add_mag_as_ref` points to.
+- Fixed that changing a layer's bounding box resized the arrays of read-only mags, which modified the array metadata of the foreign dataset that a mag added with `add_mag_as_ref` points to. [#1526](https://github.com/scalableminds/webknossos-libs/pull/1526)
 - Fixed that local dataset/layer/mag/attachment path resolution on Windows converted mapped/substituted network drives (e.g. `Z:\...`) to their UNC form (`\\server\share\...`), which TensorStore's local file driver rejected. [#1513](https://github.com/scalableminds/webknossos-libs/issues/1513)
 - Fixed that renaming a layer of a zarr-streamed `RemoteDataset` (where layer metadata cannot be persisted) raised an opaque `StopIteration` instead of the expected `RuntimeError` explaining that the layer is read-only. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
 - Fixed that `UnexpectedStatusError` and `CannotHandleResponseError` raised an `AttributeError` when unpickled (e.g. when raised inside a `ProcessPoolExecutor` worker), instead of reproducing the original error. [#1517](https://github.com/scalableminds/webknossos-libs/pull/1517)

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -2223,6 +2223,44 @@ def test_add_mag_as_ref(data_format: DataFormat, output_path: UPath) -> None:
 
 
 @pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
+def test_extending_bounding_box_leaves_referenced_mag_untouched(
+    data_format: DataFormat, output_path: UPath
+) -> None:
+    ds_path = prepare_dataset_path(data_format, output_path, "original")
+    new_path = prepare_dataset_path(data_format, output_path, "with_ref")
+
+    original_ds = Dataset(ds_path, voxel_size=(1, 1, 1))
+    original_layer = original_ds.add_layer(
+        "color",
+        COLOR_CATEGORY,
+        dtype="uint8",
+        data_format=data_format,
+        bounding_box=BoundingBox((0, 0, 0), (10, 20, 30)),
+    )
+    original_data = (np.random.rand(10, 20, 30) * 255).astype(np.uint8)
+    original_mag = original_layer.add_mag(1)
+    original_mag.write(data=original_data)
+    original_array_bbox = original_mag.info.bounding_box
+
+    ds = Dataset(new_path, voxel_size=(1, 1, 1))
+    layer = ds.add_layer(
+        "color", COLOR_CATEGORY, dtype="uint8", data_format=data_format
+    )
+    assert layer.add_mag_as_ref(original_mag).read_only
+
+    layer.bounding_box = layer.bounding_box.extended_by(
+        BoundingBox((0, 0, 0), (100, 100, 100))
+    )
+
+    reopened_mag = Dataset.open(ds_path).get_layer("color").get_mag(1)
+    assert reopened_mag.info.bounding_box == original_array_bbox
+    np.testing.assert_array_equal(reopened_mag.read()[0], original_data)
+
+    assure_exported_properties(original_ds)
+    assure_exported_properties(ds)
+
+
+@pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
 def test_add_mag_as_ref_with_mag(data_format: DataFormat, output_path: UPath) -> None:
     ds_path = prepare_dataset_path(data_format, output_path, "original")
     new_path = prepare_dataset_path(data_format, output_path, "with_ref")
@@ -2251,6 +2289,8 @@ def test_add_mag_as_ref_with_mag(data_format: DataFormat, output_path: UPath) ->
     assert list(layer.mags.values())[0]._properties.path == dump_path(
         ds_path / "color" / "1", new_path
     )
+    # the referenced voxel grid covers twice the extent in Mag(1)
+    assert layer.bounding_box == BoundingBox((0, 0, 0), (20, 40, 60))
 
     assure_exported_properties(ds)
     assure_exported_properties(original_ds)
@@ -2332,6 +2372,63 @@ def test_add_mag_as_copy(data_format: DataFormat, output_path: UPath) -> None:
 
     np.testing.assert_array_equal(
         copy_mag.read(absolute_offset=(0, 0, 0), size=(5, 5, 5))[0], new_data
+    )
+    np.testing.assert_array_equal(original_mag.read()[0], original_data)
+
+    assure_exported_properties(original_ds)
+    assure_exported_properties(copy_ds)
+
+
+@pytest.mark.parametrize("data_format,output_path", DATA_FORMATS_AND_OUTPUT_PATHS)
+@pytest.mark.parametrize("force_re_encode", [False, True])
+def test_add_mag_as_copy_with_mag(
+    data_format: DataFormat, output_path: UPath, force_re_encode: bool
+) -> None:
+    original_ds_path = prepare_dataset_path(data_format, output_path, "original")
+    copy_ds_path = prepare_dataset_path(data_format, output_path, "copy")
+
+    original_ds = Dataset(original_ds_path, voxel_size=(1, 1, 1))
+    original_layer = original_ds.add_layer(
+        "color",
+        COLOR_CATEGORY,
+        dtype="uint8",
+        data_format=data_format,
+        bounding_box=BoundingBox((6, 6, 6), (10, 20, 30)),
+    )
+    original_data = (np.random.rand(10, 20, 30) * 255).astype(np.uint8)
+    original_mag = original_layer.add_mag(1)
+    original_mag.write(data=original_data, absolute_offset=(6, 6, 6))
+
+    copy_ds = Dataset(copy_ds_path, voxel_size=(1, 1, 1))
+    copy_layer = copy_ds.add_layer(
+        "color", COLOR_CATEGORY, dtype="uint8", data_format=data_format
+    )
+
+    with mock.patch.object(
+        copy_layer, "_add_fs_copy_mag", wraps=copy_layer._add_fs_copy_mag
+    ) as mocked_method:
+        copy_mag = copy_layer.add_mag_as_copy(
+            original_mag,
+            mag="2",
+            # a differing compression prevents the file-based copy
+            compress=False if force_re_encode else None,
+            extend_layer_bounding_box=True,
+        )
+        assert mocked_method.call_count == (0 if force_re_encode else 1)
+
+    assert copy_mag.mag == Mag("2")
+    assert not copy_mag.read_only
+    assert (copy_ds_path / "color" / "2").exists()
+    assert not (copy_ds_path / "color" / "1").exists()
+    assert len(copy_layer._properties.mags) == 1
+
+    # the voxel grid is unchanged, so it covers twice the extent in Mag(1)
+    assert tuple(copy_layer.bounding_box.topleft) == (12, 12, 12)
+    assert tuple(copy_layer.bounding_box.size) == (20, 40, 60)
+
+    np.testing.assert_array_equal(
+        copy_mag.read(absolute_offset=(12, 12, 12), size=(20, 40, 60))[0],
+        original_data,
     )
     np.testing.assert_array_equal(original_mag.read()[0], original_data)
 

--- a/webknossos/tests/dataset/test_remote_dataset.py
+++ b/webknossos/tests/dataset/test_remote_dataset.py
@@ -154,6 +154,41 @@ def test_remote_dataset_add_mag_as_copy(transfer_mode: TransferMode) -> None:
     np.testing.assert_array_equal(copied_mag.read(), source_mag.read())
 
 
+@pytest.mark.parametrize("transfer_mode", [TransferMode.HTTP, TransferMode.COPY])
+def test_remote_dataset_add_mag_as_copy_with_mag(transfer_mode: TransferMode) -> None:
+    ds_path = _prepare_dataset_path(TESTOUTPUT_DIR, "remote_copy_mag_with_mag_src")
+    source_ds = Dataset(ds_path, voxel_size=(2, 2, 1))
+    source_layer = source_ds.add_layer(
+        "color", COLOR_CATEGORY, data_format=DataFormat.Zarr3
+    )
+    source_mag = source_layer.add_mag(1)
+    source_mag.write(
+        absolute_offset=(0, 0, 0),
+        data=(np.random.rand(16, 16, 16) * 255).astype(np.uint8),
+        allow_resize=True,
+    )
+
+    remote_ds = source_ds.upload(
+        new_dataset_name="test_remote_dataset_add_mag_as_copy_with_mag"
+    )
+    remote_ds = reopen_dataset(remote_ds)
+    remote_layer = remote_ds.add_layer(
+        "color2", COLOR_CATEGORY, data_format=DataFormat.Zarr3
+    )
+    copied_mag = remote_layer.add_mag_as_copy(
+        source_mag,
+        mag="2",
+        transfer_mode=transfer_mode,
+        extend_layer_bounding_box=True,
+    )
+    assert Mag(2) in remote_layer.mags
+    assert Mag(1) not in remote_layer.mags
+    assert copied_mag.mag == Mag(2)
+    # the voxel grid is unchanged, so it covers twice the extent in Mag(1)
+    assert tuple(remote_layer.bounding_box.size) == (32, 32, 32)
+    np.testing.assert_array_equal(copied_mag.read(), source_mag.read())
+
+
 def test_add_remote_mags_from_mag_view(
     sample_downloaded_dataset: Dataset,
     sample_layer_and_mag_name: Iterable[tuple[str, str]],

--- a/webknossos/webknossos/client/_upload_dataset.py
+++ b/webknossos/webknossos/client/_upload_dataset.py
@@ -12,6 +12,7 @@ from upath import UPath
 from .. import LayerToLink
 from ..dataset import Attachment, Dataset, MagView
 from ..datastore import Datastore
+from ..geometry import Mag
 from ..utils import get_rich_progress
 from ._resumable import Resumable
 from .api_client.models import (
@@ -76,6 +77,7 @@ def upload_mag(
     dataset_id: str,
     layer_name: str,
     mag: MagView,
+    target_mag: Mag | None = None,
     axis_order: dict[str, int],
     channel_index: int | None,
     datastore_url: str | None = None,
@@ -101,7 +103,7 @@ def upload_mag(
             dataset_id=dataset_id,
             layer_name=layer_name,
             mag=ApiMagProperties(
-                mag=mag.mag.to_tuple(),
+                mag=(target_mag or mag.mag).to_tuple(),
                 channel_index=channel_index,
                 axis_order=axis_order,
             ),

--- a/webknossos/webknossos/dataset/layer/abstract_layer.py
+++ b/webknossos/webknossos/dataset/layer/abstract_layer.py
@@ -32,6 +32,21 @@ if TYPE_CHECKING:
     )
 
 
+def _rescaled_foreign_bounding_box(
+    foreign_mag_view: MagView, target_mag: Mag
+) -> NDBoundingBox:
+    """Returns the bounding box of the foreign mag's layer, re-interpreted as if the
+    foreign voxel grid were at `target_mag` instead of the mag it actually has."""
+    bounding_box = foreign_mag_view.layer.bounding_box
+    if target_mag == foreign_mag_view.mag:
+        return bounding_box
+    return (
+        bounding_box.align_with_mag(foreign_mag_view.mag, ceil=True)
+        .in_mag(foreign_mag_view.mag)
+        .from_mag_to_mag1(target_mag)
+    )
+
+
 def _validate_layer_name(layer_name: str) -> None:
     if _ALLOWED_LAYER_NAME_REGEX.match(layer_name) is None:
         raise ValueError(
@@ -213,6 +228,10 @@ class AbstractLayer:
         self._properties.bounding_box = bbox
         self._save_layer_properties()
         for mag in self.mags.values():
+            # Read-only mags may be owned by a foreign dataset, so their array must not
+            # be touched.
+            if mag.read_only:
+                continue
             mag._array.resize(bbox.align_with_mag(mag.mag).in_mag(mag.mag))
 
     @property

--- a/webknossos/webknossos/dataset/layer/layer.py
+++ b/webknossos/webknossos/dataset/layer/layer.py
@@ -28,7 +28,7 @@ from ._downsampling_utils import (
     parse_interpolation_mode,
 )
 from ._upsampling_utils import upsample_cube_job
-from .abstract_layer import AbstractLayer
+from .abstract_layer import AbstractLayer, _rescaled_foreign_bounding_box
 from .view import (
     ArrayException,
     MagView,
@@ -599,6 +599,7 @@ class Layer(AbstractLayer):
         self,
         foreign_mag_view_or_path: PathLike | UPath | str | MagView,
         *,
+        mag: MagLike | None = None,
         extend_layer_bounding_box: bool = True,
         chunk_shape: Vec3IntLike | int | None = None,
         shard_shape: Vec3IntLike | int | None = None,
@@ -612,9 +613,14 @@ class Layer(AbstractLayer):
         Copies the data at `foreign_mag_view_or_path` which can belong to another dataset
         to the current dataset. Additionally, the relevant information from the
         `datasource-properties.json` of the other dataset are copied, too.
+
+        If `mag` is given, the copied data is registered under that mag instead of the
+        mag it has in the source dataset. The voxel data is not resampled, so the copied
+        mag covers a different extent in Mag(1) than the source mag does.
         """
         self._ensure_writable()
         foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
+        target_mag = Mag(mag) if mag is not None else foreign_mag_view.mag
 
         if progress_desc is None:
             progress_desc = f"Copying mag {foreign_mag_view.mag.to_layer_name()} from {foreign_mag_view.layer} to {self}"
@@ -648,7 +654,7 @@ class Layer(AbstractLayer):
 
         uses_compatible_protocols = (
             foreign_mag_view.path.protocol in COPY_COMPATIBLE_PROTOCOLS
-            and (self.path / foreign_mag_view.mag.to_layer_name()).protocol
+            and (self.path / target_mag.to_layer_name()).protocol
             in COPY_COMPATIBLE_PROTOCOLS
         )
 
@@ -659,10 +665,11 @@ class Layer(AbstractLayer):
             and uses_compatible_protocols
         ):
             logger.debug(
-                f"Optimization: Copying files from {foreign_mag_view.path} to {self.path}/{foreign_mag_view.mag} directly without re-encoding."
+                f"Optimization: Copying files from {foreign_mag_view.path} to {self.path}/{target_mag} directly without re-encoding."
             )
             return self._add_fs_copy_mag(
                 foreign_mag_view,
+                mag=target_mag,
                 extend_layer_bounding_box=extend_layer_bounding_box,
                 exists_ok=exists_ok,
                 progress_desc=progress_desc,
@@ -685,15 +692,15 @@ class Layer(AbstractLayer):
         shard_shape = shard_shape or foreign_mag_view.info.shard_shape
         if exists_ok:
             mag_view = self.get_or_add_mag(
-                mag=foreign_mag_view.mag,
+                mag=target_mag,
                 chunk_shape=chunk_shape,
                 shard_shape=shard_shape,
                 compress=compress,
             )
         else:
-            self._assert_mag_does_not_exist_yet(foreign_mag_view.mag)
+            self._assert_mag_does_not_exist_yet(target_mag)
             mag_view = self.add_mag(
-                mag=foreign_mag_view.mag,
+                mag=target_mag,
                 chunk_shape=chunk_shape,
                 shard_shape=shard_shape,
                 compress=compress,
@@ -701,18 +708,31 @@ class Layer(AbstractLayer):
 
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
-                foreign_mag_view.layer.bounding_box
+                _rescaled_foreign_bounding_box(foreign_mag_view, target_mag)
+            )
+
+        source_view = foreign_mag_view.get_view(read_only=True)
+        target_view: View = mag_view
+        if target_mag != foreign_mag_view.mag:
+            # The voxel grid is copied as-is, so the target region in Mag(1) is the
+            # source region re-interpreted at the target mag.
+            target_view = mag_view.get_view(
+                absolute_bounding_box=source_view.bounding_box.align_with_mag(
+                    foreign_mag_view.mag, ceil=True
+                )
+                .in_mag(foreign_mag_view.mag)
+                .from_mag_to_mag1(target_mag)
             )
 
         # use the target shard shape for the copy operation
-        copy_shape = mag_view.info.shard_shape * mag_view.mag.to_vec3_int()
-        foreign_mag_view.get_view(read_only=True).for_zipped_chunks(
+        source_view.for_zipped_chunks(
             func_per_chunk=_copy_job,
-            target_view=mag_view,
+            target_view=target_view,
             executor=executor,
             progress_desc=progress_desc,
-            source_chunk_shape=copy_shape,
-            target_chunk_shape=copy_shape,
+            source_chunk_shape=mag_view.info.shard_shape
+            * foreign_mag_view.mag.to_vec3_int(),
+            target_chunk_shape=mag_view.info.shard_shape * target_mag.to_vec3_int(),
         )
 
         return mag_view
@@ -807,6 +827,10 @@ class Layer(AbstractLayer):
         The relevant information from the `datasource-properties.json` of the other dataset is copied to this dataset.
         Note: If the other dataset modifies its bounding box afterwards, the change does not affect this properties
         (or vice versa).
+
+        If `mag` is given, the foreign data is registered under that mag instead of the
+        mag it has in the source dataset. The voxel data is not resampled, so the
+        referenced mag covers a different extent in Mag(1) than the source mag does.
         """
         self._ensure_writable()
         foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
@@ -836,7 +860,7 @@ class Layer(AbstractLayer):
 
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
-                foreign_mag_view.layer.bounding_box
+                _rescaled_foreign_bounding_box(foreign_mag_view, mag)
             )
 
         return self.get_mag(mag)
@@ -845,6 +869,7 @@ class Layer(AbstractLayer):
         self,
         foreign_mag_view_or_path: PathLike | UPath | str | MagView,
         *,
+        mag: MagLike | None = None,
         extend_layer_bounding_box: bool = True,
         exists_ok: bool = False,
         progress_desc: str | None = None,
@@ -852,29 +877,30 @@ class Layer(AbstractLayer):
         self._ensure_writable()
 
         foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
-        self._assert_mag_does_not_exist_yet(foreign_mag_view.mag)
+        target_mag = Mag(mag) if mag is not None else foreign_mag_view.mag
+        self._assert_mag_does_not_exist_yet(target_mag)
 
         assert foreign_mag_view.info.data_format == self.data_format, (
             f"Cannot use file-based copy, because the foreign data format {foreign_mag_view.info.data_format} does not match the layer's data format {self.data_format}."
         )
 
-        mag_path = self.path / str(foreign_mag_view.mag)
+        mag_path = self.path / str(target_mag)
         if not exists_ok and mag_path.exists():
             raise FileExistsError(
                 f"Cannot copy {foreign_mag_view.path} to {mag_path} because it already exists."
             )
         copytree(foreign_mag_view.path, mag_path, progress_desc=progress_desc)
 
-        mag = self._add_mag_for_existing_files(
-            foreign_mag_view.mag, mag_path=mag_path, read_only=False
+        mag_view = self._add_mag_for_existing_files(
+            target_mag, mag_path=mag_path, read_only=False
         )
 
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
-                foreign_mag_view.layer.bounding_box
+                _rescaled_foreign_bounding_box(foreign_mag_view, target_mag)
             )
 
-        return mag
+        return mag_view
 
     def add_fs_copy_mag(
         self,

--- a/webknossos/webknossos/dataset/layer/remote_layer.py
+++ b/webknossos/webknossos/dataset/layer/remote_layer.py
@@ -19,7 +19,11 @@ from ...client.api_client.models import (
 from ...geometry import Mag, MagLike, Vec3IntLike
 from ...utils import enrich_path
 from ..transfer_mode import TransferMode
-from .abstract_layer import AbstractLayer, _validate_layer_name
+from .abstract_layer import (
+    AbstractLayer,
+    _rescaled_foreign_bounding_box,
+    _validate_layer_name,
+)
 from .view import MagView, Zarr3Config
 
 if TYPE_CHECKING:
@@ -72,6 +76,7 @@ class RemoteLayer(AbstractLayer):
         self,
         foreign_mag_view_or_path: PathLike | UPath | str | MagView,
         *,
+        mag: MagLike | None = None,
         extend_layer_bounding_box: bool = True,
         transfer_mode: TransferMode = TransferMode.COPY,
         common_storage_path_prefix: str | None = None,
@@ -81,9 +86,14 @@ class RemoteLayer(AbstractLayer):
         Copies the data at `foreign_mag_view_or_path` which can belong to another dataset
         to the current remote dataset. Additionally, the relevant information from the
         `datasource-properties.json` of the other dataset are copied, too.
+
+        If `mag` is given, the copied data is registered under that mag instead of the
+        mag it has in the source dataset. The voxel data is not resampled, so the copied
+        mag covers a different extent in Mag(1) than the source mag does.
         """
         self._ensure_writable()
         foreign_mag_view = MagView._ensure_mag_view(foreign_mag_view_or_path)
+        target_mag = Mag(mag) if mag is not None else foreign_mag_view.mag
 
         from ...client.context import _get_api_client
 
@@ -106,6 +116,7 @@ class RemoteLayer(AbstractLayer):
                     dataset_id=self.dataset.dataset_id,
                     layer_name=self.name,
                     mag=foreign_mag_view,
+                    target_mag=target_mag,
                     axis_order=axis_order,
                     channel_index=channel_index,
                     overwrite_pending=overwrite_pending,
@@ -113,7 +124,7 @@ class RemoteLayer(AbstractLayer):
             else:
                 reserve_parameters = ApiReserveMagUploadToPathParameters(
                     layer_name=self.name,
-                    mag=foreign_mag_view.mag.to_list(),
+                    mag=target_mag.to_list(),
                     axis_order=axis_order,
                     channel_index=channel_index,
                     path_prefix=common_storage_path_prefix,
@@ -127,7 +138,7 @@ class RemoteLayer(AbstractLayer):
                 transfer_mode.transfer(
                     foreign_mag_view.path,
                     path,
-                    progress_desc_label=f"{self.name}/{foreign_mag_view.mag}",
+                    progress_desc_label=f"{self.name}/{target_mag}",
                 )
                 client.finish_mag_upload_to_paths(
                     self._dataset.dataset_id, reserve_parameters
@@ -136,9 +147,9 @@ class RemoteLayer(AbstractLayer):
         self._apply_server_layer_properties()
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
-                foreign_mag_view.layer.bounding_box
+                _rescaled_foreign_bounding_box(foreign_mag_view, target_mag)
             )
-        return self.get_mag(foreign_mag_view.mag)
+        return self.get_mag(target_mag)
 
     def add_mag_as_ref(
         self,
@@ -198,7 +209,7 @@ class RemoteLayer(AbstractLayer):
 
         if extend_layer_bounding_box:
             self.bounding_box = self.bounding_box.extended_by(
-                foreign_mag_view.layer.bounding_box
+                _rescaled_foreign_bounding_box(foreign_mag_view, mag)
             )
 
         return self.get_mag(mag)


### PR DESCRIPTION
### Description:
- `Layer.add_mag_as_ref` and `RemoteLayer.add_mag_as_ref` had a `mag` keyword to register foreign data under a different resolution level than it has in the source dataset. This PR adds the same `mag` keyword to `Layer.add_mag_as_copy` and `RemoteLayer.add_mag_as_copy`.
- `extend_layer_bounding_box` fixed accordingly.
- Bugfix: The layer bounding box setter no longer resizes read-only mags. Such a mag may be owned by a foreign dataset, so extending the bounding box of a layer that references it rewrote the *source* dataset's array metadata (observable for Zarr: the source array grew from 32³ to 128³). This also stops `RemoteLayer`, whose mags are always read-only, from issuing resize calls against zarr-streamed arrays.

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog
 - [x] Added / Updated Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
