### PR TITLE
Exclude changelogs from the docs search index

### DIFF
--- a/docs/hooks.py
+++ b/docs/hooks.py
@@ -1,0 +1,19 @@
+"""MkDocs hooks.
+
+Some pages are symlinked in from other repositories (e.g. the changelogs), so we
+cannot add front matter to them directly. Instead, mark them here.
+"""
+
+from mkdocs.structure.pages import Page
+
+# Pages (docs_dir-relative) that should not show up in the search index.
+SEARCH_EXCLUDED_PAGES = {
+    "webknossos/CHANGELOG.released.md",
+    "webknossos-py/changelog.md",
+}
+
+
+def on_page_markdown(markdown: str, page: Page, **kwargs: object) -> str:
+    if page.file.src_uri in SEARCH_EXCLUDED_PAGES:
+        page.meta["search"] = {"exclude": True}
+    return markdown

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -61,6 +61,9 @@ extra:
       link: https://medium.com/webknossos
   generator: false
 
+hooks:
+  - hooks.py
+
 plugins:
   # - gen-files:
   #     scripts:


### PR DESCRIPTION
### Description:
- The two changelog pages (`webknossos/CHANGELOG.released.md` and `webknossos-py/changelog.md`) repeat every feature name once per release, so they dominate search results for many terms. They are now excluded from the MkDocs search index via Material's `search: exclude: true` page meta.
- Both pages are symlinks (`src/webknossos-py/changelog.md` → `webknossos/Changelog.md`, `src/webknossos/` → the wk-repo clone), so front matter can't be added to them from this repo. A small MkDocs hook (`docs/hooks.py`) sets the meta during `on_page_markdown` instead; add more paths to `SEARCH_EXCLUDED_PAGES` to exclude further pages.
- Verified with a full `mkdocs build`: the search index contains 2289 documents and zero changelog entries.

### Issues:
- n/a

### Todos:
Make sure to delete unnecessary points or to check all before merging:
 - [x] Updated Documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)