### PR TITLE
Import OME-Zarr 0.6 coordinate transforms

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,8 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
-- Added conversion support for OME-Zarr/NGFF 0.6 (`0.6rc1` and `0.6`), including its `coordinateSystems` axes and `sequence` coordinate transformations. Writing OME-Zarr metadata still produces 0.4/0.5.
-- OME-Zarr coordinate transformations are now imported: `Dataset.from_images` derives the voxel size from the level's `scale` transform and the axes' `unit` when neither `voxel_size` nor `voxel_size_with_unit` is given, and the level's translation becomes an affine `Layer.coordinate_transformations`.
+- Added conversion support for OME-Zarr/NGFF 0.6 (`0.6rc1` and `0.6`), including its `coordinateSystems` axes and `sequence` coordinate transformations. Writing OME-Zarr metadata still produces 0.4/0.5. [#1533](https://github.com/scalableminds/webknossos-libs/pull/1533)
+- OME-Zarr coordinate transformations are now imported: `Dataset.from_images` derives the voxel size from the level's `scale` transform and the axes' `unit` when neither `voxel_size` nor `voxel_size_with_unit` is given, and the level's translation becomes an affine `Layer.coordinate_transformations`. [#1533](https://github.com/scalableminds/webknossos-libs/pull/1533)
 
 ### Changed
 

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,6 +15,8 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- Added conversion support for OME-Zarr/NGFF 0.6 (`0.6rc1` and `0.6`), including its `coordinateSystems` axes and `sequence` coordinate transformations. Writing OME-Zarr metadata still produces 0.4/0.5.
+- OME-Zarr coordinate transformations are now imported: `Dataset.from_images` derives the voxel size from the level's `scale` transform and the axes' `unit` when neither `voxel_size` nor `voxel_size_with_unit` is given, and the level's translation becomes an affine `Layer.coordinate_transformations`.
 
 ### Changed
 

--- a/webknossos/tests/data_fixtures.py
+++ b/webknossos/tests/data_fixtures.py
@@ -350,6 +350,84 @@ def write_ome_zarr_v3_group(
         write_zarr_v3_array(path / rel_path, data)
 
 
+def write_ome_zarr_v3_06_group(
+    path: UPath,
+    datasets: list[tuple[str, np.ndarray, list[float]]],
+    axes: list[dict[str, str]],
+    omero: dict[str, Any] | None = None,
+    *,
+    version: str = "0.6",
+    translations: dict[str, list[float]] | None = None,
+    top_level_transformations: list[dict[str, Any]] | None = None,
+    coordinate_system_name: str = "intrinsic",
+) -> None:
+    """Writes a v3 (`zarr.json`) OME-Zarr (NGFF 0.6) multiscale group. Takes the
+    same `datasets` and `axes` as `write_ome_zarr_v3_group`, but writes them the
+    0.6 way: `axes` go into a `coordinateSystems` entry, and a level listed in
+    `translations` gets a `sequence` of its scale and that translation instead
+    of a bare scale."""
+    path.mkdir(parents=True, exist_ok=True)
+    translations = translations or {}
+
+    def transform(rel_path: str, scale: list[float]) -> dict[str, Any]:
+        endpoints = {
+            "input": {"path": rel_path},
+            "output": {"name": coordinate_system_name},
+        }
+        translation = translations.get(rel_path)
+        if translation is None:
+            return {"type": "scale", "scale": scale, **endpoints}
+        return {
+            "type": "sequence",
+            **endpoints,
+            "transformations": [
+                {"type": "scale", "scale": scale},
+                {"type": "translation", "translation": translation},
+            ],
+        }
+
+    multiscale: dict[str, Any] = {
+        "coordinateSystems": [{"name": coordinate_system_name, "axes": axes}],
+        "datasets": [
+            {
+                "path": rel_path,
+                "coordinateTransformations": [transform(rel_path, scale)],
+            }
+            for rel_path, _, scale in datasets
+        ],
+    }
+    if top_level_transformations is not None:
+        multiscale["coordinateTransformations"] = top_level_transformations
+    ome: dict[str, Any] = {"version": version, "multiscales": [multiscale]}
+    if omero is not None:
+        ome["omero"] = omero
+    (path / "zarr.json").write_text(
+        json.dumps(
+            {
+                "zarr_format": 3,
+                "node_type": "group",
+                "attributes": {"ome": ome},
+            }
+        )
+    )
+    for rel_path, data, _ in datasets:
+        write_zarr_v3_array(path / rel_path, data)
+
+
+def _zip_ome_zarr_group(group_path: UPath, path: UPath) -> None:
+    """Zips an OME-Zarr group directory up uncompressed, with the root
+    `zarr.json` as the first entry — as RFC-9 recommends."""
+    with ZipFile(str(path), "w", compression=ZIP_STORED) as zip_file:
+        zip_file.write(str(group_path / "zarr.json"), "zarr.json")
+        for file_path in sorted(group_path.rglob("*")):
+            if file_path.is_dir():
+                continue
+            rel_path = file_path.relative_to(group_path).as_posix()
+            if rel_path == "zarr.json":
+                continue
+            zip_file.write(str(file_path), rel_path)
+
+
 def write_ozx_file(
     path: UPath,
     datasets: list[tuple[str, np.ndarray, list[float]]],
@@ -358,17 +436,23 @@ def write_ozx_file(
 ) -> None:
     """Writes `datasets` as a zipped OME-Zarr (`.ozx`, NGFF RFC-9) archive at
     `path`: a v3 OME-Zarr multiscale group (see `write_ome_zarr_v3_group`),
-    written to a temporary directory and then zipped up uncompressed, with
-    the root `zarr.json` as the first entry — as RFC-9 recommends."""
+    written to a temporary directory and then zipped up uncompressed."""
     with TemporaryDirectory() as tmp_dir:
         group_path = UPath(tmp_dir) / "group"
         write_ome_zarr_v3_group(group_path, datasets, axes, omero)
-        with ZipFile(str(path), "w", compression=ZIP_STORED) as zip_file:
-            zip_file.write(str(group_path / "zarr.json"), "zarr.json")
-            for file_path in sorted(group_path.rglob("*")):
-                if file_path.is_dir():
-                    continue
-                rel_path = file_path.relative_to(group_path).as_posix()
-                if rel_path == "zarr.json":
-                    continue
-                zip_file.write(str(file_path), rel_path)
+        _zip_ome_zarr_group(group_path, path)
+
+
+def write_ozx_06_file(
+    path: UPath,
+    datasets: list[tuple[str, np.ndarray, list[float]]],
+    axes: list[dict[str, str]],
+    omero: dict[str, Any] | None = None,
+    **kwargs: Any,
+) -> None:
+    """The NGFF 0.6 counterpart of `write_ozx_file`, see
+    `write_ome_zarr_v3_06_group` for the keyword arguments."""
+    with TemporaryDirectory() as tmp_dir:
+        group_path = UPath(tmp_dir) / "group"
+        write_ome_zarr_v3_06_group(group_path, datasets, axes, omero, **kwargs)
+        _zip_ome_zarr_group(group_path, path)

--- a/webknossos/tests/dataset/test_from_images.py
+++ b/webknossos/tests/dataset/test_from_images.py
@@ -18,6 +18,7 @@ from tests.constants import TESTDATA_DIR
 from tests.data_fixtures import (
     create_synthetic_multi_timepoint_ims,
     download_wklibs_sample_archive,
+    write_ome_zarr_v3_06_group,
     write_zarr_v3_array,
 )
 from webknossos.dataset import (
@@ -28,6 +29,11 @@ from webknossos.dataset import (
 from webknossos.dataset._image_conversion.image_source import ReadOptions
 from webknossos.dataset._image_conversion.mrc_image_source import MrcImageSource
 from webknossos.dataset._image_conversion.tiff_slice_reader import TiffSliceReader
+from webknossos.dataset_properties import (
+    AffineCoordinateTransformation,
+    LengthUnit,
+    VoxelSize,
+)
 from webknossos.geometry import (
     C_AXIS,
     T_AXIS,
@@ -483,6 +489,77 @@ def test_from_images_input_path_is_itself_a_store_directory(tmp_upath: UPath) ->
     np.testing.assert_array_equal(
         ds.layers["test.zarr"].get_finest_mag().read()[0], data.transpose(2, 1, 0)
     )
+
+
+_OME_06_AXES = [
+    {"name": Z_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": Y_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": X_AXIS, "type": "space", "unit": "micrometer"},
+]
+
+
+def _write_ome_zarr_06_store(path: UPath, *, with_units: bool = True) -> np.ndarray:
+    data = np.arange(4 * 8 * 8, dtype="uint8").reshape(4, 8, 8)
+    axes = _OME_06_AXES if with_units else [dict(a, unit=None) for a in _OME_06_AXES]
+    axes = [{k: v for k, v in a.items() if v is not None} for a in axes]
+    write_ome_zarr_v3_06_group(
+        path,
+        [("0", data, [0.2, 0.5, 0.5])],
+        axes,
+        translations={"0": [0.4, 1.0, 1.5]},
+    )
+    return data
+
+
+def test_from_images_takes_voxel_size_and_transform_from_ome_zarr(
+    tmp_upath: UPath,
+) -> None:
+    store_path = tmp_upath / "transformed.zarr"
+    data = _write_ome_zarr_06_store(store_path)
+
+    with SequentialExecutor() as executor:
+        ds = Dataset.from_images(store_path, tmp_upath / "ds", executor=executor)
+
+    assert ds.voxel_size_with_unit == VoxelSize((0.5, 0.5, 0.2), LengthUnit.MICROMETER)
+    layer = ds.layers["transformed.zarr"]
+    assert layer.coordinate_transformations == (
+        AffineCoordinateTransformation.from_translation((3.0, 2.0, 2.0)),
+    )
+    # The transformation is metadata only — the data still starts at the origin.
+    assert layer.bounding_box.topleft == Vec3Int(0, 0, 0)
+    np.testing.assert_array_equal(
+        layer.get_finest_mag().read()[0], data.transpose(2, 1, 0)
+    )
+
+
+def test_from_images_rescales_the_ome_zarr_transform_to_the_given_voxel_size(
+    tmp_upath: UPath,
+) -> None:
+    store_path = tmp_upath / "transformed.zarr"
+    _write_ome_zarr_06_store(store_path)
+
+    with SequentialExecutor() as executor:
+        ds = Dataset.from_images(
+            store_path,
+            tmp_upath / "ds",
+            voxel_size_with_unit=VoxelSize((1.0, 1.0, 0.4), LengthUnit.MICROMETER),
+            executor=executor,
+        )
+
+    # Twice as coarse voxels, so the same physical offset is half as many.
+    assert ds.layers["transformed.zarr"].coordinate_transformations == (
+        AffineCoordinateTransformation.from_translation((1.5, 1.0, 1.0)),
+    )
+
+
+def test_from_images_without_a_voxel_size_needs_one_from_the_images(
+    tmp_upath: UPath,
+) -> None:
+    store_path = tmp_upath / "unitless.zarr"
+    _write_ome_zarr_06_store(store_path, with_units=False)
+
+    with pytest.raises(AssertionError, match="voxel_size"):
+        Dataset.from_images(store_path, tmp_upath / "ds")
 
 
 def test_valid_chunked_image_source_extensions_include_zarr_and_n5() -> None:

--- a/webknossos/tests/dataset/test_ome_zarr_helpers.py
+++ b/webknossos/tests/dataset/test_ome_zarr_helpers.py
@@ -10,9 +10,16 @@ from webknossos.dataset._image_conversion.ome_zarr_helpers import (
     OmeChannelMetadata,
     layer_split_label,
     resolve_ome_multiscale,
+    suggested_coordinate_transformations,
     suggested_view_configuration,
+    suggested_voxel_size,
 )
-from webknossos.dataset_properties import LayerViewConfiguration
+from webknossos.dataset_properties import (
+    AffineCoordinateTransformation,
+    LayerViewConfiguration,
+    LengthUnit,
+    VoxelSize,
+)
 from webknossos.geometry.constants import C_AXIS, X_AXIS, Y_AXIS, Z_AXIS
 
 _PATH = UPath("test.ome.zarr")
@@ -48,6 +55,59 @@ def _multiscale_attributes(
             }
         ]
     }
+    if omero is not None:
+        attributes["omero"] = omero
+    return attributes
+
+
+def _dataset_06(
+    path: str, scale: list[float], translation: list[float] | None = None
+) -> dict:
+    endpoints = {"input": {"path": path}, "output": {"name": "intrinsic"}}
+    if translation is None:
+        return {
+            "path": path,
+            "coordinateTransformations": [
+                {"type": "scale", "scale": scale, **endpoints}
+            ],
+        }
+    return {
+        "path": path,
+        "coordinateTransformations": [
+            {
+                "type": "sequence",
+                **endpoints,
+                "transformations": [
+                    {"type": "scale", "scale": scale},
+                    {"type": "translation", "translation": translation},
+                ],
+            }
+        ],
+    }
+
+
+def _multiscale_06_attributes(
+    datasets: list[dict],
+    *,
+    coordinate_systems: list[dict] | None = None,
+    version: str = "0.6",
+    version_in_multiscale: bool = False,
+    top_level_transformations: list[dict] | None = None,
+    omero: dict | None = None,
+) -> dict:
+    if coordinate_systems is None:
+        coordinate_systems = [{"name": "intrinsic", "axes": _CZYX_AXES}]
+    multiscale: dict = {
+        "coordinateSystems": coordinate_systems,
+        "datasets": datasets,
+    }
+    if top_level_transformations is not None:
+        multiscale["coordinateTransformations"] = top_level_transformations
+    attributes: dict = {"multiscales": [multiscale]}
+    if version_in_multiscale:
+        multiscale["version"] = version
+    else:
+        attributes["version"] = version
     if omero is not None:
         attributes["omero"] = omero
     return attributes
@@ -260,3 +320,268 @@ def test_layer_split_label_is_none_when_label_sanitizes_to_nothing() -> None:
     # stripped separately) falls back to the caller's default naming.
     channels = (OmeChannelMetadata(None, "...!!!"),)
     assert layer_split_label(channels, "channel", 0) is None
+
+
+def test_resolve_ome_multiscale_06_ranks_by_spatial_resolution() -> None:
+    attributes = _multiscale_06_attributes(
+        [
+            _dataset_06("2", [1.0, 4.0, 4.0, 4.0], [0.0, 1.5, 1.5, 1.5]),
+            _dataset_06("0", [1.0, 1.0, 1.0, 1.0]),
+            _dataset_06("1", [1.0, 2.0, 2.0, 2.0], [0.0, 0.5, 0.5, 0.5]),
+        ]
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.dataset_paths == ("0", "1", "2")
+    assert multiscale.axis_names == (C_AXIS, Z_AXIS, Y_AXIS, X_AXIS)
+    assert multiscale.transforms[1].scale == (1.0, 2.0, 2.0, 2.0)
+    assert multiscale.transforms[1].translation == (0.0, 0.5, 0.5, 0.5)
+
+
+@pytest.mark.parametrize("version", ["0.6", "0.6rc1"])
+def test_resolve_ome_multiscale_accepts_06_versions(version: str) -> None:
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 1.0, 1.0, 1.0])], version=version
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.dataset_paths == ("0",)
+
+
+def test_resolve_ome_multiscale_rejects_06_version_inside_the_multiscale_entry() -> (
+    None
+):
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 1.0, 1.0, 1.0])], version_in_multiscale=True
+    )
+
+    with pytest.raises(UnsupportedImageFormatError):
+        resolve_ome_multiscale(attributes, path=_PATH)
+
+
+def test_resolve_ome_multiscale_06_accepts_an_identity_transform() -> None:
+    attributes = _multiscale_06_attributes(
+        [{"path": "0", "coordinateTransformations": [{"type": "identity"}]}]
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.transforms[0].scale == (1.0, 1.0, 1.0, 1.0)
+    assert multiscale.transforms[0].translation == (0.0, 0.0, 0.0, 0.0)
+
+
+@pytest.mark.parametrize("reverse", [False, True])
+def test_resolve_ome_multiscale_06_flattens_a_sequence(reverse: bool) -> None:
+    scale = {"type": "scale", "scale": [1.0, 2.0, 2.0, 2.0]}
+    translation = {"type": "translation", "translation": [0.0, 3.0, 3.0, 3.0]}
+    transformations = [translation, scale] if reverse else [scale, translation]
+    attributes = _multiscale_06_attributes(
+        [
+            {
+                "path": "0",
+                "coordinateTransformations": [
+                    {"type": "sequence", "transformations": transformations}
+                ],
+            }
+        ]
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.transforms[0].scale == (1.0, 2.0, 2.0, 2.0)
+    # Scaling after the translation scales the translation too.
+    expected = (0.0, 6.0, 6.0, 6.0) if reverse else (0.0, 3.0, 3.0, 3.0)
+    assert multiscale.transforms[0].translation == expected
+
+
+def test_resolve_ome_multiscale_06_rejects_an_unsupported_transform() -> None:
+    attributes = _multiscale_06_attributes(
+        [
+            {
+                "path": "0",
+                "coordinateTransformations": [
+                    {"type": "affine", "affine": [[1, 0, 0, 0]]}
+                ],
+            }
+        ]
+    )
+
+    with pytest.raises(UnsupportedImageDataError):
+        resolve_ome_multiscale(attributes, path=_PATH)
+
+
+def test_resolve_ome_multiscale_06_takes_the_axes_of_the_named_coordinate_system() -> (
+    None
+):
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 1.0, 1.0, 1.0])],
+        coordinate_systems=[
+            {"name": "physical", "axes": [{"name": "q", "type": "space"}]},
+            {"name": "intrinsic", "axes": _CZYX_AXES},
+        ],
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.axis_names == (C_AXIS, Z_AXIS, Y_AXIS, X_AXIS)
+
+
+def test_resolve_ome_multiscale_keeps_the_translation_of_a_0_4_dataset() -> None:
+    attributes = _multiscale_attributes(
+        [
+            {
+                "path": "0",
+                "coordinateTransformations": [
+                    {"type": "scale", "scale": [1.0, 1.0, 1.0, 1.0]},
+                    {"type": "translation", "translation": [0.0, 7.0, 8.0, 9.0]},
+                ],
+            }
+        ]
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.dataset_paths == ("0",)
+    assert multiscale.transforms[0].translation == (0.0, 7.0, 8.0, 9.0)
+
+
+_MICROMETER_AXES = [
+    {"name": C_AXIS, "type": "channel"},
+    {"name": Z_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": Y_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": X_AXIS, "type": "space", "unit": "micrometer"},
+]
+
+
+def _micrometer_multiscale() -> dict:
+    return _multiscale_06_attributes(
+        [
+            _dataset_06("0", [1.0, 0.1, 0.5, 0.5], [0.0, 0.2, 1.0, 1.5]),
+            _dataset_06("1", [1.0, 0.2, 1.0, 1.0], [0.0, 0.4, 2.0, 3.0]),
+        ],
+        coordinate_systems=[{"name": "intrinsic", "axes": _MICROMETER_AXES}],
+    )
+
+
+def test_suggested_voxel_size_uses_the_scale_of_the_requested_rank() -> None:
+    multiscale = resolve_ome_multiscale(_micrometer_multiscale(), path=_PATH)
+
+    assert suggested_voxel_size(multiscale, 0) == VoxelSize(
+        (0.5, 0.5, 0.1), LengthUnit.MICROMETER
+    )
+    assert suggested_voxel_size(multiscale, 1) == VoxelSize(
+        (1.0, 1.0, 0.2), LengthUnit.MICROMETER
+    )
+
+
+def test_suggested_voxel_size_normalizes_mixed_units() -> None:
+    axes = [
+        {"name": C_AXIS, "type": "channel"},
+        {"name": Z_AXIS, "type": "space", "unit": "micrometer"},
+        {"name": Y_AXIS, "type": "space", "unit": "nanometer"},
+        {"name": X_AXIS, "type": "space", "unit": "nanometer"},
+    ]
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 0.1, 20.0, 20.0])],
+        coordinate_systems=[{"name": "intrinsic", "axes": axes}],
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert suggested_voxel_size(multiscale, 0) == VoxelSize(
+        (20.0, 20.0, 100.0), LengthUnit.NANOMETER
+    )
+
+
+def test_suggested_voxel_size_without_units_is_none() -> None:
+    multiscale = resolve_ome_multiscale(
+        _multiscale_06_attributes([_dataset_06("0", [1.0, 1.0, 1.0, 1.0])]),
+        path=_PATH,
+    )
+
+    assert suggested_voxel_size(multiscale, 0) is None
+
+
+def test_suggested_voxel_size_with_an_unknown_unit_is_none() -> None:
+    axes = [{"name": X_AXIS, "type": "space", "unit": "furlong"}]
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0])],
+        coordinate_systems=[{"name": "intrinsic", "axes": axes}],
+    )
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    with pytest.warns(UserWarning, match="furlong"):
+        assert suggested_voxel_size(multiscale, 0) is None
+
+
+def test_suggested_voxel_size_of_a_2d_group_has_a_z_factor_of_one() -> None:
+    axes = [
+        {"name": Y_AXIS, "type": "space", "unit": "nanometer"},
+        {"name": X_AXIS, "type": "space", "unit": "nanometer"},
+    ]
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [11.0, 12.0])],
+        coordinate_systems=[{"name": "intrinsic", "axes": axes}],
+    )
+
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert suggested_voxel_size(multiscale, 0) == VoxelSize(
+        (12.0, 11.0, 1.0), LengthUnit.NANOMETER
+    )
+
+
+def test_suggested_coordinate_transformations_are_the_translation_in_voxels() -> None:
+    multiscale = resolve_ome_multiscale(_micrometer_multiscale(), path=_PATH)
+
+    transformations = suggested_coordinate_transformations(multiscale, 0)
+
+    assert transformations == (
+        AffineCoordinateTransformation.from_translation((3.0, 2.0, 2.0)),
+    )
+    # The coarse level sits at the same physical position, so its translation
+    # in its own (twice as large) voxels is the same.
+    assert suggested_coordinate_transformations(multiscale, 1) == transformations
+
+
+def test_suggested_coordinate_transformations_without_a_translation_are_none() -> None:
+    multiscale = resolve_ome_multiscale(
+        _multiscale_06_attributes([_dataset_06("0", [1.0, 1.0, 1.0, 1.0])]),
+        path=_PATH,
+    )
+
+    assert suggested_coordinate_transformations(multiscale, 0) is None
+
+
+def test_top_level_transformation_is_folded_in() -> None:
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 1.0, 2.0, 2.0], [0.0, 0.0, 1.0, 1.0])],
+        coordinate_systems=[{"name": "intrinsic", "axes": _MICROMETER_AXES}],
+        top_level_transformations=[
+            {"type": "scale", "scale": [1.0, 1.0, 10.0, 10.0]},
+            {"type": "translation", "translation": [0.0, 0.0, 5.0, 5.0]},
+        ],
+    )
+    multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert suggested_voxel_size(multiscale, 0) == VoxelSize(
+        (20.0, 20.0, 1.0), LengthUnit.MICROMETER
+    )
+    # (10 * 1 + 5) / (10 * 2) for x and y, nothing for z.
+    assert suggested_coordinate_transformations(multiscale, 0) == (
+        AffineCoordinateTransformation.from_translation((0.75, 0.75, 0.0)),
+    )
+
+
+def test_unsupported_top_level_transformation_is_ignored() -> None:
+    attributes = _multiscale_06_attributes(
+        [_dataset_06("0", [1.0, 1.0, 1.0, 1.0])],
+        top_level_transformations=[{"type": "rotation", "rotation": [0.0]}],
+    )
+
+    with pytest.warns(UserWarning, match="top-level"):
+        multiscale = resolve_ome_multiscale(attributes, path=_PATH)
+
+    assert multiscale.top_level_transform is None

--- a/webknossos/tests/dataset/test_ozx_image_source.py
+++ b/webknossos/tests/dataset/test_ozx_image_source.py
@@ -7,10 +7,19 @@ import pytest
 import tensorstore as ts
 from upath import UPath
 
-from tests.data_fixtures import download_wklibs_sample_archive, write_ozx_file
+from tests.data_fixtures import (
+    download_wklibs_sample_archive,
+    write_ozx_06_file,
+    write_ozx_file,
+)
 from webknossos.dataset import CorruptImageError, UnsupportedImageFormatError
 from webknossos.dataset._image_conversion.image_source import ReadOptions
 from webknossos.dataset._image_conversion.ozx_image_source import OzxImageSource
+from webknossos.dataset_properties import (
+    AffineCoordinateTransformation,
+    LengthUnit,
+    VoxelSize,
+)
 from webknossos.geometry.constants import C_AXIS, X_AXIS, Y_AXIS, Z_AXIS
 
 
@@ -231,3 +240,48 @@ def test_real_world_ozx_sample() -> None:
         .result()
     )
     np.testing.assert_array_equal(block[0], reference)
+
+
+def test_ozx_06_archive_suggests_voxel_size_and_transformations(
+    tmp_upath: UPath,
+) -> None:
+    ozx_path = tmp_upath / "transformed.ozx"
+    axes = [
+        {"name": Z_AXIS, "type": "space", "unit": "micrometer"},
+        {"name": Y_AXIS, "type": "space", "unit": "micrometer"},
+        {"name": X_AXIS, "type": "space", "unit": "micrometer"},
+    ]
+    write_ozx_06_file(
+        ozx_path,
+        [
+            ("0", np.ones((4, 8, 8), dtype=np.uint8), [0.2, 0.5, 0.5]),
+            ("1", np.ones((4, 4, 4), dtype=np.uint8), [0.4, 1.0, 1.0]),
+        ],
+        axes,
+        version="0.6rc1",
+        translations={"0": [0.4, 1.0, 1.5]},
+    )
+
+    source = _open(ozx_path)
+
+    assert (source._z, source._y, source._x) == (4, 8, 8)
+    assert source.suggested_voxel_size == VoxelSize(
+        (0.5, 0.5, 0.2), LengthUnit.MICROMETER
+    )
+    assert source.suggested_coordinate_transformations == (
+        AffineCoordinateTransformation.from_translation((3.0, 2.0, 2.0)),
+    )
+
+
+def test_ozx_archive_without_transformations_suggests_none(tmp_upath: UPath) -> None:
+    ozx_path = tmp_upath / "plain.ozx"
+    write_ozx_file(
+        ozx_path,
+        [("0", np.ones((4, 8, 8), dtype=np.uint8), [1.0, 1.0, 1.0])],
+        _AXES_CZYX[1:],
+    )
+
+    source = _open(ozx_path)
+
+    assert source.suggested_voxel_size is None
+    assert source.suggested_coordinate_transformations is None

--- a/webknossos/tests/dataset/test_zarr_image_source.py
+++ b/webknossos/tests/dataset/test_zarr_image_source.py
@@ -7,6 +7,7 @@ from upath import UPath
 
 from tests.data_fixtures import (
     write_ome_zarr_v2_group,
+    write_ome_zarr_v3_06_group,
     write_ome_zarr_v3_group,
     write_zarr_v2_array,
     write_zarr_v3_array,
@@ -14,6 +15,11 @@ from tests.data_fixtures import (
 from webknossos.dataset import CorruptImageError, UnsupportedImageFormatError
 from webknossos.dataset._image_conversion.image_source import ReadOptions
 from webknossos.dataset._image_conversion.zarr_image_source import ZarrImageSource
+from webknossos.dataset_properties import (
+    AffineCoordinateTransformation,
+    LengthUnit,
+    VoxelSize,
+)
 from webknossos.geometry.constants import C_AXIS, CXYZ_AXES, X_AXIS, Y_AXIS, Z_AXIS
 
 
@@ -90,7 +96,10 @@ def test_plain_zarr_v3_array_with_dimension_names_uses_labels(tmp_upath: UPath) 
     )  # (x, y, z) -> (z, y, x), channel 0 (the default pin)
 
 
-@pytest.mark.parametrize("writer", [write_ome_zarr_v2_group, write_ome_zarr_v3_group])
+@pytest.mark.parametrize(
+    "writer",
+    [write_ome_zarr_v2_group, write_ome_zarr_v3_group, write_ome_zarr_v3_06_group],
+)
 def test_ome_zarr_group_picks_finest_resolution(tmp_upath: UPath, writer: Any) -> None:
     group_path = tmp_upath / "multiscale"
     finest = np.arange(2 * 4 * 8 * 8, dtype=np.uint8).reshape(2, 4, 8, 8)
@@ -118,7 +127,10 @@ def test_ome_zarr_group_picks_finest_resolution(tmp_upath: UPath, writer: Any) -
     np.testing.assert_array_equal(block[0], finest[0])  # channel 0, the default pin
 
 
-@pytest.mark.parametrize("writer", [write_ome_zarr_v2_group, write_ome_zarr_v3_group])
+@pytest.mark.parametrize(
+    "writer",
+    [write_ome_zarr_v2_group, write_ome_zarr_v3_group, write_ome_zarr_v3_06_group],
+)
 def test_ome_zarr_group_scale_option_picks_other_level(
     tmp_upath: UPath, writer: Any
 ) -> None:
@@ -201,7 +213,10 @@ def test_corrupt_metadata_json_raises_corrupt_image_error(tmp_upath: UPath) -> N
         _open(array_path)
 
 
-@pytest.mark.parametrize("writer", [write_ome_zarr_v2_group, write_ome_zarr_v3_group])
+@pytest.mark.parametrize(
+    "writer",
+    [write_ome_zarr_v2_group, write_ome_zarr_v3_group, write_ome_zarr_v3_06_group],
+)
 def test_unsupported_ome_version_is_rejected(tmp_upath: UPath, writer: Any) -> None:
     group_path = tmp_upath / "future_version"
     data = np.zeros((4, 8, 8), dtype=np.uint8)
@@ -221,3 +236,78 @@ def test_unsupported_ome_version_is_rejected(tmp_upath: UPath, writer: Any) -> N
 
     with pytest.raises(UnsupportedImageFormatError, match="0.1"):
         _open(group_path)
+
+
+_AXES_ZYX_MICROMETER = [
+    {"name": Z_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": Y_AXIS, "type": "space", "unit": "micrometer"},
+    {"name": X_AXIS, "type": "space", "unit": "micrometer"},
+]
+
+
+def _write_transformed_group(group_path: UPath) -> None:
+    write_ome_zarr_v3_06_group(
+        group_path,
+        [
+            ("0", np.ones((4, 8, 8), dtype=np.uint8), [0.2, 0.5, 0.5]),
+            ("1", np.ones((4, 4, 4), dtype=np.uint8), [0.4, 1.0, 1.0]),
+        ],
+        _AXES_ZYX_MICROMETER,
+        translations={"0": [0.4, 1.0, 1.5], "1": [0.4, 1.0, 1.5]},
+    )
+
+
+def test_ome_zarr_06_group_suggests_voxel_size_and_transformations(
+    tmp_upath: UPath,
+) -> None:
+    group_path = tmp_upath / "transformed"
+    _write_transformed_group(group_path)
+
+    source = _open(group_path)
+
+    assert source.suggested_voxel_size == VoxelSize(
+        (0.5, 0.5, 0.2), LengthUnit.MICROMETER
+    )
+    assert source.suggested_coordinate_transformations == (
+        AffineCoordinateTransformation.from_translation((3.0, 2.0, 2.0)),
+    )
+
+
+def test_ome_zarr_06_group_suggestions_follow_the_scale_option(
+    tmp_upath: UPath,
+) -> None:
+    group_path = tmp_upath / "transformed_coarse"
+    _write_transformed_group(group_path)
+
+    source = _open(group_path, format_options={"scale": 1})
+
+    assert source.suggested_voxel_size == VoxelSize(
+        (1.0, 1.0, 0.4), LengthUnit.MICROMETER
+    )
+    assert source.suggested_coordinate_transformations == (
+        AffineCoordinateTransformation.from_translation((1.5, 1.0, 1.0)),
+    )
+
+
+def test_plain_zarr_array_suggests_nothing(tmp_upath: UPath) -> None:
+    array_path = tmp_upath / "plain_suggestions"
+    write_zarr_v3_array(array_path, np.zeros((2, 2, 2), dtype=np.uint8))
+
+    source = _open(array_path)
+
+    assert source.suggested_voxel_size is None
+    assert source.suggested_coordinate_transformations is None
+
+
+def test_ome_zarr_group_without_units_suggests_no_voxel_size(tmp_upath: UPath) -> None:
+    group_path = tmp_upath / "unitless"
+    write_ome_zarr_v3_06_group(
+        group_path,
+        [("0", np.zeros((4, 8, 8), dtype=np.uint8), [1.0, 1.0, 1.0])],
+        _AXES_CZYX[1:],
+    )
+
+    source = _open(group_path)
+
+    assert source.suggested_voxel_size is None
+    assert source.suggested_coordinate_transformations is None

--- a/webknossos/webknossos/dataset/_image_conversion/image_conversion.py
+++ b/webknossos/webknossos/dataset/_image_conversion/image_conversion.py
@@ -28,6 +28,8 @@ from ... import utils
 from ...dataset_properties import (
     COLOR_CATEGORY,
     SEGMENTATION_CATEGORY,
+    AffineCoordinateTransformation,
+    CoordinateTransformation,
     DataFormat,
     LayerCategoryType,
     LayerProperties,
@@ -321,6 +323,68 @@ def _has_image_z_dimension(filepath: UPath) -> bool:
     )
 
 
+def _voxel_size_from_images(
+    filepaths_per_layer: dict[str, list[UPath]],
+) -> VoxelSize | None:
+    """The voxel size the images report themselves, for callers that supplied
+    none. Layers that report nothing are skipped; if they disagree, the first
+    one wins. None when no layer reports one."""
+    suggestions: list[tuple[str, VoxelSize]] = []
+    with _quiet_reader_warnings():
+        for name, filepaths in filepaths_per_layer.items():
+            try:
+                source = open_image_source(
+                    filepaths[0] if len(filepaths) == 1 else sorted(filepaths),
+                    ReadOptions(),
+                )
+            except Exception:
+                # Opening it again below reports this properly.
+                continue
+            if (suggested := source.suggested_voxel_size) is not None:
+                suggestions.append((name, suggested))
+    if len(suggestions) == 0:
+        return None
+    first_name, first = suggestions[0]
+    differing = [
+        name
+        for name, suggested in suggestions[1:]
+        if not np.allclose(suggested.to_nanometer(), first.to_nanometer())
+    ]
+    if differing:
+        warnings.warn(
+            f"[INFO] The images report different voxel sizes. Using {first} from "
+            f"{first_name} for the whole dataset, also for {differing}."
+        )
+    return first
+
+
+def _in_dataset_voxels(
+    transformations: tuple[CoordinateTransformation, ...],
+    *,
+    suggested_voxel_size: VoxelSize | None,
+    dataset_voxel_size: VoxelSize,
+) -> list[CoordinateTransformation]:
+    """A source states its transformations in voxels of the voxel size it
+    suggests, while WEBKNOSSOS reads them in the dataset's voxels. Conjugating
+    by the ratio converts between the two."""
+    if suggested_voxel_size is None:
+        return list(transformations)
+    ratio = np.asarray(suggested_voxel_size.to_nanometer()) / np.asarray(
+        dataset_voxel_size.to_nanometer()
+    )
+    if np.allclose(ratio, 1.0):
+        return list(transformations)
+    scale = np.diag([*ratio, 1.0])
+    return [
+        AffineCoordinateTransformation(
+            matrix=scale @ transformation.matrix @ np.linalg.inv(scale)
+        )
+        if isinstance(transformation, AffineCoordinateTransformation)
+        else transformation
+        for transformation in transformations
+    ]
+
+
 def from_images(
     dataset_cls: type[Dataset],
     input_path: str | PathLike | UPath,
@@ -412,18 +476,6 @@ def from_images(
             )
     else:
         map_filepath_to_layer_name_func = map_filepath_to_layer_name
-    if voxel_size_with_unit is None:
-        assert voxel_size is not None, (
-            "Please supply either voxel_size or voxel_size_with_unit."
-        )
-        voxel_size_with_unit = VoxelSize(voxel_size)
-    else:
-        assert voxel_size is None, (
-            "Please supply either voxel_size or voxel_size_with_unit not both."
-        )
-
-    ds = dataset_cls(output_path, voxel_size_with_unit=voxel_size_with_unit, name=name)
-
     filepaths_per_layer: dict[str, list[UPath]] = {}
     for input_file in input_files:
         layer_name_from_mapping = map_filepath_to_layer_name_func(input_file)
@@ -451,6 +503,23 @@ def from_images(
             filepaths_per_layer = {
                 f"{layer_name}_{k}": v for k, v in filepaths_per_layer.items()
             }
+
+    if voxel_size_with_unit is None:
+        if voxel_size is None:
+            voxel_size_with_unit = _voxel_size_from_images(filepaths_per_layer)
+            assert voxel_size_with_unit is not None, (
+                "Please supply either voxel_size or voxel_size_with_unit. The "
+                "images carry no voxel size of their own."
+            )
+        else:
+            voxel_size_with_unit = VoxelSize(voxel_size)
+    else:
+        assert voxel_size is None, (
+            "Please supply either voxel_size or voxel_size_with_unit not both."
+        )
+
+    ds = dataset_cls(output_path, voxel_size_with_unit=voxel_size_with_unit, name=name)
+
     with utils.wrap_executor(executor) as executor:
         with _quiet_reader_warnings():
             for layer_name, filepaths in filepaths_per_layer.items():
@@ -694,6 +763,16 @@ def add_layer_from_images(
                 )
             elif suggested is not None:
                 layer.default_view_configuration = suggested
+
+        # OME-Zarr's coordinate transformations place the data in space. Only
+        # the layer's metadata records this — the data itself is written at the
+        # same position it would be without them.
+        if transformations := image_source.suggested_coordinate_transformations:
+            layer.coordinate_transformations = _in_dataset_voxels(
+                transformations,
+                suggested_voxel_size=image_source.suggested_voxel_size,
+                dataset_voxel_size=dataset.voxel_size_with_unit,
+            )
 
         expected_bbox = image_source.expected_bbox
 

--- a/webknossos/webknossos/dataset/_image_conversion/image_source.py
+++ b/webknossos/webknossos/dataset/_image_conversion/image_source.py
@@ -21,7 +21,11 @@ from typing import NamedTuple
 import numpy as np
 from numpy.typing import DTypeLike
 
-from ...dataset_properties import LayerViewConfiguration
+from ...dataset_properties import (
+    CoordinateTransformation,
+    LayerViewConfiguration,
+    VoxelSize,
+)
 from ...geometry.constants import C_AXIS, CXYZ_AXES, T_AXIS, XYZ_AXES
 from ...geometry.mag import Mag
 from ...geometry.normalized_bounding_box import NormalizedBoundingBox
@@ -214,6 +218,23 @@ class ImageSource(ABC):
         """Format-specific default display (color, intensity range, ...) for
         the channel this source writes, when the format's own metadata
         carries one. None for formats with no such metadata."""
+        return None
+
+    @property
+    def suggested_voxel_size(self) -> VoxelSize | None:
+        """The physical size of one Mag(1) voxel of the data this source
+        writes, when the format's own metadata carries one (e.g. OME-Zarr
+        coordinate transformations). None for formats with no such metadata."""
+        return None
+
+    @property
+    def suggested_coordinate_transformations(
+        self,
+    ) -> tuple[CoordinateTransformation, ...] | None:
+        """Where this source's data sits relative to the origin, as layer
+        coordinate transformations in Mag(1) voxels of
+        `suggested_voxel_size`. None when the format carries no placement, or
+        the data sits at the origin."""
         return None
 
     def layer_split_label(self, key: str, value: int) -> str:

--- a/webknossos/webknossos/dataset/_image_conversion/ome_zarr_helpers.py
+++ b/webknossos/webknossos/dataset/_image_conversion/ome_zarr_helpers.py
@@ -1,19 +1,30 @@
 """Shared OME-Zarr multiscale group parsing: ranking a group's `datasets` by
-resolution and naming its axes. Used by both `ZarrImageSource` (a multiscale
-group stored as a directory) and `OzxImageSource` (one zipped into an `.ozx`
-archive) — the `multiscales` metadata itself is identical either way, only
-how the resolved dataset path is turned into something openable differs.
+resolution, naming its axes, and reading their coordinate transformations. Used
+by both `ZarrImageSource` (a multiscale group stored as a directory) and
+`OzxImageSource` (one zipped into an `.ozx` archive) — the `multiscales`
+metadata itself is identical either way, only how the resolved dataset path is
+turned into something openable differs.
 """
 
 from __future__ import annotations
 
+import math
+import warnings
 from dataclasses import dataclass
 from typing import Any
 
 from upath import UPath
 
-from ...dataset_properties import LayerViewConfiguration
-from ...geometry.constants import C_AXIS, T_AXIS
+from ...dataset_properties import (
+    _LENGTH_UNIT_TO_NANOMETER,
+    AffineCoordinateTransformation,
+    LayerViewConfiguration,
+    LengthUnit,
+    VoxelSize,
+    length_unit_from_str,
+)
+from ...geometry.constants import C_AXIS, T_AXIS, XYZ_AXES
+from ...geometry.vec3_float import Vec3Float
 from ..errors import (
     CorruptImageError,
     UnsupportedImageDataError,
@@ -22,7 +33,40 @@ from ..errors import (
 from ..layer.abstract_layer import _UNALLOWED_LAYER_NAME_CHARS
 from .tensorstore_chunked_image_source import normalize_axis
 
-_SUPPORTED_OME_VERSIONS = ("0.4", "0.5")
+_SUPPORTED_OME_VERSIONS = ("0.4", "0.5", "0.6rc1", "0.6")
+_OME_06_VERSIONS = ("0.6rc1", "0.6")
+_MAX_SEQUENCE_DEPTH = 8
+
+
+@dataclass(frozen=True)
+class OmeTransform:
+    """One dataset's coordinate transformation, reduced to a scale and a
+    translation. Both are index-aligned with the multiscale's axes, not with
+    x/y/z — that mapping happens in `suggested_voxel_size` and
+    `suggested_coordinate_transformations`."""
+
+    scale: tuple[float, ...]
+    translation: tuple[float, ...]
+
+    @classmethod
+    def identity(cls, ndim: int) -> OmeTransform:
+        return cls((1.0,) * ndim, (0.0,) * ndim)
+
+    def is_identity(self) -> bool:
+        return all(s == 1.0 for s in self.scale) and all(
+            t == 0.0 for t in self.translation
+        )
+
+
+def _compose(outer: OmeTransform, inner: OmeTransform) -> OmeTransform:
+    """`outer` applied after `inner`."""
+    return OmeTransform(
+        tuple(o * i for o, i in zip(outer.scale, inner.scale)),
+        tuple(
+            o * i + t
+            for o, i, t in zip(outer.scale, inner.translation, outer.translation)
+        ),
+    )
 
 
 def _scale_transform(dataset: dict[str, Any], *, path: UPath) -> list[float]:
@@ -36,13 +80,154 @@ def _scale_transform(dataset: dict[str, Any], *, path: UPath) -> list[float]:
     )
 
 
-def _resolution_key(
-    dataset: dict[str, Any], axes: list[dict[str, Any]], *, path: UPath
-) -> float:
+def _translation_transform(dataset: dict[str, Any]) -> list[float] | None:
+    for transform in dataset.get("coordinateTransformations", ()):
+        if transform.get("type") == "translation":
+            return transform["translation"]
+    return None
+
+
+def _legacy_transform(dataset: dict[str, Any], *, path: UPath) -> OmeTransform:
+    """The scale and translation of one NGFF 0.4/0.5 dataset entry, which lists
+    them side by side rather than nesting them in a `sequence`."""
+    scale = _scale_transform(dataset, path=path)
+    translation = _translation_transform(dataset) or [0.0] * len(scale)
+    return OmeTransform(tuple(scale), tuple(translation))
+
+
+def _literal_values(
+    transform: dict[str, Any], key: str, *, ndim: int, path: UPath
+) -> tuple[float, ...]:
+    values = transform.get(key)
+    if not isinstance(values, list):
+        raise UnsupportedImageDataError(
+            f"The OME-Zarr {transform.get('type')!r} coordinateTransformation of "
+            f"{path} does not give {key!r} as a list of numbers — one stored in "
+            "an array is not supported.",
+            path=path,
+        )
+    if len(values) != ndim:
+        raise CorruptImageError(
+            f"The OME-Zarr {transform.get('type')!r} coordinateTransformation of "
+            f"{path} has {len(values)} {key} entries, but the group has {ndim} axes.",
+            path=path,
+        )
+    return tuple(float(value) for value in values)
+
+
+def _flatten_transform(
+    transform: dict[str, Any], *, ndim: int, path: UPath, depth: int = 0
+) -> OmeTransform:
+    """One NGFF 0.6 coordinateTransformation reduced to a scale and a
+    translation. A `sequence` is composed entry by entry."""
+    transform_type = transform.get("type")
+    if transform_type == "identity":
+        return OmeTransform.identity(ndim)
+    if transform_type == "scale":
+        return OmeTransform(
+            _literal_values(transform, "scale", ndim=ndim, path=path), (0.0,) * ndim
+        )
+    if transform_type == "translation":
+        return OmeTransform(
+            (1.0,) * ndim,
+            _literal_values(transform, "translation", ndim=ndim, path=path),
+        )
+    if transform_type == "sequence":
+        if depth >= _MAX_SEQUENCE_DEPTH:
+            raise UnsupportedImageDataError(
+                f"The OME-Zarr coordinateTransformation of {path} nests "
+                "'sequence' too deeply.",
+                path=path,
+            )
+        result = OmeTransform.identity(ndim)
+        for inner in transform.get("transformations") or ():
+            result = _compose(
+                _flatten_transform(inner, ndim=ndim, path=path, depth=depth + 1),
+                result,
+            )
+        return result
+    raise UnsupportedImageDataError(
+        f"The OME-Zarr coordinateTransformation of {path} is of type "
+        f"{transform_type!r}; only identity, scale, translation and sequences "
+        "of them are supported.",
+        path=path,
+    )
+
+
+def _ome_06_transform(
+    dataset: dict[str, Any], *, ndim: int, path: UPath
+) -> OmeTransform:
+    transforms = dataset.get("coordinateTransformations") or []
+    if len(transforms) != 1:
+        raise CorruptImageError(
+            f"OME-Zarr dataset {dataset.get('path')!r} of {path} has "
+            f"{len(transforms)} coordinateTransformations; NGFF 0.6 requires "
+            "exactly one.",
+            path=path,
+        )
+    return _flatten_transform(transforms[0], ndim=ndim, path=path)
+
+
+def _ome_06_axes(
+    multiscale: dict[str, Any], datasets: list[dict[str, Any]], *, path: UPath
+) -> list[dict[str, Any]]:
+    """The axes of the intrinsic coordinate system — the one the first dataset's
+    transformation names as its `output`, or the first system otherwise. NGFF
+    0.6 moved `axes` from the multiscale entry into `coordinateSystems`."""
+    systems = multiscale.get("coordinateSystems") or []
+    if not systems:
+        raise CorruptImageError(
+            f"OME-Zarr multiscale group {path} has no coordinateSystems.", path=path
+        )
+    intrinsic_name = None
+    transforms = datasets[0].get("coordinateTransformations") or []
+    if transforms:
+        output = transforms[0].get("output")
+        if isinstance(output, dict):
+            intrinsic_name = output.get("name")
+    system = next(
+        (s for s in systems if s.get("name") == intrinsic_name),
+        systems[0],
+    )
+    axes = system.get("axes") or []
+    if not axes:
+        raise CorruptImageError(
+            f"The OME-Zarr coordinate system {system.get('name')!r} of {path} "
+            "has no axes.",
+            path=path,
+        )
+    return axes
+
+
+def _ome_top_level_transform(
+    multiscale: dict[str, Any], *, ndim: int, path: UPath
+) -> OmeTransform | None:
+    """`multiscales[0].coordinateTransformations`, which places the whole
+    pyramid in another coordinate system. None when absent, the identity, or of
+    a type we cannot represent — it is optional metadata, so an unsupported one
+    is warned about rather than raised."""
+    transforms = multiscale.get("coordinateTransformations") or []
+    if not transforms:
+        return None
+    result = OmeTransform.identity(ndim)
+    try:
+        for transform in transforms:
+            result = _compose(
+                _flatten_transform(transform, ndim=ndim, path=path), result
+            )
+    except (UnsupportedImageDataError, CorruptImageError):
+        warnings.warn(
+            f"[INFO] Ignoring the top-level coordinateTransformation of {path}, "
+            "which is not supported."
+        )
+        return None
+    return None if result.is_identity() else result
+
+
+def _resolution_key(scale: tuple[float, ...], axes: list[dict[str, Any]]) -> float:
     """Product of the spatial-axis scale factors — smaller is finer. Uses the
     group's `axes` metadata to know which scale entries are spatial, rather
     than assuming any particular list order."""
-    scale = _scale_transform(dataset, path=path)
     if axes:
         spatial_indices = [
             i for i, axis in enumerate(axes) if axis.get("type") == "space"
@@ -205,12 +390,25 @@ class OmeMultiscale:
     """Per-channel `omero.channels` metadata, index-aligned with the group's
     channel axis. None when the group has no `omero` metadata."""
 
+    transforms: tuple[OmeTransform, ...] = ()
+    """Each dataset's coordinate transformation, index-aligned with
+    `dataset_paths` and therefore ranked finest first. Each one's components
+    are index-aligned with `axis_names`."""
+
+    axis_units: tuple[str | None, ...] | None = None
+    """Each axis' `unit` string, index-aligned with `axis_names`. None when the
+    group has no `axes` entries."""
+
+    top_level_transform: OmeTransform | None = None
+    """The multiscale entry's own `coordinateTransformations`, placing the whole
+    pyramid in another coordinate system. None when there is none."""
+
 
 def resolve_ome_multiscale(attributes: dict[str, Any], *, path: UPath) -> OmeMultiscale:
     """
     Validates and ranks the first `multiscales` entry of an OME-Zarr group's
     attributes. `attributes` is the group's `.zattrs` (NGFF 0.4) or its
-    `attributes.ome` (NGFF 0.5) — whichever carries `multiscales` and,
+    `attributes.ome` (NGFF 0.5 and 0.6) — whichever carries `multiscales` and,
     for 0.4, `version` alongside it.
     """
     multiscales = attributes.get("multiscales")
@@ -223,14 +421,22 @@ def resolve_ome_multiscale(attributes: dict[str, Any], *, path: UPath) -> OmeMul
     multiscale = multiscales[0]
 
     # NGFF 0.4 (Zarr v2) carries "version" inside the multiscale entry; NGFF
-    # 0.5 (Zarr v3) carries it on the enclosing "ome" object instead —
+    # 0.5 and 0.6 (Zarr v3) carry it on the enclosing "ome" object instead —
     # `attributes` is whichever of the two was passed in.
-    version = attributes.get("version") or multiscale.get("version")
+    version_from_attributes = attributes.get("version")
+    version = version_from_attributes or multiscale.get("version")
     if version not in _SUPPORTED_OME_VERSIONS:
         raise UnsupportedImageFormatError(
             f"{path} is an OME-Zarr multiscale group with version "
             f"{version!r}; only {', '.join(_SUPPORTED_OME_VERSIONS)} are "
             "supported.",
+            path=path,
+        )
+    is_06 = version in _OME_06_VERSIONS
+    if is_06 and version_from_attributes is None:
+        raise UnsupportedImageFormatError(
+            f"{path} declares OME-Zarr version {version!r} inside its multiscale "
+            "entry; NGFF 0.6 requires it on the enclosing 'ome' object.",
             path=path,
         )
 
@@ -239,15 +445,140 @@ def resolve_ome_multiscale(attributes: dict[str, Any], *, path: UPath) -> OmeMul
         raise CorruptImageError(
             f"OME-Zarr multiscale group {path} has no datasets.", path=path
         )
-    axes = multiscale.get("axes", [])
+    axes = (
+        _ome_06_axes(multiscale, datasets, path=path)
+        if is_06
+        else multiscale.get("axes", [])
+    )
+    ndim = len(axes) or len(_scale_transform(datasets[0], path=path))
+    transforms = [
+        _ome_06_transform(dataset, ndim=ndim, path=path)
+        if is_06
+        else _legacy_transform(dataset, path=path)
+        for dataset in datasets
+    ]
+    top_level_transform = _ome_top_level_transform(multiscale, ndim=ndim, path=path)
 
     ranked_indices = sorted(
         range(len(datasets)),
-        key=lambda i: _resolution_key(datasets[i], axes, path=path),
+        key=lambda i: _resolution_key(transforms[i].scale, axes),
     )
     dataset_paths = tuple(datasets[i]["path"] for i in ranked_indices)
     axis_names = (
         tuple(_ome_axis_name(axis, path=path) for axis in axes) if axes else None
     )
+    axis_units = tuple(axis.get("unit") for axis in axes) if axes else None
     channels = _parse_omero_channels(attributes)
-    return OmeMultiscale(dataset_paths, axis_names, channels)
+    return OmeMultiscale(
+        dataset_paths=dataset_paths,
+        axis_names=axis_names,
+        channels=channels,
+        transforms=tuple(transforms[i] for i in ranked_indices),
+        axis_units=axis_units,
+        top_level_transform=top_level_transform,
+    )
+
+
+def _spatial_components(
+    multiscale: OmeMultiscale, rank: int
+) -> tuple[OmeTransform, dict[str, int]] | None:
+    """The transform of the level at `rank` plus where each of x/y/z sits in
+    it. None when the group's axes or that rank are unusable."""
+    if multiscale.axis_names is None or not (0 <= rank < len(multiscale.transforms)):
+        return None
+    index_of = {axis: i for i, axis in enumerate(multiscale.axis_names)}
+    return multiscale.transforms[rank], index_of
+
+
+def suggested_voxel_size(multiscale: OmeMultiscale, rank: int) -> VoxelSize | None:
+    """The physical size of one voxel of the level at `rank`, from its `scale`
+    coordinateTransformation and the axes' `unit`. `rank` is the level that
+    actually gets opened, since that one becomes the layer's Mag(1).
+
+    None when the metadata does not determine a voxel size — no axes, no unit
+    on any spatial axis, or an unusable factor. Guessing a unit would fabricate
+    a physical scale, so the caller is left to supply one instead.
+    """
+    components = _spatial_components(multiscale, rank)
+    if components is None or multiscale.axis_units is None:
+        return None
+    transform, index_of = components
+    top = multiscale.top_level_transform
+
+    factors: list[float] = []
+    units: list[LengthUnit | None] = []
+    for axis in XYZ_AXES:
+        i = index_of.get(axis)
+        if i is None:
+            # An axis the data does not have, e.g. z for a 2D image.
+            factors.append(1.0)
+            units.append(None)
+            continue
+        factors.append(transform.scale[i] * (top.scale[i] if top else 1.0))
+        unit = multiscale.axis_units[i]
+        if unit is None:
+            units.append(None)
+            continue
+        try:
+            units.append(length_unit_from_str(unit))
+        except ValueError:
+            warnings.warn(
+                f"[INFO] Ignoring the OME-Zarr voxel size, because the axis unit "
+                f"{unit!r} is not a known length unit."
+            )
+            return None
+
+    present_units = [unit for unit in units if unit is not None]
+    if not present_units:
+        return None
+    common = min(present_units, key=lambda unit: _LENGTH_UNIT_TO_NANOMETER[unit])
+    factors = [
+        factor
+        * (
+            _LENGTH_UNIT_TO_NANOMETER[unit] / _LENGTH_UNIT_TO_NANOMETER[common]
+            if unit is not None
+            else 1.0
+        )
+        for factor, unit in zip(factors, units)
+    ]
+    if not all(math.isfinite(factor) and factor > 0 for factor in factors):
+        return None
+    return VoxelSize(Vec3Float(*factors), common)
+
+
+def suggested_coordinate_transformations(
+    multiscale: OmeMultiscale, rank: int
+) -> tuple[AffineCoordinateTransformation, ...] | None:
+    """Where the level at `rank` sits relative to the origin, as a layer
+    coordinate transformation in that level's own voxels.
+
+    The scale already went into `suggested_voxel_size`, so what is left is the
+    translation, divided by the scale to express it in voxels. None when the
+    level sits at the origin.
+    """
+    components = _spatial_components(multiscale, rank)
+    if components is None:
+        return None
+    transform, index_of = components
+    top = multiscale.top_level_transform
+
+    translation: list[float] = []
+    for axis in XYZ_AXES:
+        i = index_of.get(axis)
+        if i is None:
+            translation.append(0.0)
+            continue
+        top_scale = top.scale[i] if top else 1.0
+        top_translation = top.translation[i] if top else 0.0
+        scale = transform.scale[i] * top_scale
+        translation.append(
+            (top_scale * transform.translation[i] + top_translation) / scale
+            if scale
+            else 0.0
+        )
+
+    if not all(math.isfinite(value) for value in translation):
+        return None
+    if all(value == 0.0 for value in translation):
+        return None
+    return (AffineCoordinateTransformation.from_translation(translation),)

--- a/webknossos/webknossos/dataset/_image_conversion/ozx_image_source.py
+++ b/webknossos/webknossos/dataset/_image_conversion/ozx_image_source.py
@@ -19,7 +19,11 @@ import zipfile
 import tensorstore as ts
 from upath import UPath
 
-from ...dataset_properties import LayerViewConfiguration
+from ...dataset_properties import (
+    CoordinateTransformation,
+    LayerViewConfiguration,
+    VoxelSize,
+)
 from ...geometry.constants import C_AXIS, X_AXIS, Y_AXIS, Z_AXIS
 from .._utils.tensorstore_helpers import TS_CONTEXT, _make_kvstore
 from ..errors import CorruptImageError, UnsupportedImageFormatError
@@ -28,8 +32,12 @@ from .image_source_registry import register_chunked_image_source
 from .ome_zarr_helpers import layer_split_label as _ome_layer_split_label
 from .ome_zarr_helpers import resolve_ome_multiscale
 from .ome_zarr_helpers import (
+    suggested_coordinate_transformations as _ome_suggested_coordinate_transformations,
+)
+from .ome_zarr_helpers import (
     suggested_view_configuration as _ome_suggested_view_configuration,
 )
+from .ome_zarr_helpers import suggested_voxel_size as _ome_suggested_voxel_size
 from .tensorstore_chunked_image_source import TensorStoreChunkedImageSource, guess_axes
 
 _ROOT_ZARR_JSON_KEY = "zarr.json"
@@ -94,6 +102,7 @@ class OzxImageSource(TensorStoreChunkedImageSource):
         ome = attributes.get("ome", attributes)
         multiscale = resolve_ome_multiscale(ome, path=path)
         self._omero_channels = multiscale.channels
+        self._ome_multiscale = multiscale
 
         rank = options.format_option("scale")
         rank = 0 if rank is None else rank
@@ -102,6 +111,7 @@ class OzxImageSource(TensorStoreChunkedImageSource):
                 f"scale {rank} does not exist in {path}. Available: "
                 f"{list(range(len(multiscale.dataset_paths)))}."
             )
+        self._ome_rank = rank
         chosen_dataset_path = multiscale.dataset_paths[rank]
         self._ts_spec = {
             "driver": "zarr3",
@@ -165,3 +175,15 @@ class OzxImageSource(TensorStoreChunkedImageSource):
         return _ome_layer_split_label(
             self._omero_channels, key, value
         ) or super().layer_split_label(key, value)
+
+    @property
+    def suggested_voxel_size(self) -> VoxelSize | None:
+        return _ome_suggested_voxel_size(self._ome_multiscale, self._ome_rank)
+
+    @property
+    def suggested_coordinate_transformations(
+        self,
+    ) -> tuple[CoordinateTransformation, ...] | None:
+        return _ome_suggested_coordinate_transformations(
+            self._ome_multiscale, self._ome_rank
+        )

--- a/webknossos/webknossos/dataset/_image_conversion/zarr_image_source.py
+++ b/webknossos/webknossos/dataset/_image_conversion/zarr_image_source.py
@@ -11,12 +11,16 @@ picks a CZI acquisition channel.
 from __future__ import annotations
 
 import json
-from typing import Any
+from typing import Any, NamedTuple
 
 import tensorstore as ts
 from upath import UPath
 
-from ...dataset_properties import LayerViewConfiguration
+from ...dataset_properties import (
+    CoordinateTransformation,
+    LayerViewConfiguration,
+    VoxelSize,
+)
 from ...geometry.constants import C_AXIS, X_AXIS, Y_AXIS, Z_AXIS
 from .._utils.tensorstore_helpers import TS_CONTEXT, _make_kvstore
 from ..defaults import (
@@ -28,12 +32,31 @@ from ..defaults import (
 from ..errors import CorruptImageError
 from .image_source import ReadOptions, compute_channel_selection
 from .image_source_registry import register_chunked_image_source
-from .ome_zarr_helpers import OmeChannelMetadata, resolve_ome_multiscale
+from .ome_zarr_helpers import (
+    OmeChannelMetadata,
+    OmeMultiscale,
+    resolve_ome_multiscale,
+)
 from .ome_zarr_helpers import layer_split_label as _ome_layer_split_label
+from .ome_zarr_helpers import (
+    suggested_coordinate_transformations as _ome_suggested_coordinate_transformations,
+)
 from .ome_zarr_helpers import (
     suggested_view_configuration as _ome_suggested_view_configuration,
 )
+from .ome_zarr_helpers import suggested_voxel_size as _ome_suggested_voxel_size
 from .tensorstore_chunked_image_source import TensorStoreChunkedImageSource, guess_axes
+
+
+class _ResolvedArray(NamedTuple):
+    """The array to open, plus what the OME-Zarr group it came out of said
+    about it. Everything but `path` is None for a plain Zarr array."""
+
+    path: UPath
+    axis_names: list[str] | None
+    channels: tuple[OmeChannelMetadata, ...] | None
+    multiscale: OmeMultiscale | None
+    rank: int
 
 
 def _read_json(path: UPath, *, path_for_errors: UPath) -> Any:
@@ -51,7 +74,7 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
     """
     ChunkedImageSource for plain Zarr arrays (v2 `.zarray`, v3 `zarr.json`
     array nodes) and OME-Zarr multiscale groups (NGFF 0.4 on Zarr v2, NGFF 0.5
-    on Zarr v3). For a multiscale group, the finest resolution level is opened
+    and 0.6 on Zarr v3). For a multiscale group, the finest resolution level is opened
     by default; only the first `multiscales` entry is considered.
     """
 
@@ -71,9 +94,12 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
         super().__init__(path, options)
         self._possible_layers: dict[str, list[int]] = {}
 
-        resolved_path, axis_name_hint, self._omero_channels = self._resolve_array_path(
-            path, options
-        )
+        resolved = self._resolve_array_path(path, options)
+        resolved_path = resolved.path
+        axis_name_hint = resolved.axis_names
+        self._omero_channels = resolved.channels
+        self._ome_multiscale = resolved.multiscale
+        self._ome_rank = resolved.rank
 
         try:
             driver = (
@@ -132,9 +158,23 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
             self._omero_channels, key, value
         ) or super().layer_split_label(key, value)
 
-    def _resolve_array_path(
-        self, path: UPath, options: ReadOptions
-    ) -> tuple[UPath, list[str] | None, tuple[OmeChannelMetadata, ...] | None]:
+    @property
+    def suggested_voxel_size(self) -> VoxelSize | None:
+        if self._ome_multiscale is None:
+            return None
+        return _ome_suggested_voxel_size(self._ome_multiscale, self._ome_rank)
+
+    @property
+    def suggested_coordinate_transformations(
+        self,
+    ) -> tuple[CoordinateTransformation, ...] | None:
+        if self._ome_multiscale is None:
+            return None
+        return _ome_suggested_coordinate_transformations(
+            self._ome_multiscale, self._ome_rank
+        )
+
+    def _resolve_array_path(self, path: UPath, options: ReadOptions) -> _ResolvedArray:
         """
         Resolves `path` to the Zarr array to actually open: itself, if it is
         already a plain array, or — for an OME-Zarr multiscale group — the
@@ -151,7 +191,7 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
             metadata = _read_json(zarr_json_path, path_for_errors=path)
             node_type = metadata.get("node_type")
             if node_type == "array":
-                return path, None, None
+                return _ResolvedArray(path, None, None, None, 0)
             if node_type == "group":
                 attributes = metadata.get("attributes", {})
                 ome = attributes.get("ome", attributes)
@@ -162,7 +202,7 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
             )
 
         if zarray_path.is_file():
-            return path, None, None
+            return _ResolvedArray(path, None, None, None, 0)
 
         if zgroup_path.is_file():
             zattrs_path = path / ZATTRS_FILE_NAME
@@ -181,7 +221,7 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
 
     def _resolve_ome_multiscale(
         self, path: UPath, attributes: dict[str, Any], options: ReadOptions
-    ) -> tuple[UPath, list[str] | None, tuple[OmeChannelMetadata, ...] | None]:
+    ) -> _ResolvedArray:
         multiscale = resolve_ome_multiscale(attributes, path=path)
 
         rank = options.format_option("scale")
@@ -194,4 +234,6 @@ class ZarrImageSource(TensorStoreChunkedImageSource):
 
         resolved_path = path / multiscale.dataset_paths[rank]
         axis_names = list(multiscale.axis_names) if multiscale.axis_names else None
-        return resolved_path, axis_names, multiscale.channels
+        return _ResolvedArray(
+            resolved_path, axis_names, multiscale.channels, multiscale, rank
+        )

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -731,12 +731,16 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
         Args:
             input_path: Path to input image files
             output_path: Output path for created dataset
-            voxel_size: Optional tuple of floats (x,y,z) for voxel size in nm
+            voxel_size: Optional tuple of floats (x,y,z) for voxel size in nm. When
+                neither this nor `voxel_size_with_unit` is given, it is read from the
+                images themselves where they carry one (currently OME-Zarr coordinate
+                transformations), and an error is raised otherwise
             name: Optional name for dataset
             map_filepath_to_layer_name: Strategy for mapping files to layers, either a ConversionLayerMapping
                 enum value or callable taking Path and returning str
             z_slices_sort_key: Optional key function for sorting z-slices
-            voxel_size_with_unit: Optional voxel size with unit specification
+            voxel_size_with_unit: Optional voxel size with unit specification, see
+                `voxel_size` for what happens when neither is given
             layer_name: Optional name for layer(s)
             layer_category: Optional category override (LayerCategoryType.color / LayerCategoryType.segmentation)
             data_format: Format to store data in ('wkw'/'zarr'/'zarr3)
@@ -1176,6 +1180,11 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
         layers, the first three get `default_view_configuration.color` red,
         green and blue respectively (further channels get other, evenly
         spaced colors), so the layers overlay sensibly right away.
+
+        An OME-Zarr input's coordinate transformations are imported into
+        `Layer.coordinate_transformations`. Only the layer's metadata records
+        them — the data is written at the same position it would be without
+        them, and `topleft` is unaffected.
 
         Raises:
             UnsupportedImageFormatError: If no reader can convert `images`. Its

--- a/webknossos/webknossos/dataset/remote_dataset.py
+++ b/webknossos/webknossos/dataset/remote_dataset.py
@@ -1732,11 +1732,15 @@ class RemoteDataset(AbstractDataset[RemoteLayer, RemoteSegmentationLayer]):
 
         Args:
             input_path: Path to input image files
-            voxel_size: Optional tuple of floats (x,y,z) for voxel size in nm
+            voxel_size: Optional tuple of floats (x,y,z) for voxel size in nm. When
+                neither this nor `voxel_size_with_unit` is given, it is read from the
+                images themselves where they carry one (currently OME-Zarr coordinate
+                transformations), and an error is raised otherwise
             name: Optional name for the uploaded dataset
             map_filepath_to_layer_name: Strategy for mapping files to layers
             z_slices_sort_key: Optional key function for sorting z-slices
-            voxel_size_with_unit: Optional voxel size with unit specification
+            voxel_size_with_unit: Optional voxel size with unit specification, see
+                `voxel_size` for what happens when neither is given
             layer_name: Optional name for layer(s)
             layer_category: Optional category override
             data_format: Format to store data in


### PR DESCRIPTION
### Description:
- Adds conversion support for OME-Zarr/NGFF 0.6 (`0.6rc1` and `0.6`). 0.6 moves the multiscale `axes` into `coordinateSystems`, requires exactly one transform per dataset, and allows it to be a `sequence` of a scale and a translation — all of which `resolve_ome_multiscale` now handles, alongside the unchanged 0.4/0.5 paths. A 0.6 version declared inside the multiscale entry instead of on the `ome` object is rejected.
- Imports the coordinate transforms, which were previously parsed and thrown away — the `scale` was used only to rank pyramid levels, and `translation` and the axes' `unit` were ignored entirely. So converting an OME-Zarr store always needed a hand-supplied voxel size and lost the level's placement in space. Now:
  - `Dataset.from_images` derives the dataset's `VoxelSize` (factor + `LengthUnit`) from the opened level's scale and the axes' `unit`, when neither `voxel_size` nor `voxel_size_with_unit` was given.
  - The level's translation becomes an affine `Layer.coordinate_transformations`, in that level's own voxels.
  - `multiscales[0].coordinateTransformations` is folded into both; an unsupported type there warns instead of failing.
- Both are exposed as new optional `ImageSource` properties (`suggested_voxel_size`, `suggested_coordinate_transformations`), mirroring the existing `suggested_view_configuration`. They default to `None`, so every other reader is unaffected.

### Issues:
- fixes #...

### Notes for reviewers:
- **The affine is translation-only.** The scale already went into the `VoxelSize`, so including it again in the matrix would double-apply it. The translation is divided by the scale to express it in voxels, and rescaled in `add_layer_from_images` when the dataset's voxel size differs from what the source suggested (e.g. the caller passed an explicit `voxel_size`).
- **It is metadata only.** The data is written at the same position it would be without it, and `topleft` is untouched.
- `suggested_voxel_size` returns `None` when no spatial axis carries a `unit`, rather than defaulting to nanometers — guessing would fabricate a physical scale. The caller then gets the ordinary "please supply a voxel_size" assertion.
- An `AffineCoordinateTransformation` is only emitted for a non-identity translation, so existing conversions produce byte-identical `datasource-properties.json`.
- 0.4/0.5 parsing is deliberately kept on its own code path so its behaviour is unchanged, including an `identity`-only transform still raising `CorruptImageError` (legal in 0.6, not in 0.4).
- `from_images` needed the layer-grouping loop moved above the `Dataset` construction, since the voxel size now comes from the grouped inputs.
- Out of scope, happy to add on request: writing 0.6 metadata (`ome_metadata.py` and `.ozx` export still produce 0.4/0.5), and making the CLI's `--voxel-size` optional.

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)