### PR TITLE
Fix webknossos --version command in case tifffile extra is missing

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -19,7 +19,7 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Changed
 
 ### Fixed
-
+- Fixed that the `webknossos --version` command failed if the tifffile extra dependency was not installed. [#1534](https://github.com/scalableminds/webknossos-libs/pull/1534)
 
 ## [4.0.0](https://github.com/scalableminds/webknossos-libs/releases/tag/v4.0.0) - 2026-09-03
 [Commits](https://github.com/scalableminds/webknossos-libs/compare/v3.7.0...v4.0.0)

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -93,8 +93,6 @@ def export_tiff_slice_batch(
     mapping_path: UPath | None,
     view: View,
 ) -> None:
-    # Imported here, not at module level, so this module can be imported
-    # (e.g. for `webknossos --version`) without tifffile installed.
     from tifffile import imwrite
 
     tiff_bbox_mag1 = view.bounding_box

--- a/webknossos/webknossos/cli/export_as_tiff.py
+++ b/webknossos/webknossos/cli/export_as_tiff.py
@@ -10,7 +10,6 @@ import typer
 from cluster_tools import Executor
 from scipy.ndimage import zoom
 from tensorstore import Context, TensorStore
-from tifffile import imwrite
 from upath import UPath
 
 from ..dataset import MagView, View
@@ -94,6 +93,10 @@ def export_tiff_slice_batch(
     mapping_path: UPath | None,
     view: View,
 ) -> None:
+    # Imported here, not at module level, so this module can be imported
+    # (e.g. for `webknossos --version`) without tifffile installed.
+    from tifffile import imwrite
+
     tiff_bbox_mag1 = view.bounding_box
     tiff_bbox = tiff_bbox_mag1.in_mag(view.mag)
     compression_arg = "zlib" if compress else None
@@ -293,6 +296,11 @@ def main(
     access_mode: AccessModeOption = None,
 ) -> None:
     """Export your WEBKNOSSOS dataset to TIFF image data."""
+
+    try:
+        import tifffile  # noqa: F401
+    except ImportError as e:
+        raise WkImportError("tifffile", "tifffile") from e
 
     mag_view: MagView | None = None
     mapping_path: UPath | None = None


### PR DESCRIPTION
### Description:
- Fix webknossos --version command in case the tifffile extra is missing by making the import lazy.

I am still getting
```
>>> import webknossos as wk
./webknossos/dataset/_image_conversion/common_slice_readers.py:25: UserWarning: [WARNING] Not all image readers could be imported:
	- TiffSliceReader: Cannot import tifffile. Please install it e.g. using `pip install webknossos[tifffile]`.
	- ImsImageSource: No module named 'h5py'
	- MrcImageSource: Cannot import mrcfile. Please install it e.g. using `pip install webknossos[mrcfile]`.
	- CziImageSource: Cannot import pylibCZIrw. Please install it e.g. using `pip install webknossos[czi]`.
Install the readers you need or use 'webknossos[all]' to install all readers.
  from .image_source_registry import register_slice_reader
```
I assume that is intended?


### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Changelog