### PR TITLE
Name the found file extensions in UnsupportedImageFormatError

### DIFF
--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,10 +15,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
-- `UnsupportedImageFormatError` now carries `found_file_extensions`, the extensions actually present in the input (most common first), so that a failure on a directory can be reported as "found `.dcm` files, which aren't supported" instead of only listing the supported formats. The error message names them as well.
+- `UnsupportedImageFormatError` now carries `found_file_extensions`, the extensions actually present in the input (most common first), so that a failure on a directory can be reported as "found `.dcm` files, which aren't supported" instead of only listing the supported formats. The error message names them as well. [#1538](https://github.com/scalableminds/webknossos-libs/pull/1538)
 
 ### Changed
-- `Dataset.add_layer_from_images` now raises `UnsupportedImageFormatError` when given a directory that contains no convertible file, instead of a generic `ValueError` listing the errors of every attempted reader.
+- `Dataset.add_layer_from_images` now raises `UnsupportedImageFormatError` when given a directory that contains no convertible file, instead of a generic `ValueError` listing the errors of every attempted reader. [#1538](https://github.com/scalableminds/webknossos-libs/pull/1538)
 
 ### Fixed
 - Fixed that the `webknossos --version` command failed if the tifffile extra dependency was not installed. [#1534](https://github.com/scalableminds/webknossos-libs/pull/1534)

--- a/webknossos/Changelog.md
+++ b/webknossos/Changelog.md
@@ -15,8 +15,10 @@ For upgrade instructions, please check the respective _Breaking Changes_ section
 ### Breaking Changes
 
 ### Added
+- `UnsupportedImageFormatError` now carries `found_file_extensions`, the extensions actually present in the input (most common first), so that a failure on a directory can be reported as "found `.dcm` files, which aren't supported" instead of only listing the supported formats. The error message names them as well.
 
 ### Changed
+- `Dataset.add_layer_from_images` now raises `UnsupportedImageFormatError` when given a directory that contains no convertible file, instead of a generic `ValueError` listing the errors of every attempted reader.
 
 ### Fixed
 - Fixed that the `webknossos --version` command failed if the tifffile extra dependency was not installed. [#1534](https://github.com/scalableminds/webknossos-libs/pull/1534)

--- a/webknossos/tests/dataset/test_add_layer_from_images.py
+++ b/webknossos/tests/dataset/test_add_layer_from_images.py
@@ -370,6 +370,26 @@ def test_add_layer_from_images_unsupported_format(tmp_upath: UPath) -> None:
     assert isinstance(error, ValueError)
 
 
+def test_add_layer_from_images_unsupported_directory(tmp_upath: UPath) -> None:
+    # A directory without a single convertible file is an unsupported format
+    # too, and names what it does contain — the directory itself has no
+    # extension to blame.
+    images = tmp_upath / "images"
+    images.mkdir()
+    for i in range(2):
+        (images / f"scan{i}.dcm").write_bytes(b"\x00" * 132)
+    ds = wk.Dataset(tmp_upath / "ds", (1, 1, 1))
+
+    with pytest.raises(wk.UnsupportedImageFormatError) as excinfo:
+        ds.add_layer_from_images(images, layer_name="color")
+    error = excinfo.value
+    assert error.path == images
+    assert error.file_extension is None
+    assert error.found_file_extensions == ("dcm",)
+    assert error.missing_extras == ()
+    assert "Found .dcm files" in str(error)
+
+
 @pytest.mark.parametrize(
     "filename,contents,wraps_reader_error",
     [

--- a/webknossos/tests/dataset/test_from_images.py
+++ b/webknossos/tests/dataset/test_from_images.py
@@ -598,6 +598,7 @@ def test_from_images_names_missing_optional_dependency(
     # A non-empty missing_extras is how downstream tells "install this" apart
     # from "this format cannot be converted at all".
     assert excinfo.value.missing_extras == ("ims",)
+    assert excinfo.value.found_file_extensions == ("ims",)
 
 
 def test_from_images_error_unchanged_when_nothing_is_missing(
@@ -613,8 +614,39 @@ def test_from_images_error_unchanged_when_nothing_is_missing(
     assert error.missing_extras == ()
     # The input is a directory, so there is no single offending extension.
     assert error.file_extension is None
+    # …but the extensions it does contain are named, so that a caller can say
+    # what was wrong with the input instead of only what would have worked.
+    assert error.found_file_extensions == ("unsupported",)
+    assert ".unsupported" in str(error)
     assert error.path == tmp_upath
     assert "tif" in error.supported_file_extensions
+
+
+def test_from_images_directory_names_found_extensions(tmp_upath: UPath) -> None:
+    # The extensions of a directory are reported most common first, so the
+    # dominant format comes first in a message built from them.
+    for i in range(3):
+        (tmp_upath / f"scan{i}.dcm").write_bytes(b"x")
+    (tmp_upath / "notes.txt").write_bytes(b"x")
+    (tmp_upath / "no_extension").write_bytes(b"x")
+    (tmp_upath / "nested").mkdir()
+    (tmp_upath / "nested" / "scan3.dcm").write_bytes(b"x")
+
+    with pytest.raises(UnsupportedImageFormatError) as excinfo:
+        Dataset.from_images(tmp_upath, tmp_upath / "ds", voxel_size=(1, 1, 1))
+    error = excinfo.value
+    assert error.found_file_extensions == ("dcm", "txt")
+    assert "Found .dcm, .txt files" in str(error)
+
+
+def test_from_images_empty_directory(tmp_upath: UPath) -> None:
+    empty = tmp_upath / "empty"
+    empty.mkdir()
+    with pytest.raises(
+        UnsupportedImageFormatError, match="Could not find any supported image data"
+    ) as excinfo:
+        Dataset.from_images(empty, tmp_upath / "ds", voxel_size=(1, 1, 1))
+    assert excinfo.value.found_file_extensions == ()
 
 
 def test_from_images_single_unsupported_file(tmp_upath: UPath) -> None:
@@ -630,6 +662,7 @@ def test_from_images_single_unsupported_file(tmp_upath: UPath) -> None:
         Dataset.from_images(unsupported, tmp_upath / "ds", voxel_size=(1, 1, 1))
     error = excinfo.value
     assert error.file_extension == "dcm"
+    assert error.found_file_extensions == ("dcm",)
     assert error.path == unsupported
     assert error.missing_extras == ()
     # Subclassing ValueError keeps `except ValueError` callers working.

--- a/webknossos/webknossos/dataset/_image_conversion/image_conversion.py
+++ b/webknossos/webknossos/dataset/_image_conversion/image_conversion.py
@@ -58,7 +58,9 @@ from ..layer.layer import _get_shard_and_chunk_shapes
 from . import common_slice_readers, sliced_image_source
 from .image_source import ImageSource, ReadOptions, ValueRange
 from .image_source_registry import (
+    describe_found_formats,
     describe_missing_extras,
+    find_input_file_extensions,
     get_unavailable_extensions,
     get_valid_extensions,
     is_chunked_source_directory,
@@ -212,30 +214,20 @@ def _iter_convertible_paths(root: UPath, valid_extensions: set[str]) -> Iterator
             yield child
 
 
-def _find_unavailable_input_formats(input_upath: UPath) -> dict[str, str]:
+def _find_unavailable_input_formats(
+    found_file_extensions: tuple[str, ...],
+) -> dict[str, str]:
     """
-    Looks for files whose format a chunk-based reader would handle if its
-    optional dependency were installed, and maps their extension to the extra
-    that provides it. Empty if there are none.
-
-    Only runs on the "no supported image data" error path, so the extra
-    directory scan costs nothing in the normal case.
+    Narrows the extensions found in the input to those a reader would handle if
+    its optional dependency were installed, mapped to the extra that provides
+    it. Empty if there are none.
     """
     unavailable = get_unavailable_extensions()
-    if not unavailable:
-        return {}
-
-    if input_upath.is_file():
-        candidates = [input_upath]
-    else:
-        candidates = [p for p in input_upath.glob("**/*") if p.is_file()]
-
-    found: dict[str, str] = {}
-    for path in candidates:
-        extension = path.suffix.lstrip(".").lower()
-        if extension in unavailable:
-            found[extension] = unavailable[extension]
-    return found
+    return {
+        extension: unavailable[extension]
+        for extension in found_file_extensions
+        if extension in unavailable
+    }
 
 
 # Formats whose channels mean RGB rather than separate acquisitions: the
@@ -382,14 +374,20 @@ def from_images(
         ]
 
     if len(input_files) == 0:
-        message = (
-            "Could not find any supported image data. "
-            + f"The following extensions are supported: {sorted(valid_extensions)}"
-        )
+        found_file_extensions = find_input_file_extensions(original_input_upath)
         # A reader whose optional dependency is missing never registers, so its
-        # formats are simply absent from the list above. Without this the only
-        # clue is an import warning emitted much earlier, far from the failure.
-        missing = _find_unavailable_input_formats(original_input_upath)
+        # formats are simply absent from the supported list below. Without this
+        # the only clue is an import warning emitted much earlier, far from the
+        # failure. Those extensions are described by describe_missing_extras()
+        # instead, so they are left out of the "not supported" sentence.
+        missing = _find_unavailable_input_formats(found_file_extensions)
+        message = (
+            "Could not find any supported image data."
+            + describe_found_formats(
+                tuple(e for e in found_file_extensions if e not in missing)
+            )
+            + f" The following extensions are supported: {sorted(valid_extensions)}"
+        )
         if missing:
             message += describe_missing_extras(missing)
         raise UnsupportedImageFormatError(
@@ -401,6 +399,7 @@ def from_images(
                 else None
             ),
             supported_file_extensions=tuple(sorted(valid_extensions)),
+            found_file_extensions=found_file_extensions,
             missing_extras=tuple(sorted(set(missing.values()))),
         )
 

--- a/webknossos/webknossos/dataset/_image_conversion/image_source_registry.py
+++ b/webknossos/webknossos/dataset/_image_conversion/image_source_registry.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import glob
 import os
 import warnings
+from collections import Counter
 from os import environ
 from typing import NamedTuple
 
@@ -199,6 +200,39 @@ def get_unavailable_extensions() -> dict[str, str]:
     supported list.
     """
     return dict(_UNAVAILABLE_EXTENSIONS)
+
+
+def find_input_file_extensions(path: UPath) -> tuple[str, ...]:
+    """
+    The distinct extensions of the files under `path` — lowercase and without
+    the leading dot — most common first, ties in alphabetical order. A single
+    file yields its own extension; files without one are skipped.
+
+    Only called on error paths, so the directory scan costs nothing in the
+    normal case.
+    """
+    if path.is_file():
+        candidates = [path]
+    else:
+        candidates = [p for p in path.glob("**/*") if p.is_file()]
+
+    counts = Counter(
+        extension
+        for extension in (p.suffix.lstrip(".").lower() for p in candidates)
+        if extension
+    )
+    return tuple(sorted(counts, key=lambda extension: (-counts[extension], extension)))
+
+
+def describe_found_formats(found_file_extensions: tuple[str, ...]) -> str:
+    """Names the extensions the input actually contains. Appended to an error
+    message, where the supported ones are listed separately."""
+    if not found_file_extensions:
+        return ""
+    return (
+        f" Found {', '.join('.' + e for e in found_file_extensions)} files, "
+        + "none of which are supported."
+    )
 
 
 def describe_missing_extras(found: dict[str, str]) -> str:

--- a/webknossos/webknossos/dataset/_image_conversion/sliced_image_source.py
+++ b/webknossos/webknossos/dataset/_image_conversion/sliced_image_source.py
@@ -27,7 +27,9 @@ from .image_source import (
     compute_channel_selection,
 )
 from .image_source_registry import (
+    describe_found_formats,
     describe_missing_extras,
+    find_input_file_extensions,
     get_unavailable_extensions,
     get_valid_extensions,
     get_valid_slice_reader_extensions,
@@ -153,20 +155,40 @@ class SlicedImageSource(ImageSource):
         so files that open without a recognized extension are unaffected.
         """
         path = self._error_path()
-        # Only a file's extension says anything about which readers apply; a
-        # directory has none, or worse, a dot in its name.
-        extension = (
-            (path.suffix.lstrip(".").lower() or None)
-            if path is not None and not path.is_dir()
-            else None
-        )
-
         supported_extensions = get_valid_extensions()
+        unavailable = get_unavailable_extensions()
+
+        if path is not None and path.is_dir():
+            # A directory has no extension of its own — what it contains is
+            # what says whether any reader applies.
+            found = find_input_file_extensions(path)
+            if any(extension in supported_extensions for extension in found):
+                # There is convertible data in here; the failure is something
+                # else.
+                return None
+            missing = {e: unavailable[e] for e in found if e in unavailable}
+            message = (
+                f"Could not convert {path}: it contains no supported image data."
+                + describe_found_formats(tuple(e for e in found if e not in missing))
+                + f" The following extensions are supported: {sorted(supported_extensions)}"
+            )
+            if missing:
+                message += describe_missing_extras(missing)
+            return UnsupportedImageFormatError(
+                message,
+                path=path,
+                supported_file_extensions=tuple(sorted(supported_extensions)),
+                found_file_extensions=found,
+                missing_extras=tuple(sorted(set(missing.values()))),
+            )
+
+        extension = (
+            (path.suffix.lstrip(".").lower() or None) if path is not None else None
+        )
 
         if extension is None or extension in supported_extensions:
             return None
 
-        unavailable = get_unavailable_extensions()
         missing = (
             {extension: unavailable[extension]} if extension in unavailable else {}
         )

--- a/webknossos/webknossos/dataset/dataset.py
+++ b/webknossos/webknossos/dataset/dataset.py
@@ -757,9 +757,11 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
 
         Raises:
             UnsupportedImageFormatError: If the input contains no file that any
-                reader can convert. Its `missing_extras` attribute names the
-                extras to install when the format would be supported by an
-                optional dependency that is not installed.
+                reader can convert. Its `found_file_extensions` attribute names
+                the extensions that were actually found, and its
+                `missing_extras` attribute names the extras to install when the
+                format would be supported by an optional dependency that is not
+                installed.
             CorruptImageError: If a file of a supported format could not be
                 read, which usually means it is damaged or incomplete.
             UnsupportedImageDataError: If the images were read, but their data
@@ -1179,9 +1181,10 @@ class Dataset(AbstractDataset[Layer, SegmentationLayer]):
 
         Raises:
             UnsupportedImageFormatError: If no reader can convert `images`. Its
-                `missing_extras` attribute names the extras to install when the
-                format would be supported by an optional dependency that is not
-                installed.
+                `found_file_extensions` attribute names the extensions that were
+                actually found, and its `missing_extras` attribute names the
+                extras to install when the format would be supported by an
+                optional dependency that is not installed.
             CorruptImageError: If a file of a supported format could not be
                 read, which usually means it is damaged or incomplete.
             UnsupportedImageDataError: If the images were read, but their data

--- a/webknossos/webknossos/dataset/errors.py
+++ b/webknossos/webknossos/dataset/errors.py
@@ -41,6 +41,12 @@ class UnsupportedImageFormatError(ImageConversionError):
             or unknown.
         supported_file_extensions: The extensions that can currently be
             converted, in the same lowercase, dot-less form.
+        found_file_extensions: The extensions actually present in the input, in
+            the same lowercase, dot-less form, most common first. For a
+            directory this is what it contains, which is what names the
+            offending format when `file_extension` is `None`; for a single file
+            it is just that file's extension. Empty when nothing was found,
+            e.g. for an empty directory.
         missing_extras: The `webknossos` extras that would add support for the
             input at hand, e.g. `("ims",)` when converting an `.ims` file
             without `webknossos[ims]` installed. Empty when the format is not
@@ -55,8 +61,9 @@ class UnsupportedImageFormatError(ImageConversionError):
         except wk.UnsupportedImageFormatError as e:
             if e.missing_extras:
                 print(f"Install webknossos[{','.join(e.missing_extras)}] to convert this file.")
-            else:
-                print(f"Cannot convert .{e.file_extension} files.")
+            elif e.found_file_extensions:
+                found = ", ".join("." + s for s in e.found_file_extensions)
+                print(f"Cannot convert {found} files.")
         ```
     """
 
@@ -67,11 +74,19 @@ class UnsupportedImageFormatError(ImageConversionError):
         path: UPath | None = None,
         file_extension: str | None = None,
         supported_file_extensions: tuple[str, ...] = (),
+        found_file_extensions: tuple[str, ...] | None = None,
         missing_extras: tuple[str, ...] = (),
     ) -> None:
         super().__init__(message, path=path)
         self.file_extension = file_extension
         self.supported_file_extensions = supported_file_extensions
+        # A single offending file is its own answer to "what was found", so
+        # only the directory case has to pass this explicitly.
+        self.found_file_extensions = (
+            found_file_extensions
+            if found_file_extensions is not None
+            else ((file_extension,) if file_extension is not None else ())
+        )
         self.missing_extras = missing_extras
 
 


### PR DESCRIPTION
### Description:
- `UnsupportedImageFormatError` gains `found_file_extensions`: the extensions actually present in the input (lowercase, dot-less, most common first). For a directory that contains nothing convertible this is what names the offending format, since `file_extension` is `None` there; for a single file it defaults to that file's extension. The error message names them too ("Found .dcm, .txt files, none of which are supported.").
- `add_layer_from_images(<directory without any convertible file>)` now raises `UnsupportedImageFormatError` with the same attributes, instead of the generic "tried different methods, none succeeded" `ValueError`.

### Issues:
- fixes #1537

### Todos:
 - [x] Updated Changelog
 - [x] Updated Documentation
 - [x] Added / Updated Tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)