### PR TITLE
Allow passing a dataset id to RemoteDataset.open

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,6 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
 - Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
+- Added support for passing a dataset id as the first argument of `RemoteDataset.open` (and `Dataset.download`, `RemoteDataset.trigger_reload_in_datastore`), in addition to a dataset name or url. If no dataset with that id exists, the argument is resolved as a dataset name as before.
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -17,7 +17,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Added
 - Added support for WEBKNOSSOS API version 15, which allows segment ids to use the full uint64 range. Such ids may now be serialized as `{"customJsonEncoding": "bigint", "value": "<decimal string>"}` instead of a plain JSON number, both in API responses and in `datasource-properties.json`.
 - Added `neuroglancerPrecomputed` as a valid `AttachmentDataFormat` for `MeshAttachment`s. [#1518](https://github.com/scalableminds/webknossos-libs/pull/1518)
-- Added support for passing a dataset id as the first argument of `RemoteDataset.open` (and `Dataset.download`, `RemoteDataset.trigger_reload_in_datastore`), in addition to a dataset name or url. If no dataset with that id exists, the argument is resolved as a dataset name as before.
+- Added support for passing a dataset id as the first argument of `RemoteDataset.open` (and `Dataset.download`, `RemoteDataset.trigger_reload_in_datastore`), in addition to a dataset name or url. If no dataset with that id exists, the argument is resolved as a dataset name as before. [#1527](https://github.com/scalableminds/webknossos-libs/pull/1527)
 
 ### Changed
 

--- a/webknossos/tests/dataset/test_dataset.py
+++ b/webknossos/tests/dataset/test_dataset.py
@@ -4049,6 +4049,13 @@ def test_remote_dataset_urls() -> None:
     ds_open_with_id = RemoteDataset.open(dataset_id=dataset_id)
     assert ds_open_with_id.url == ds.url
 
+    ds_open_with_positional_id = RemoteDataset.open(dataset_id)
+    assert ds_open_with_positional_id.url == ds.url
+
+    # An id-shaped argument that is neither an existing id nor name
+    with pytest.raises(ValueError):
+        RemoteDataset.open("0" * 24, organization_id="Organization_X")
+
     # Test different variants of the URL
     # 1. deprecated url: "http://localhost:9000/datasets/Organization_X/l4_sample"
 

--- a/webknossos/webknossos/dataset/abstract_dataset.py
+++ b/webknossos/webknossos/dataset/abstract_dataset.py
@@ -51,6 +51,8 @@ _DATASET_DEPRECATED_URL_REGEX = re.compile(
     + r"(?P<organization_id>[^/]*)/(?P<dataset_name>[^/]*)(/(view)?)?"
     + r"(\?token=(?P<sharing_token>[^#]*))?"
 )
+# Dataset ids are hex-encoded object ids.
+_DATASET_ID_REGEX = re.compile(r"[0-9a-fA-F]{24}")
 
 LayerType = TypeVar("LayerType", bound=AbstractLayer)
 SegmentationLayerType = TypeVar(

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -528,7 +528,7 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
     ) -> "Dataset":
         """Downloads a dataset and returns the Dataset instance.
 
-        * `dataset_name_or_url` may be a dataset name or a full URL to a dataset view, e.g.
+        * `dataset_name_or_url` may be a dataset name, a dataset ID or a full URL to a dataset view, e.g.
           `https://webknossos.org/datasets/scalable_minds/l4_sample_dev/view`
           If a URL is used, `organization_id`, `webknossos_url` and `sharing_token` must not be set.
         * `organization_id` may be supplied if a dataset name was used in the previous argument,

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1349,6 +1349,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         else:
             annotation_id = None
 
+        dataset_name: str | None = None
         if dataset_id is None:
             assert dataset_name_or_url is not None, (
                 f"Please supply either a dataset_id or a dataset name or url to Dataset.{caller}()."
@@ -1388,20 +1389,9 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
 
                 assert organization_id is not None
                 assert dataset_name is not None
-
-                dataset_id = cls._disambiguate_remote(dataset_name, organization_id)
             else:
                 dataset_name = dataset_name_or_url
                 organization_id = organization_id or current_context.organization_id
-
-                # An id-shaped argument is treated as a dataset id, unless no such
-                # dataset exists. Then it is resolved as a dataset name.
-                if _DATASET_ID_REGEX.fullmatch(dataset_name) and cls._dataset_id_exists(
-                    dataset_name, sharing_token=sharing_token
-                ):
-                    dataset_id = dataset_name
-                else:
-                    dataset_id = cls._disambiguate_remote(dataset_name, organization_id)
 
         if webknossos_url is None:
             webknossos_url = current_context.url
@@ -1417,6 +1407,19 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
                     + "Please see https://docs.webknossos.org/api/webknossos/client/context.html to adapt the URL and token."
                 )
                 context_manager = webknossos_context(webknossos_url, None)
+
+        if dataset_id is None:
+            assert dataset_name is not None and organization_id is not None
+            with context_manager:
+                # An id-shaped argument is treated as a dataset id, unless no such
+                # dataset exists. Then it is resolved as a dataset name.
+                if _DATASET_ID_REGEX.fullmatch(dataset_name) and cls._dataset_id_exists(
+                    dataset_name, sharing_token=sharing_token
+                ):
+                    dataset_id = dataset_name
+                else:
+                    dataset_id = cls._disambiguate_remote(dataset_name, organization_id)
+
         return (context_manager, dataset_id, annotation_id, sharing_token)
 
     @classmethod

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -28,6 +28,7 @@ from webknossos.client.api_client.models import (
 from webknossos.dataset._metadata import DatasetMetadata
 from webknossos.dataset.abstract_dataset import (
     _DATASET_DEPRECATED_URL_REGEX,
+    _DATASET_ID_REGEX,
     _DATASET_URL_REGEX,
     AbstractDataset,
     AttachmentRenaming,
@@ -205,7 +206,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         via the respective `RemoteDataset` properties.
 
         Args:
-            dataset_name_or_url: Either dataset name or full URL to dataset view, e.g.
+            dataset_name_or_url: Either dataset name, dataset ID or full URL to dataset view, e.g.
                 https://webknossos.org/datasets/scalable_minds/l4_sample_dev/view
             organization_id: Optional organization ID if using dataset name. Can be found [here](https://webknossos.org/account/token)
             sharing_token: Optional sharing token for dataset access
@@ -1296,6 +1297,22 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         return possible_ids[0]
 
     @classmethod
+    def _dataset_id_exists(
+        cls,
+        dataset_id: str,
+        sharing_token: str | None = None,
+    ) -> bool:
+        from ..client.context import _get_api_client
+
+        try:
+            _get_api_client().dataset_info(
+                dataset_id=dataset_id, sharing_token=sharing_token
+            )
+        except UnexpectedStatusError:
+            return False
+        return True
+
+    @classmethod
     def _parse_remote(
         cls,
         *,
@@ -1377,7 +1394,14 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
                 dataset_name = dataset_name_or_url
                 organization_id = organization_id or current_context.organization_id
 
-                dataset_id = cls._disambiguate_remote(dataset_name, organization_id)
+                # An id-shaped argument is treated as a dataset id, unless no such
+                # dataset exists. Then it is resolved as a dataset name.
+                if _DATASET_ID_REGEX.fullmatch(dataset_name) and cls._dataset_id_exists(
+                    dataset_name, sharing_token=sharing_token
+                ):
+                    dataset_id = dataset_name
+                else:
+                    dataset_id = cls._disambiguate_remote(dataset_name, organization_id)
 
         if webknossos_url is None:
             webknossos_url = current_context.url
@@ -1416,7 +1440,7 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
         Cannot be used for local datasets.
 
         Args:
-            dataset_name_or_url: Name or URL of dataset to reload
+            dataset_name_or_url: Name, ID or URL of dataset to reload
             dataset_id: ID of dataset to reload
             organization_id: Organization ID where dataset is located
             datastore_url: Optional URL to the datastore


### PR DESCRIPTION
### Description:
- `RemoteDataset.open("59e9cfbdba632ac2ab8b23b5")` now works: if the first positional argument is shaped like a dataset id (24 hex chars) and such a dataset exists, it is used as the dataset id. Otherwise it is resolved as a dataset name as before, so existing calls are unaffected.
- Implemented in the shared `_parse_remote`, so `Dataset.open_remote`, `Dataset.download` and `trigger_reload_in_datastore` benefit too.

### Issues:
- n/a

### Todos:
 - [x] Updated Changelog
 - [x] Added / Updated Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)